### PR TITLE
specify peer deps

### DIFF
--- a/.changeset/shiny-planes-whisper.md
+++ b/.changeset/shiny-planes-whisper.md
@@ -1,0 +1,19 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Add peer dependencies to `@vygruppen/spor-react`
+
+In order to optimize for flexibility, the `spor-react` package loses a few direct dependencies, and adds them as peer dependencies.
+
+This is a **breaking change**. To upgrade, please run:
+
+```bash
+$ npm install @chakra-ui/react @emotion/styled @emotion/react framer-motion
+```
+
+or:
+
+```bash
+$ yarn add @chakra-ui/react @emotion/styled @emotion/react framer-motion
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -4673,6 +4673,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true
+    },
     "node_modules/debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -9570,6 +9576,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-merge-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -9659,6 +9675,19 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.1.tgz",
+      "integrity": "sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==",
+      "dev": true,
+      "dependencies": {
+        "debounce": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      }
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -11995,7 +12024,7 @@
     },
     "packages/spor-button-react": {
       "name": "@vygruppen/spor-button-react",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*"
@@ -12020,7 +12049,7 @@
     },
     "packages/spor-i18n-react": {
       "name": "@vygruppen/spor-i18n-react",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@leile/lobo-t": "^1.0.5"
@@ -12037,7 +12066,7 @@
     },
     "packages/spor-input-react": {
       "name": "@vygruppen/spor-input-react",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*"
@@ -12062,7 +12091,7 @@
     },
     "packages/spor-logo-react": {
       "name": "@vygruppen/spor-logo-react",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "react": ">17.0.0",
@@ -12080,33 +12109,117 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/react": "^1.7.3",
-        "@emotion/react": "^11.7.1",
-        "@emotion/styled": "^11.6.0",
         "@leile/lobo-t": "^1.0.5",
         "@vygruppen/spor-button-react": "*",
         "@vygruppen/spor-i18n-react": "*",
         "@vygruppen/spor-input-react": "*",
         "@vygruppen/spor-logo-react": "*",
-        "@vygruppen/spor-theme-react": "*",
-        "framer-motion": "^4.1.17"
+        "@vygruppen/spor-theme-react": "*"
       },
       "devDependencies": {
+        "@chakra-ui/react": "^1.7.3",
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
+        "framer-motion": "^5.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "tsup": "^5.11.11"
       },
       "peerDependencies": {
+        "@chakra-ui/react": "^1.7.3",
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
+        "framer-motion": "^4.1.0 || ^5.0.0",
         "react": ">= 17.0.0",
         "react-dom": ">= 17.0.0"
       }
     },
+    "packages/spor-react/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "packages/spor-react/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "dev": true,
+      "optional": true
+    },
+    "packages/spor-react/node_modules/framer-motion": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-5.6.0.tgz",
+      "integrity": "sha512-Y4FtwUU+LUWLKSzoT6Sq538qluvhpe6izdQK8/xZeVjQZ/ORKGfZzyhzcUxNfscqnfEa3dUOA47s+dwrSipdGA==",
+      "dev": true,
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "react-merge-refs": "^1.1.0",
+        "react-use-measure": "^2.1.1",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "*",
+        "react": ">=16.8 || ^17.0.0",
+        "react-dom": ">=16.8 || ^17.0.0",
+        "three": "^0.135.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-three/fiber": {
+          "optional": true
+        },
+        "three": {
+          "optional": true
+        }
+      }
+    },
+    "packages/spor-react/node_modules/framesync": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "packages/spor-react/node_modules/popmotion": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "dev": true,
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "packages/spor-react/node_modules/style-value-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "dev": true,
+      "dependencies": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
+      }
+    },
     "packages/spor-theme-react": {
       "name": "@vygruppen/spor-theme-react",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -14556,10 +14669,76 @@
         "@vygruppen/spor-input-react": "*",
         "@vygruppen/spor-logo-react": "*",
         "@vygruppen/spor-theme-react": "*",
-        "framer-motion": "^4.1.17",
+        "framer-motion": "^5.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "tsup": "^5.11.11"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "0.8.8",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@emotion/memoize": "0.7.4"
+          }
+        },
+        "@emotion/memoize": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+          "dev": true,
+          "optional": true
+        },
+        "framer-motion": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-5.6.0.tgz",
+          "integrity": "sha512-Y4FtwUU+LUWLKSzoT6Sq538qluvhpe6izdQK8/xZeVjQZ/ORKGfZzyhzcUxNfscqnfEa3dUOA47s+dwrSipdGA==",
+          "dev": true,
+          "requires": {
+            "@emotion/is-prop-valid": "^0.8.2",
+            "framesync": "6.0.1",
+            "hey-listen": "^1.0.8",
+            "popmotion": "11.0.3",
+            "react-merge-refs": "^1.1.0",
+            "react-use-measure": "^2.1.1",
+            "style-value-types": "5.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "framesync": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+          "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "popmotion": {
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+          "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+          "dev": true,
+          "requires": {
+            "framesync": "6.0.1",
+            "hey-listen": "^1.0.8",
+            "style-value-types": "5.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "style-value-types": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+          "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+          "dev": true,
+          "requires": {
+            "hey-listen": "^1.0.8",
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@vygruppen/spor-theme-react": {
@@ -15752,6 +15931,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
       "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+    },
+    "debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true
     },
     "debug": {
       "version": "4.3.3",
@@ -19342,6 +19527,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-merge-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
+      "dev": true
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -19397,6 +19588,15 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
+      }
+    },
+    "react-use-measure": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.1.tgz",
+      "integrity": "sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==",
+      "dev": true,
+      "requires": {
+        "debounce": "^1.2.1"
       }
     },
     "read-pkg": {

--- a/packages/spor-react/README.md
+++ b/packages/spor-react/README.md
@@ -5,8 +5,22 @@ This package includes everything you need to build your React component library.
 ## Installation
 
 ```bash
-$ npm install @vygruppen/spor-react
+$ npm install @vygruppen/spor-react @chakra-ui/react @emotion/styled @emotion/react framer-motion
 ```
+
+or
+
+```bash
+$ yarn add @vygruppen/spor-react @chakra-ui/react @emotion/styled @emotion/react framer-motion
+```
+
+<details>
+<summary>That's a lot of dependencies! Why?</summary>
+The reason there's a lot of dependencies, is that you'll most likely use both Chakra UI and framer-motion to implement your application, and you shouldn't be required to install these dependencies twice.
+
+You'll also be able to update them independently of this library, in case there's a new feature or non-breaking feature out there that you need.
+
+</details>
 
 ## Usage
 

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -9,23 +9,27 @@
     "dev": "tsup src/index.tsx --watch"
   },
   "dependencies": {
-    "@chakra-ui/react": "^1.7.3",
-    "@emotion/react": "^11.7.1",
-    "@emotion/styled": "^11.6.0",
     "@leile/lobo-t": "^1.0.5",
     "@vygruppen/spor-button-react": "*",
     "@vygruppen/spor-input-react": "*",
     "@vygruppen/spor-logo-react": "*",
     "@vygruppen/spor-theme-react": "*",
-    "@vygruppen/spor-i18n-react": "*",
-    "framer-motion": "^4.1.17"
+    "@vygruppen/spor-i18n-react": "*"
   },
   "devDependencies": {
+    "@chakra-ui/react": "^1.7.3",
+    "@emotion/react": "^11.7.1",
+    "@emotion/styled": "^11.6.0",
+    "framer-motion": "^5.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "tsup": "^5.11.11"
   },
   "peerDependencies": {
+    "@chakra-ui/react": "^1.7.3",
+    "@emotion/react": "^11.7.1",
+    "@emotion/styled": "^11.6.0",
+    "framer-motion": "^4.1.0 || ^5.0.0",
     "react": ">= 17.0.0",
     "react-dom": ">= 17.0.0"
   }


### PR DESCRIPTION
In order to optimize for flexibility, the `spor-react` package loses a few direct dependencies, and adds them as peer dependencies.

This is a **breaking change**. To upgrade, please run:

```bash
$ npm install @chakra-ui/react @emotion/styled @emotion/react framer-motion
```

Note that this change is for the 0.1.0 release. Since we're still pre-1.0.0, we're introducing breaking changes as minor version bumps. This will change once we get to 1.0.0, hopefully sometime the next couple of weeks.