### PR TITLE
Add Card component

### DIFF
--- a/.changeset/brown-scissors-hear.md
+++ b/.changeset/brown-scissors-hear.md
@@ -1,0 +1,7 @@
+---
+"@vygruppen/spor-react": minor
+"@vygruppen/spor-card-react": patch
+"@vygruppen/spor-theme-react": patch
+---
+
+Add new spor-card-react package

--- a/apps/docs/app/features/routes/index/ActionLinks.tsx
+++ b/apps/docs/app/features/routes/index/ActionLinks.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Card,
   ComponentsOutline30Icon,
   Container,
   Flex,
@@ -102,18 +103,16 @@ type ActionLinkCardProps = {
 };
 function ActionLinkCard({ to, children }: ActionLinkCardProps) {
   return (
-    <Flex
+    <Card
       as={Link}
       to={to}
-      borderRadius="md"
-      boxShadow="md"
       flexDirection={["row", "column"]}
       gap={[3, 4]}
       p={4}
-      background="alias.white"
+      variant="elevated"
     >
       {children}
-    </Flex>
+    </Card>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4236,6 +4236,10 @@
       "resolved": "packages/spor-button-react",
       "link": true
     },
+    "node_modules/@vygruppen/spor-card-react": {
+      "resolved": "packages/spor-card-react",
+      "link": true
+    },
     "node_modules/@vygruppen/spor-design-tokens": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@vygruppen/spor-design-tokens/-/spor-design-tokens-2.2.1.tgz",
@@ -16583,7 +16587,7 @@
     },
     "packages/spor-button-react": {
       "name": "@vygruppen/spor-button-react",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*"
@@ -16604,6 +16608,110 @@
         "framer-motion": "^4.1.17",
         "react": ">17.0.0",
         "react-dom": ">17.0.0"
+      }
+    },
+    "packages/spor-card-react": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@vygruppen/spor-layout-react": "*"
+      },
+      "devDependencies": {
+        "@chakra-ui/react": "^1.7.3",
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
+        "framer-motion": "^5.0.0",
+        "react": ">17.0.0",
+        "react-dom": ">17.0.0",
+        "tsup": "^5.11.11"
+      },
+      "peerDependencies": {
+        "@chakra-ui/react": "^1.7.3",
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
+        "framer-motion": "^5.0.0",
+        "react": ">17.0.0",
+        "react-dom": ">17.0.0"
+      }
+    },
+    "packages/spor-card-react/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "packages/spor-card-react/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "dev": true,
+      "optional": true
+    },
+    "packages/spor-card-react/node_modules/framer-motion": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-5.6.0.tgz",
+      "integrity": "sha512-Y4FtwUU+LUWLKSzoT6Sq538qluvhpe6izdQK8/xZeVjQZ/ORKGfZzyhzcUxNfscqnfEa3dUOA47s+dwrSipdGA==",
+      "dev": true,
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "react-merge-refs": "^1.1.0",
+        "react-use-measure": "^2.1.1",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "*",
+        "react": ">=16.8 || ^17.0.0",
+        "react-dom": ">=16.8 || ^17.0.0",
+        "three": "^0.135.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-three/fiber": {
+          "optional": true
+        },
+        "three": {
+          "optional": true
+        }
+      }
+    },
+    "packages/spor-card-react/node_modules/framesync": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "packages/spor-card-react/node_modules/popmotion": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "dev": true,
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "packages/spor-card-react/node_modules/style-value-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "dev": true,
+      "dependencies": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
       }
     },
     "packages/spor-i18n-react": {
@@ -16630,7 +16738,7 @@
     },
     "packages/spor-icon-react": {
       "name": "@vygruppen/spor-icon-react",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-layout-react": "*"
@@ -16688,7 +16796,8 @@
       }
     },
     "packages/spor-image-react": {
-      "version": "0.0.1",
+      "name": "@vygruppen/spor-image-react",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^1.7.3",
@@ -16815,7 +16924,7 @@
     },
     "packages/spor-layout-react": {
       "name": "@vygruppen/spor-layout-react",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "react": ">17.0.0",
@@ -16851,11 +16960,12 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@leile/lobo-t": "^1.0.5",
         "@vygruppen/spor-button-react": "*",
+        "@vygruppen/spor-card-react": "*",
         "@vygruppen/spor-design-tokens": "*",
         "@vygruppen/spor-i18n-react": "*",
         "@vygruppen/spor-icon-react": "*",
@@ -16966,7 +17076,7 @@
     },
     "packages/spor-theme-react": {
       "name": "@vygruppen/spor-theme-react",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16987,7 +17097,7 @@
     },
     "packages/spor-typography-react": {
       "name": "@vygruppen/spor-typography-react",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^1.7.3",
@@ -20211,6 +20321,85 @@
         "tsup": "^5.11.11"
       }
     },
+    "@vygruppen/spor-card-react": {
+      "version": "file:packages/spor-card-react",
+      "requires": {
+        "@chakra-ui/react": "^1.7.3",
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
+        "@vygruppen/spor-layout-react": "*",
+        "framer-motion": "^5.0.0",
+        "react": ">17.0.0",
+        "react-dom": ">17.0.0",
+        "tsup": "^5.11.11"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "0.8.8",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@emotion/memoize": "0.7.4"
+          }
+        },
+        "@emotion/memoize": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+          "dev": true,
+          "optional": true
+        },
+        "framer-motion": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-5.6.0.tgz",
+          "integrity": "sha512-Y4FtwUU+LUWLKSzoT6Sq538qluvhpe6izdQK8/xZeVjQZ/ORKGfZzyhzcUxNfscqnfEa3dUOA47s+dwrSipdGA==",
+          "dev": true,
+          "requires": {
+            "@emotion/is-prop-valid": "^0.8.2",
+            "framesync": "6.0.1",
+            "hey-listen": "^1.0.8",
+            "popmotion": "11.0.3",
+            "react-merge-refs": "^1.1.0",
+            "react-use-measure": "^2.1.1",
+            "style-value-types": "5.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "framesync": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+          "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "popmotion": {
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+          "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+          "dev": true,
+          "requires": {
+            "framesync": "6.0.1",
+            "hey-listen": "^1.0.8",
+            "style-value-types": "5.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "style-value-types": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+          "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+          "dev": true,
+          "requires": {
+            "hey-listen": "^1.0.8",
+            "tslib": "^2.1.0"
+          }
+        }
+      }
+    },
     "@vygruppen/spor-design-tokens": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@vygruppen/spor-design-tokens/-/spor-design-tokens-2.2.1.tgz",
@@ -20392,6 +20581,7 @@
         "@emotion/styled": "^11.6.0",
         "@leile/lobo-t": "^1.0.5",
         "@vygruppen/spor-button-react": "*",
+        "@vygruppen/spor-card-react": "*",
         "@vygruppen/spor-design-tokens": "*",
         "@vygruppen/spor-i18n-react": "*",
         "@vygruppen/spor-icon-react": "*",

--- a/packages/config/eslint-preset.js
+++ b/packages/config/eslint-preset.js
@@ -17,6 +17,7 @@ module.exports = {
         "packages/spor-icon/",
         "packages/spor-icon-react/",
         "packages/spor-image-react/",
+        "packages/spor-card-react/",
       ],
     },
   },

--- a/packages/spor-card-react/README.md
+++ b/packages/spor-card-react/README.md
@@ -1,6 +1,6 @@
 # Card (React)
 
-TODO: Add description
+Cards are used to encapsulate some information, or as interactive elements in our UI.
 
 ## Installation
 
@@ -13,6 +13,7 @@ $ npm install @vygruppen/spor-card-react
 ```tsx
 import { } from "@vygruppen/spor-card-react";
 ```
+
 TODO: Add usage description
 
 ## Development

--- a/packages/spor-card-react/README.md
+++ b/packages/spor-card-react/README.md
@@ -1,0 +1,20 @@
+# Card (React)
+
+TODO: Add description
+
+## Installation
+
+```bash
+$ npm install @vygruppen/spor-card-react
+```
+
+## Usage
+
+```tsx
+import { } from "@vygruppen/spor-card-react";
+```
+TODO: Add usage description
+
+## Development
+
+Please refer to the root readme for development notes.

--- a/packages/spor-card-react/README.md
+++ b/packages/spor-card-react/README.md
@@ -11,10 +11,19 @@ $ npm install @vygruppen/spor-card-react
 ## Usage
 
 ```tsx
-import { } from "@vygruppen/spor-card-react";
+import { Card } from "@vygruppen/spor-card-react";
 ```
 
-TODO: Add usage description
+Cards come in three different variants - `filled`, `outlined` and `elevated`.
+If you specify the `filled` variant, you need to specify a `colorScheme` as well. The available color schemes are `blue`, `green` and `grey`.
+
+```tsx
+<Card variant="elevated">I'm an elevated card</Card>
+<Card variant="outlined">I'm an outlined card</Card>
+<Card variant="filled" colorScheme="blue">I'm a filled card</Card>
+```
+
+You can also pass any style props you want, like padding or borderRadius.
 
 ## Development
 

--- a/packages/spor-card-react/package.json
+++ b/packages/spor-card-react/package.json
@@ -15,6 +15,9 @@
     "build": "tsup src/index.tsx --dts",
     "dev": "tsup src/index.tsx --watch"
   },
+  "dependencies": {
+    "@vygruppen/spor-layout-react": "*"
+  },
   "devDependencies": {
     "react": ">17.0.0",
     "react-dom": ">17.0.0",

--- a/packages/spor-card-react/package.json
+++ b/packages/spor-card-react/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@vygruppen/spor-card-react",
+  "version": "0.0.1",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "license": "MIT",
+  "files": ["dist"],
+  "homepage": "https://github.com/nsbno/spor/tree/main/packages/spor-card-react",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nsbno/spor.git",
+    "directory": "packages/spor-card-react"
+  },
+  "scripts": {
+    "build": "tsup src/index.tsx --dts",
+    "dev": "tsup src/index.tsx --watch"
+  },
+  "devDependencies": {
+    "react": ">17.0.0",
+    "react-dom": ">17.0.0",
+    "@chakra-ui/react": "^1.7.3",
+    "@emotion/react": "^11.7.1",
+    "@emotion/styled": "^11.6.0",
+    "framer-motion": "^5.0.0",
+    "tsup": "^5.11.11"
+  },
+  "peerDependencies": {
+    "react": ">17.0.0",
+    "react-dom": ">17.0.0",
+    "@chakra-ui/react": "^1.7.3",
+    "@emotion/react": "^11.7.1",
+    "@emotion/styled": "^11.6.0",
+    "framer-motion": "^5.0.0"
+  }
+}

--- a/packages/spor-card-react/src/Card.tsx
+++ b/packages/spor-card-react/src/Card.tsx
@@ -1,6 +1,23 @@
-import React from 'react';
+import { As, BoxProps, forwardRef, useStyleConfig } from "@chakra-ui/react";
+import { Box } from "@vygruppen/spor-layout-react";
+import React from "react";
 
-type CardProps = {};
-export const Card = (props: CardProps) => {
-  return <div>Hi there</div>;
+type CardProps = BoxProps & {
+  variant: "elevated" | "filled" | "outlined";
+  children: React.ReactNode;
+  /** Should only be used with variant="filled" */
+  colorScheme?: "blue" | "green" | "grey";
 };
+export const Card = forwardRef<CardProps, As<any>>(
+  ({ variant, colorScheme = "grey", children, ...props }, ref) => {
+    const styles = useStyleConfig("Card", {
+      variant: variant as any,
+      colorScheme,
+    });
+    return (
+      <Box __css={styles} {...props} ref={ref}>
+        {children}
+      </Box>
+    );
+  }
+);

--- a/packages/spor-card-react/src/Card.tsx
+++ b/packages/spor-card-react/src/Card.tsx
@@ -2,12 +2,14 @@ import { As, BoxProps, forwardRef, useStyleConfig } from "@chakra-ui/react";
 import { Box } from "@vygruppen/spor-layout-react";
 import React from "react";
 
-type CardProps = BoxProps & {
-  variant: "elevated" | "filled" | "outlined";
-  children: React.ReactNode;
-  /** Should only be used with variant="filled" */
-  colorScheme?: "blue" | "green" | "grey";
-};
+type CardProps = BoxProps &
+  (
+    | {
+        variant: "elevated" | "outlined";
+        children: React.ReactNode;
+      }
+    | { variant: "filled"; colorScheme: "blue" | "green" | "grey" }
+  );
 export const Card = forwardRef<CardProps, As<any>>(
   ({ variant, colorScheme = "grey", children, ...props }, ref) => {
     const styles = useStyleConfig("Card", {

--- a/packages/spor-card-react/src/Card.tsx
+++ b/packages/spor-card-react/src/Card.tsx
@@ -10,6 +10,23 @@ type CardProps = BoxProps &
       }
     | { variant: "filled"; colorScheme: "blue" | "green" | "grey" }
   );
+/**
+ * Cards come in three different variants - `filled`, `outlined` and `elevated`.
+ * If you specify the `filled` variant, you need to specify a `colorScheme` as well. The available color schemes are `blue`, `green` and `grey`.
+ * 
+```tsx
+<Card variant="elevated">
+  I'm an elevated card
+</Card>
+<Card variant="outlined">
+  I'm an outlined card
+</Card>
+<Card variant="filled" colorScheme="blue">
+  I'm a filled card
+</Card>
+```
+ * You can also pass any style props you want, like padding or borderRadius.
+ */
 export const Card = forwardRef<CardProps, As<any>>(
   ({ variant, colorScheme = "grey", children, ...props }, ref) => {
     const styles = useStyleConfig("Card", {

--- a/packages/spor-card-react/src/Card.tsx
+++ b/packages/spor-card-react/src/Card.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+type CardProps = {};
+export const Card = (props: CardProps) => {
+  return <div>Hi there</div>;
+};

--- a/packages/spor-card-react/src/index.tsx
+++ b/packages/spor-card-react/src/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Card";

--- a/packages/spor-card-react/tsconfig.json
+++ b/packages/spor-card-react/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "tsconfig/react-library.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "rootDir": ".",
+  }
+}

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@leile/lobo-t": "^1.0.5",
     "@vygruppen/spor-button-react": "*",
+    "@vygruppen/spor-card-react": "*",
     "@vygruppen/spor-design-tokens": "*",
     "@vygruppen/spor-i18n-react": "*",
     "@vygruppen/spor-input-react": "*",

--- a/packages/spor-react/src/index.tsx
+++ b/packages/spor-react/src/index.tsx
@@ -1,5 +1,6 @@
 export { extendTheme } from "@chakra-ui/react";
 export * from "@vygruppen/spor-button-react";
+export * from "@vygruppen/spor-card-react";
 export * from "@vygruppen/spor-design-tokens";
 export * from "@vygruppen/spor-i18n-react";
 export * from "@vygruppen/spor-icon-react";

--- a/packages/spor-theme-react/src/components/card.ts
+++ b/packages/spor-theme-react/src/components/card.ts
@@ -1,0 +1,51 @@
+import type {
+  SystemStyleInterpolation,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools";
+
+const baseStyle: SystemStyleObject = {
+  border: "1px solid",
+  borderRadius: "md",
+};
+
+type Variant = "elevated" | "filled" | "outlined";
+const variants: Record<Variant, SystemStyleInterpolation> = {
+  elevated: {
+    backgroundColor: "alias.white",
+    boxShadow: "md",
+  },
+  filled: ({ colorScheme }) => ({
+    border: "1px solid",
+    ...getColorSchemeProps(colorScheme),
+  }),
+  outlined: {
+    border: "1px solid",
+    borderColor: "alias.osloGrey",
+  },
+};
+
+function getColorSchemeProps(colorScheme: string) {
+  switch (colorScheme) {
+    case "blue":
+      return {
+        backgroundColor: "alias.lightBlue",
+        borderColor: "alias.cloudy",
+      };
+    case "green":
+      return {
+        backgroundColor: "alias.mint",
+        borderColor: "alias.coralGreen",
+      };
+    case "grey":
+    default:
+      return {
+        backgroundColor: "alias.platinum",
+        borderColor: "alias.silver",
+      };
+  }
+}
+
+export default {
+  baseStyle,
+  variants,
+};

--- a/packages/spor-theme-react/src/components/card.ts
+++ b/packages/spor-theme-react/src/components/card.ts
@@ -4,7 +4,7 @@ import type {
 } from "@chakra-ui/theme-tools";
 
 const baseStyle: SystemStyleObject = {
-  border: "1px solid",
+  border: "1px solid transparent",
   borderRadius: "md",
 };
 

--- a/packages/spor-theme-react/src/components/index.ts
+++ b/packages/spor-theme-react/src/components/index.ts
@@ -1,4 +1,5 @@
 export { default as Button } from "./button";
+export { default as Card } from "./card";
 export { default as Checkbox } from "./checkbox";
 export { default as ChoiceChip } from "./choice-chip";
 export { default as Form } from "./form";


### PR DESCRIPTION
- Run the add-package script for adding spor-card-react
- Update README with a few details
- Add initial implementation of cards with three variants
- Add initial version of Card component
- Set the initial border as transparent
- Expose the spor-card-react exports through spor-react
- Update package-lock
- Use Card component in our docs
- Make sure you pass in a color scheme when the variant is filled
- Add changeset
- Add some basic documentation to card components
