### PR TITLE
Add a double box shadow to some button states to alleviate a rendering bug

### DIFF
--- a/.changeset/quick-chairs-deny.md
+++ b/.changeset/quick-chairs-deny.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-theme-react": patch
+"@vygruppen/spor-button-react": patch
+---
+
+Improve rendering bug when some buttons are focused

--- a/packages/spor-theme-react/src/components/button.ts
+++ b/packages/spor-theme-react/src/components/button.ts
@@ -52,13 +52,13 @@ const variantPrimary: SystemStyleFunction = ({ theme }) => ({
   backgroundColor: "alias.primaryGreen",
   color: "alias.white",
   _focus: {
-    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.primaryGreen}, inset 0 0 0 6px currentColor`,
+    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.primaryGreen}, inset 0 0 0 4px ${theme.colors.alias.primaryGreen}, inset 0 0 0 6px currentColor`,
   },
   "&:focus:not(:focus-visible)": {
     boxShadow: `none`,
   },
   _focusVisible: {
-    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.primaryGreen}, inset 0 0 0 6px currentColor`,
+    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.primaryGreen}, inset 0 0 0 4px ${theme.colors.alias.primaryGreen}, inset 0 0 0 6px currentColor`,
   },
   _hover: {
     backgroundColor: "alias.pine",
@@ -72,13 +72,13 @@ const variantSecondary: SystemStyleFunction = ({ theme }) => ({
   backgroundColor: "alias.coralGreen",
   color: "alias.darkTeal",
   _focus: {
-    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.coralGreen}, inset 0 0 0 6px currentColor`,
+    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.coralGreen}, inset 0 0 0 4px ${theme.colors.alias.coralGreen}, inset 0 0 0 6px currentColor`,
   },
   ":focus:not(:focus-visible)": {
     boxShadow: "none",
   },
   _focusVisible: {
-    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.coralGreen}, inset 0 0 0 6px currentColor`,
+    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.coralGreen}, inset 0 0 0 4px ${theme.colors.alias.coralGreen}, inset 0 0 0 6px currentColor`,
   },
   _hover: {
     backgroundColor: "alias.blueGreen",
@@ -93,13 +93,13 @@ const variantTertiary: SystemStyleFunction = ({ theme }) => ({
   color: "alias.darkGrey",
   fontWeight: "normal",
   _focus: {
-    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.mint}, inset 0 0 0 6px currentColor`,
+    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.mint}, inset 0 0 0 4px ${theme.colors.alias.mint}, inset 0 0 0 6px currentColor`,
   },
   ":focus:not(:focus-visible)": {
     boxShadow: "none",
   },
   _focusVisible: {
-    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.mint}, inset 0 0 0 6px currentColor`,
+    boxShadow: `inset 0 0 0 4px ${theme.colors.alias.mint}, inset 0 0 0 4px ${theme.colors.alias.mint}, inset 0 0 0 6px currentColor`,
   },
   _hover: {
     backgroundColor: "alias.seaMist",


### PR DESCRIPTION
This is a weird bug for sure. When you overlay one box shadow with another one, a sub-pixel of the overlaid box shadow will show up. The bug shows up less if you add another box shadow on top