### PR TITLE
design tokens documentation

### DIFF
--- a/.changeset/curvy-starfishes-hope.md
+++ b/.changeset/curvy-starfishes-hope.md
@@ -1,0 +1,11 @@
+---
+"@vygruppen/spor-card-react": minor
+"@vygruppen/spor-image-react": minor
+"@vygruppen/spor-input-react": minor
+"@vygruppen/spor-layout-react": minor
+"@vygruppen/spor-logo-react": minor
+"@vygruppen/spor-theme-react": minor
+"@vygruppen/spor-typography-react": minor
+---
+
+Export all props types

--- a/.changeset/wet-mice-serve.md
+++ b/.changeset/wet-mice-serve.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-typography-react": minor
+"@vygruppen/spor-theme-react": patch
+---
+
+Add two new typography components - Badge and Code

--- a/apps/docs/app/features/layouts/docs-layout/DocsLayout.tsx
+++ b/apps/docs/app/features/layouts/docs-layout/DocsLayout.tsx
@@ -1,32 +1,36 @@
-import { Box, Button, Flex, useTheme } from "@chakra-ui/react";
+import { useTheme } from "@chakra-ui/react";
 import {
+  Box,
+  Flex,
   FormControl,
+  IconButton,
   Input,
   InputGroup,
-  InputRightElement,
+  InputLeftElement,
+  SearchOutline24Icon,
 } from "@vygruppen/spor-react";
 import React from "react";
-import { BaseLayout } from "../base-layout/BaseLayout";
 
 type DocsLayoutProps = { children: React.ReactNode };
 export const DocsLayout = ({ children }: DocsLayoutProps) => {
   return (
-    <BaseLayout>
-      <Flex flex="1">
-        <LeftNavigation />
-        <Box as="main" flex="1">
-          {children}
-        </Box>
-      </Flex>
-    </BaseLayout>
+    <Flex flex="1">
+      <LeftNavigation>TBD</LeftNavigation>
+      <Box as="main" flex="1" mt={6} mx={[3, 6, 10]}>
+        {children}
+      </Box>
+    </Flex>
   );
 };
 
-type LeftNavigationProps = {};
-const LeftNavigation = ({}: LeftNavigationProps) => {
+type LeftNavigationProps = {
+  children: React.ReactNode;
+};
+const LeftNavigation = ({ children }: LeftNavigationProps) => {
   const { space, colors } = useTheme();
   return (
     <Box
+      display={["none", "block"]}
       as="nav"
       aria-label="content"
       flex="1"
@@ -37,14 +41,18 @@ const LeftNavigation = ({}: LeftNavigationProps) => {
     >
       <FormControl>
         <InputGroup>
-          <Input label="Search" />
-          <InputRightElement>
-            <Button type="submit" aria-label="search" variant="ghost">
-              🔎
-            </Button>
-          </InputRightElement>
+          <InputLeftElement width="48px">
+            <IconButton
+              type="submit"
+              aria-label="Søk"
+              variant="ghost"
+              icon={<SearchOutline24Icon />}
+            />
+          </InputLeftElement>
+          <Input label="Search" pl="48px" />
         </InputGroup>
       </FormControl>
+      <Box mt={6}>{children}</Box>
     </Box>
   );
 };

--- a/apps/docs/app/features/routes/index/ActionLinks.tsx
+++ b/apps/docs/app/features/routes/index/ActionLinks.tsx
@@ -26,7 +26,7 @@ type LinkItem = {
 // These are the links that are rendered in the action links section.
 const links: LinkItem[] = [
   {
-    to: "/kom-i-gang",
+    to: "/ressurser/kom-i-gang",
     title: "Kom i gang",
     description: "Sett opp Spor i ditt prosjekt på få minutter",
     icon: <HomeOutline30Icon />,
@@ -41,7 +41,7 @@ const links: LinkItem[] = [
     iconColor: "alias.champagne",
   },
   {
-    to: "/design-tokens",
+    to: "/ressurser/design-tokens",
     title: "Design Tokens",
     description:
       "Se farger, størrelser og de andre atomene Spor er bygget opp av",
@@ -49,7 +49,7 @@ const links: LinkItem[] = [
     iconColor: "alias.champagne",
   },
   {
-    to: "/profil",
+    to: "/ressurser/profil",
     title: "Profil",
     description:
       "Lær mer om den visuelle profilen til Vy, og hva den inneholder",
@@ -64,7 +64,7 @@ const links: LinkItem[] = [
     iconColor: "alias.primrose",
   },
   {
-    to: "/api",
+    to: "/ressurser/api",
     title: "API",
     description: "Utforsk APIene til Vy",
     icon: <SettingsX1Outline30Icon />,

--- a/apps/docs/app/features/routes/ressurser/design-tokens/AnimationTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/AnimationTokens.tsx
@@ -1,0 +1,20 @@
+import { Text } from "@vygruppen/spor-react";
+import { SharedTokenLayout } from "./SharedTokenLayout";
+
+export function AnimationTokens() {
+  return (
+    <SharedTokenLayout
+      title="Animasjon"
+      description={
+        <Text>
+          Det er viktig at lengden på animasjonen og hvilke attributter som
+          animeres ikke virker forstyrrende eller gjør det vanskeligere å
+          navigere for brukeren. Vi har satt opp tre grunn-animasjoner man kan
+          bruke når man setter opp overganger mellom states. Disse definerer tre
+          ulike timinger og hvordan kurven på animasjonen skal utføres: Slow,
+          Medium, Fast.
+        </Text>
+      }
+    ></SharedTokenLayout>
+  );
+}

--- a/apps/docs/app/features/routes/ressurser/design-tokens/AnimationTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/AnimationTokens.tsx
@@ -1,9 +1,10 @@
-import { Text } from "@vygruppen/spor-react";
+import { BoxProps, Text } from "@vygruppen/spor-react";
 import { SharedTokenLayout } from "./SharedTokenLayout";
 
-export function AnimationTokens() {
+export function AnimationTokens(props: BoxProps) {
   return (
     <SharedTokenLayout
+      {...props}
       title="Animasjon"
       description={
         <Text>

--- a/apps/docs/app/features/routes/ressurser/design-tokens/BreakpointTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/BreakpointTokens.tsx
@@ -1,0 +1,5 @@
+import { SharedTokenLayout } from "./SharedTokenLayout";
+
+export function BreakpointTokens() {
+  return <SharedTokenLayout title="Breakpoints"></SharedTokenLayout>;
+}

--- a/apps/docs/app/features/routes/ressurser/design-tokens/BreakpointTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/BreakpointTokens.tsx
@@ -1,5 +1,6 @@
+import { BoxProps } from "@vygruppen/spor-react";
 import { SharedTokenLayout } from "./SharedTokenLayout";
 
-export function BreakpointTokens() {
-  return <SharedTokenLayout title="Breakpoints"></SharedTokenLayout>;
+export function BreakpointTokens(props: BoxProps) {
+  return <SharedTokenLayout {...props} title="Breakpoints"></SharedTokenLayout>;
 }

--- a/apps/docs/app/features/routes/ressurser/design-tokens/ColorTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/ColorTokens.tsx
@@ -1,0 +1,19 @@
+import { Text } from "@vygruppen/spor-react";
+import { SharedTokenLayout } from "./SharedTokenLayout";
+
+export function ColorTokens() {
+  return (
+    <SharedTokenLayout
+      title="Farger"
+      description={
+        <Text>
+          Hovedfargene våre er de fargene vi bruker mest. Disse brukes som bla.
+          bakgrunnsfarger, i hovedfunksjonalitet, navigasjon og knapper – for å
+          lage et rammeverk for våre tjenester. Ved å bruke mest av disse
+          fargene, skaper vi en helhet og gjenkjennbarhet på tvers av våre
+          digitale flater.
+        </Text>
+      }
+    ></SharedTokenLayout>
+  );
+}

--- a/apps/docs/app/features/routes/ressurser/design-tokens/ColorTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/ColorTokens.tsx
@@ -1,9 +1,10 @@
-import { Text } from "@vygruppen/spor-react";
+import { BoxProps, Text } from "@vygruppen/spor-react";
 import { SharedTokenLayout } from "./SharedTokenLayout";
 
-export function ColorTokens() {
+export function ColorTokens(props: BoxProps) {
   return (
     <SharedTokenLayout
+      {...props}
       title="Farger"
       description={
         <Text>

--- a/apps/docs/app/features/routes/ressurser/design-tokens/OutlineTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/OutlineTokens.tsx
@@ -1,5 +1,6 @@
+import type { BoxProps } from "@vygruppen/spor-react";
 import { SharedTokenLayout } from "./SharedTokenLayout";
 
-export function OutlineTokens() {
-  return <SharedTokenLayout title="Outlines"></SharedTokenLayout>;
+export function OutlineTokens(props: BoxProps) {
+  return <SharedTokenLayout {...props} title="Outlines"></SharedTokenLayout>;
 }

--- a/apps/docs/app/features/routes/ressurser/design-tokens/OutlineTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/OutlineTokens.tsx
@@ -1,0 +1,5 @@
+import { SharedTokenLayout } from "./SharedTokenLayout";
+
+export function OutlineTokens() {
+  return <SharedTokenLayout title="Outlines"></SharedTokenLayout>;
+}

--- a/apps/docs/app/features/routes/ressurser/design-tokens/RoundingTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/RoundingTokens.tsx
@@ -1,9 +1,10 @@
-import { Text } from "@vygruppen/spor-react";
+import { BoxProps, Text } from "@vygruppen/spor-react";
 import { SharedTokenLayout } from "./SharedTokenLayout";
 
-export function RoundingTokens() {
+export function RoundingTokens(props: BoxProps) {
   return (
     <SharedTokenLayout
+      {...props}
       title="Rounding"
       description={
         <Text>

--- a/apps/docs/app/features/routes/ressurser/design-tokens/RoundingTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/RoundingTokens.tsx
@@ -1,0 +1,24 @@
+import { Text } from "@vygruppen/spor-react";
+import { SharedTokenLayout } from "./SharedTokenLayout";
+
+export function RoundingTokens() {
+  return (
+    <SharedTokenLayout
+      title="Rounding"
+      description={
+        <Text>
+          Avrundingen følger størrelsen på komponenten. Små komponenter har
+          liten avrunding, og store komponenter har større avrunding. Alle
+          komponenter som består av en “boks/kort” har rounding. Vi bruker
+          sjeldent helt firkantede komponenter (0 px rounding). En enkel måte å
+          se hvilken rounding du burde bruke, er å følge tommelfingerregelen:
+          komponenter med 1-2 linjer med tekst eller veldig kompakte elementer,
+          vil alltid ha rounding på 12 px. Når det er flere linjer horisontalt,
+          sånn som kort eller bokser, bruker vi rounding på 18 px. I tillegg
+          brukes 24 px rounding på skuffer, 30 px rounding på knapper og 36 px
+          rounding på header i appen.
+        </Text>
+      }
+    ></SharedTokenLayout>
+  );
+}

--- a/apps/docs/app/features/routes/ressurser/design-tokens/ShadowTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/ShadowTokens.tsx
@@ -1,9 +1,10 @@
-import { Text } from "@vygruppen/spor-react";
+import { BoxProps, Text } from "@vygruppen/spor-react";
 import { SharedTokenLayout } from "./SharedTokenLayout";
 
-export function ShadowTokens() {
+export function ShadowTokens(props: BoxProps) {
   return (
     <SharedTokenLayout
+      {...props}
       title="Skygger"
       description={
         <Text>

--- a/apps/docs/app/features/routes/ressurser/design-tokens/ShadowTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/ShadowTokens.tsx
@@ -1,0 +1,22 @@
+import { Text } from "@vygruppen/spor-react";
+import { SharedTokenLayout } from "./SharedTokenLayout";
+
+export function ShadowTokens() {
+  return (
+    <SharedTokenLayout
+      title="Skygger"
+      description={
+        <Text>
+          Skygge brukes for å løfte noe fra bakgrunnen (en handling) og for å
+          tydeliggjøre at noe er klikkbart. Det skal kun brukes skygge på
+          komponenter som er klikkbare. Vi bruker skygge for å skape et hierarki
+          av viktighet. Ikke alle klikkbare elementer har skygge, som f.eks
+          inputfelt og knapper. Noen ganger brukes skygge kun i enkelte states
+          av komponenter, for å tydeliggjøre en handling. Komponenter med sterke
+          farger eller outline trenger ikke skygge. Vi har tre nivåer av skygge:
+          Elevation 1, Elevation 2 og Elevation 3.
+        </Text>
+      }
+    ></SharedTokenLayout>
+  );
+}

--- a/apps/docs/app/features/routes/ressurser/design-tokens/SharedTokenLayout.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/SharedTokenLayout.tsx
@@ -1,0 +1,24 @@
+import { Box, Heading, Text } from "@vygruppen/spor-react";
+
+type SharedTokenLayoutProps = {
+  title: string;
+  description?: React.ReactNode;
+  children?: React.ReactNode;
+};
+export function SharedTokenLayout({
+  title,
+  description,
+  children,
+}: SharedTokenLayoutProps) {
+  return (
+    <Box>
+      <Heading as="h2" textStyles="xl-display" mb={2}>
+        {title}
+      </Heading>
+      <Text mb={6} textStyle="sm">
+        {description}
+      </Text>
+      {children}
+    </Box>
+  );
+}

--- a/apps/docs/app/features/routes/ressurser/design-tokens/SharedTokenLayout.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/SharedTokenLayout.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, Text } from "@vygruppen/spor-react";
+import { Box, Heading } from "@vygruppen/spor-react";
 
 type SharedTokenLayoutProps = {
   title: string;
@@ -12,12 +12,12 @@ export function SharedTokenLayout({
 }: SharedTokenLayoutProps) {
   return (
     <Box>
-      <Heading as="h2" textStyles="xl-display" mb={2}>
+      <Heading as="h2" textStyle="xl-display" mb={2}>
         {title}
       </Heading>
-      <Text mb={6} textStyle="sm">
+      <Box mb={6} textStyle="sm">
         {description}
-      </Text>
+      </Box>
       {children}
     </Box>
   );

--- a/apps/docs/app/features/routes/ressurser/design-tokens/SharedTokenLayout.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/SharedTokenLayout.tsx
@@ -1,6 +1,6 @@
-import { Box, Heading } from "@vygruppen/spor-react";
+import { Box, BoxProps, Heading } from "@vygruppen/spor-react";
 
-type SharedTokenLayoutProps = {
+type SharedTokenLayoutProps = BoxProps & {
   title: string;
   description?: React.ReactNode;
   children?: React.ReactNode;
@@ -9,9 +9,10 @@ export function SharedTokenLayout({
   title,
   description,
   children,
+  ...rest
 }: SharedTokenLayoutProps) {
   return (
-    <Box>
+    <Box {...rest}>
       <Heading as="h2" textStyle="xl-display" mb={2}>
         {title}
       </Heading>

--- a/apps/docs/app/features/routes/ressurser/design-tokens/SpacingTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/SpacingTokens.tsx
@@ -1,0 +1,18 @@
+import { Text } from "@vygruppen/spor-react";
+import { SharedTokenLayout } from "./SharedTokenLayout";
+
+export function SpacingTokens() {
+  return (
+    <SharedTokenLayout
+      title="Spacing"
+      description={
+        <Text>
+          Vy bruker en spacing-skala basert på 6 px, i kombinasjon med et 3 px
+          baseline-grid for mindre komponenter. Det vil si at menyer, bokser,
+          marginer og padding tar utgangspunkt i 6 px. Mens komponenter som
+          knapper og ikoner tar utgangspunkt i 6 og 12 px.
+        </Text>
+      }
+    ></SharedTokenLayout>
+  );
+}

--- a/apps/docs/app/features/routes/ressurser/design-tokens/SpacingTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/SpacingTokens.tsx
@@ -1,9 +1,10 @@
-import { Text } from "@vygruppen/spor-react";
+import { BoxProps, Text } from "@vygruppen/spor-react";
 import { SharedTokenLayout } from "./SharedTokenLayout";
 
-export function SpacingTokens() {
+export function SpacingTokens(props: BoxProps) {
   return (
     <SharedTokenLayout
+      {...props}
       title="Spacing"
       description={
         <Text>

--- a/apps/docs/app/features/routes/ressurser/design-tokens/TypographyTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/TypographyTokens.tsx
@@ -63,16 +63,14 @@ export function TypographyTokens() {
                     {token.name} Regular
                   </Text>
                 </Td>
-                <Td>
+                <Td lineHeight="1.333">
                   {token["font-size"].mobile.value} /{" "}
                   {token["line-height"].value}
                 </Td>
-                <Td>
-                  <Stack>
-                    <Code>$font-style-{token.name}-font-size-mobile</Code>
-                    <Code>$font-style-{token.name}-line-height</Code>
-                    <Code>$font-style-{token.name}-font-family</Code>
-                  </Stack>
+                <Td lineHeight="1.333">
+                  <Code fontFamily="mono">$font-style-{token.name}-font-size-mobile</Code>
+                  <Code>$font-style-{token.name}-line-height</Code>
+                  <Code>$font-style-{token.name}-font-family</Code>
                 </Td>
               </Tr>
             </Fragment>

--- a/apps/docs/app/features/routes/ressurser/design-tokens/TypographyTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/TypographyTokens.tsx
@@ -1,0 +1,27 @@
+import { Stack, Text } from "@vygruppen/spor-react";
+import { SharedTokenLayout } from "./SharedTokenLayout";
+
+export function TypographyTokens() {
+  return (
+    <SharedTokenLayout
+      title="Typografi"
+      description={
+        <Stack>
+          <Text>
+            Vi har to “sett” med tekststiler; ett for mobil og ett for desktop.
+            Tekststilene for Mobil skal brukes i Vy-appen, og web på mobil, mens
+            liggende tablet, desktop og widescreen skal bruke tekststilene for
+            Desktop. Brekkpunktet er på skjermbredde større eller lik &gt;=756
+            piksler bredde. Linjehøyden skal alltid være 1.333 ganger
+            skriftstørrelsen rundet av til nærmeste pixel.
+          </Text>
+          <Text>
+            Fonten Vy Display er mindre lesbar i små størrelser, og skal derfor
+            helst bare brukes på overskrifter på Epi-sidene, mens vi i Elm- og
+            React-apper foretrekker Vy Sans.
+          </Text>
+        </Stack>
+      }
+    ></SharedTokenLayout>
+  );
+}

--- a/apps/docs/app/features/routes/ressurser/design-tokens/TypographyTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/TypographyTokens.tsx
@@ -83,9 +83,10 @@ const typographyTokens: TypographyToken[] = [
   },
 ];
 
-export function TypographyTokens() {
+export function TypographyTokens(props: BoxProps) {
   return (
     <SharedTokenLayout
+      {...props}
       title="Typografi"
       description={
         <Stack spacing={6}>
@@ -105,7 +106,7 @@ export function TypographyTokens() {
         </Stack>
       }
     >
-      <Stack spacing={9} mb={9}>
+      <Stack spacing={9}>
         <TypographyTokenTable viewportSize="mobile" title="Mobil" />
         <TypographyTokenTable viewportSize="desktop" title="Desktop" />
       </Stack>

--- a/apps/docs/app/features/routes/ressurser/design-tokens/TypographyTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/TypographyTokens.tsx
@@ -105,8 +105,10 @@ export function TypographyTokens() {
         </Stack>
       }
     >
-      <TypographyTokenTable viewportSize="mobile" title="Mobil" />
-      <TypographyTokenTable viewportSize="desktop" title="Desktop" />
+      <Stack spacing={9} mb={9}>
+        <TypographyTokenTable viewportSize="mobile" title="Mobil" />
+        <TypographyTokenTable viewportSize="desktop" title="Desktop" />
+      </Stack>
     </SharedTokenLayout>
   );
 }
@@ -127,7 +129,7 @@ const TypographyTokenTable = ({
   );
   return (
     <Box {...props}>
-      <Heading as="h2" textStyle="xl-display" mb={2}>
+      <Heading as="h2" textStyle="sm" fontWeight="bold" mb={2}>
         {title}
       </Heading>
       <Table>
@@ -167,17 +169,17 @@ const TypographyTokenTable = ({
                   / {tokens.font.style[token.key]["line-height"].value}
                 </Td>
                 <Td lineHeight="1.333">
-                  <Code colorScheme="green">
+                  <Code colorScheme="grey" variant="outline">
                     {tokenFormatter(
                       `font.style.${token.key}.font-size.${viewportSize}`
                     )}
                   </Code>
                   <br />
-                  <Code colorScheme="green">
+                  <Code colorScheme="grey" variant="outline">
                     {tokenFormatter(`font.style.${token.key}.line-height`)}
                   </Code>
                   <br />
-                  <Code colorScheme="green">
+                  <Code colorScheme="grey" variant="outline">
                     {tokenFormatter(`font.style.${token.key}.font-family`)}
                   </Code>
                 </Td>
@@ -199,7 +201,7 @@ const createTokensFormatter =
           .map((part) => (part.includes("-") ? `["${part}"]` : part))
           .join(".")
           .replace(/\.\[/g, "[");
-        return `${parts}.value`;
+        return `tokens.${parts}.value`;
       case "css":
         return `--${template.replace(/\./g, "-")}`;
       case "scss":

--- a/apps/docs/app/features/routes/ressurser/design-tokens/TypographyTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/TypographyTokens.tsx
@@ -1,7 +1,25 @@
+import {
+  Code,
+  Table,
+  TableCaption,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@chakra-ui/react";
+import tokens from "@vygruppen/spor-design-tokens";
 import { Stack, Text } from "@vygruppen/spor-react";
+import { Fragment } from "react";
 import { SharedTokenLayout } from "./SharedTokenLayout";
 
 export function TypographyTokens() {
+  const mobileTokens = Object.entries(tokens.font.style).map(
+    ([name, style]) => ({
+      name,
+      ...style,
+    })
+  );
   return (
     <SharedTokenLayout
       title="Typografi"
@@ -22,6 +40,45 @@ export function TypographyTokens() {
           </Text>
         </Stack>
       }
-    ></SharedTokenLayout>
+    >
+      <Table>
+        <TableCaption>Mobil</TableCaption>
+        <Thead>
+          <Tr>
+            <Th>Eksempel</Th>
+            <Th>Verdi</Th>
+            <Th>Kode</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {mobileTokens.map((token, index) => (
+            <Fragment key={index}>
+              <Tr>
+                <Td>
+                  <Text
+                    fontSize={token["font-size"].mobile.value}
+                    fontFamily={token["font-family"].value}
+                    lineHeight={token["line-height"].value}
+                  >
+                    {token.name} Regular
+                  </Text>
+                </Td>
+                <Td>
+                  {token["font-size"].mobile.value} /{" "}
+                  {token["line-height"].value}
+                </Td>
+                <Td>
+                  <Stack>
+                    <Code>$font-style-{token.name}-font-size-mobile</Code>
+                    <Code>$font-style-{token.name}-line-height</Code>
+                    <Code>$font-style-{token.name}-font-family</Code>
+                  </Stack>
+                </Td>
+              </Tr>
+            </Fragment>
+          ))}
+        </Tbody>
+      </Table>
+    </SharedTokenLayout>
   );
 }

--- a/apps/docs/app/features/routes/ressurser/design-tokens/ZIndexTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/ZIndexTokens.tsx
@@ -1,5 +1,6 @@
+import type { BoxProps } from "@vygruppen/spor-react";
 import { SharedTokenLayout } from "./SharedTokenLayout";
 
-export function ZIndexTokens() {
-  return <SharedTokenLayout title="Z-index"></SharedTokenLayout>;
+export function ZIndexTokens(props: BoxProps) {
+  return <SharedTokenLayout {...props} title="Z-index"></SharedTokenLayout>;
 }

--- a/apps/docs/app/features/routes/ressurser/design-tokens/ZIndexTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/ZIndexTokens.tsx
@@ -1,0 +1,5 @@
+import { SharedTokenLayout } from "./SharedTokenLayout";
+
+export function ZIndexTokens() {
+  return <SharedTokenLayout title="Z-index"></SharedTokenLayout>;
+}

--- a/apps/docs/app/features/site-header/SiteHeader.tsx
+++ b/apps/docs/app/features/site-header/SiteHeader.tsx
@@ -4,8 +4,8 @@ import {
   ColorScheme,
   ColorSchemeProvider,
 } from "../color-scheme/ColorSchemeContext";
-import { UserPreferenceSwitcher } from "./UserPreferenceSwitcher";
 import { NavigationLink, SiteNavigation } from "./SiteNavigation";
+import { UserPreferenceSwitcher } from "./UserPreferenceSwitcher";
 
 type SiteHeaderProps = {
   colorScheme: ColorScheme;
@@ -29,11 +29,15 @@ export const SiteHeader = ({ colorScheme }: SiteHeaderProps) => {
             <VyLogo colorScheme={colorScheme} width="94px" height="48px" />
           </Box>
           <SiteNavigation>
-            <NavigationLink href="/kom-i-gang">Kom i gang</NavigationLink>
-            <NavigationLink href="/profil">Profil</NavigationLink>
+            <NavigationLink href="/ressurser/kom-i-gang">
+              Kom i gang
+            </NavigationLink>
+            <NavigationLink href="/ressurser/profil">Profil</NavigationLink>
             <NavigationLink href="/komponenter">Komponenter</NavigationLink>
             <NavigationLink href="/ikoner">Ikoner</NavigationLink>
-            <NavigationLink href="/design-tokens">Design tokens</NavigationLink>
+            <NavigationLink href="/ressurser/design-tokens">
+              Design tokens
+            </NavigationLink>
           </SiteNavigation>
         </Flex>
         <Flex gap="1em">

--- a/apps/docs/app/features/site-header/UserPreferenceSwitcher.tsx
+++ b/apps/docs/app/features/site-header/UserPreferenceSwitcher.tsx
@@ -15,6 +15,7 @@ import {
 import { ChangeEvent } from "react";
 import {
   Technology,
+  TokensFormat,
   UserType,
   useUserPreferences,
 } from "../user-preferences/UserPreferencesContext";
@@ -73,17 +74,37 @@ const UserPreferencesModal = ({
               <option value="developer">Utvikler</option>
             </Select>
             {userPreferences.userType === "developer" && (
-              <Select
-                label="Hvilken teknologi bruker du mest?"
-                value={userPreferences.technology}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-                  setUserPreference("technology", e.target.value as Technology)
-                }
-              >
-                <option value="react">React</option>
-                <option value="react-native">React Native</option>
-                <option value="elm">Elm</option>
-              </Select>
+              <>
+                <Select
+                  label="Hvilken teknologi bruker du mest?"
+                  value={userPreferences.technology}
+                  onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                    setUserPreference(
+                      "technology",
+                      e.target.value as Technology
+                    )
+                  }
+                >
+                  <option value="react">React</option>
+                  <option value="react-native">React Native</option>
+                  <option value="elm">Elm</option>
+                </Select>
+                <Select
+                  label="Hva slags format vil du se tokens i?"
+                  value={userPreferences.tokensFormat}
+                  onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                    setUserPreference(
+                      "tokensFormat",
+                      e.target.value as TokensFormat
+                    )
+                  }
+                >
+                  <option value="javascript">JavaScript</option>
+                  <option value="css">CSS</option>
+                  <option value="scss">SCSS</option>
+                  <option value="less">LESS</option>
+                </Select>
+              </>
             )}
           </Stack>
         </ModalBody>

--- a/apps/docs/app/features/user-preferences/UserPreferencesContext.tsx
+++ b/apps/docs/app/features/user-preferences/UserPreferencesContext.tsx
@@ -10,14 +10,21 @@ export type UserPreferences = {
   /**
    * If the user is a developer, their preferred technology will be found here.
    *
-   * Note that if you set this value as a developer, then switch your viewMode to designer, then this value won't be reset.
+   * Note that if you set this value as a developer, then switch your userType to designer, then this value won't be reset.
    */
   technology: "react" | "react-native" | "elm";
+  /**
+   * If the user is a developer, their preferred tokens format will be found here.
+   *
+   * Note that if you set this value as a developer, then switch your userType to designer, then this value won't be reset.
+   */
+  tokensFormat: "javascript" | "css" | "scss" | "less";
 };
 
 type UserPreference = keyof UserPreferences;
 export type UserType = UserPreferences["userType"];
 export type Technology = UserPreferences["technology"];
+export type TokensFormat = UserPreferences["tokensFormat"];
 
 type UserPreferencesContextType = {
   userPreferences: UserPreferences;
@@ -33,6 +40,7 @@ const UserPreferencesContext = createContext<UserPreferencesContextType | null>(
 export const defaultUserPreferences: UserPreferences = {
   userType: "developer",
   technology: "react",
+  tokensFormat: "javascript",
 };
 
 type UserPreferencesProviderProps = {
@@ -89,7 +97,7 @@ export function useUserPreferences() {
   return context;
 }
 
-export function isUserPreferences(
+export function isValidUserPreferences(
   userPreferences: Record<string, string | undefined>
 ): userPreferences is UserPreferences {
   const isValidUserType = ["developer", "designer"].includes(
@@ -98,5 +106,8 @@ export function isUserPreferences(
   const isValidTechnology = ["react", "react-native", "elm"].includes(
     userPreferences.technology ?? ""
   );
-  return isValidUserType && isValidTechnology;
+  const isValidTokensFormat = ["javascript", "css", "scss", "less"].includes(
+    userPreferences.tokensFormat ?? ""
+  );
+  return isValidUserType && isValidTechnology && isValidTokensFormat;
 }

--- a/apps/docs/app/routes/actions/user-preferences.tsx
+++ b/apps/docs/app/routes/actions/user-preferences.tsx
@@ -1,5 +1,5 @@
 import { ActionFunction, json, LoaderFunction, redirect } from "remix";
-import { isUserPreferences } from "~/features/user-preferences/UserPreferencesContext";
+import { isValidUserPreferences } from "~/features/user-preferences/UserPreferencesContext";
 import { getUserPreferenceSession } from "~/utils/userPreferences.server";
 
 export const action: ActionFunction = async ({ request }) => {
@@ -9,9 +9,10 @@ export const action: ActionFunction = async ({ request }) => {
   const userPreferences = {
     userType: formData.get("userType")?.toString(),
     technology: formData.get("technology")?.toString(),
+    tokensFormat: formData.get("tokensFormat")?.toString(),
   };
 
-  if (!isUserPreferences(userPreferences)) {
+  if (!isValidUserPreferences(userPreferences)) {
     return json({ success: false, message: "Invalid user preferences" });
   }
 

--- a/apps/docs/app/routes/ressurser.tsx
+++ b/apps/docs/app/routes/ressurser.tsx
@@ -3,7 +3,6 @@ import { Outlet } from "remix";
 import { DocsLayout } from "~/features/layouts/docs-layout/DocsLayout";
 
 export default function ResourcesPage() {
-  console.log("ressurser-siden");
   return (
     <DocsLayout>
       <Label backgroundColor="alias.coralGreen" color="alias.darkGrey" mb={1}>
@@ -22,7 +21,7 @@ function Label(props: LabelProps) {
     <Flex
       display="inline-flex"
       borderRadius="sm"
-      textStyles="xs"
+      textStyle="xs"
       fontWeight="bold"
       height="24px"
       px={2}

--- a/apps/docs/app/routes/ressurser.tsx
+++ b/apps/docs/app/routes/ressurser.tsx
@@ -1,31 +1,19 @@
-import { Flex, FlexProps } from "@vygruppen/spor-react";
+import { Badge } from "@vygruppen/spor-react";
 import { Outlet } from "remix";
 import { DocsLayout } from "~/features/layouts/docs-layout/DocsLayout";
 
 export default function ResourcesPage() {
   return (
     <DocsLayout>
-      <Label backgroundColor="alias.coralGreen" color="alias.darkGrey" mb={1}>
+      <Badge
+        variant="solid"
+        backgroundColor="alias.coralGreen"
+        color="alias.darkGrey"
+        mb={1}
+      >
         Ressurser
-      </Label>
+      </Badge>
       <Outlet />
     </DocsLayout>
-  );
-}
-
-type WithRequired<T, U extends keyof T> = Omit<T, U> & Required<Pick<T, U>>;
-
-type LabelProps = WithRequired<FlexProps, "backgroundColor" | "color">;
-function Label(props: LabelProps) {
-  return (
-    <Flex
-      display="inline-flex"
-      borderRadius="sm"
-      textStyle="xs"
-      fontWeight="bold"
-      height="24px"
-      px={2}
-      {...props}
-    />
   );
 }

--- a/apps/docs/app/routes/ressurser.tsx
+++ b/apps/docs/app/routes/ressurser.tsx
@@ -1,0 +1,32 @@
+import { Flex, FlexProps } from "@vygruppen/spor-react";
+import { Outlet } from "remix";
+import { DocsLayout } from "~/features/layouts/docs-layout/DocsLayout";
+
+export default function ResourcesPage() {
+  console.log("ressurser-siden");
+  return (
+    <DocsLayout>
+      <Label backgroundColor="alias.coralGreen" color="alias.darkGrey" mb={1}>
+        Ressurser
+      </Label>
+      <Outlet />
+    </DocsLayout>
+  );
+}
+
+type WithRequired<T, U extends keyof T> = Omit<T, U> & Required<Pick<T, U>>;
+
+type LabelProps = WithRequired<FlexProps, "backgroundColor" | "color">;
+function Label(props: LabelProps) {
+  return (
+    <Flex
+      display="inline-flex"
+      borderRadius="sm"
+      textStyles="xs"
+      fontWeight="bold"
+      height="24px"
+      px={2}
+      {...props}
+    />
+  );
+}

--- a/apps/docs/app/routes/ressurser/design-tokens.tsx
+++ b/apps/docs/app/routes/ressurser/design-tokens.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, Stack, Text } from "@vygruppen/spor-react";
+import { Box, BoxProps, Heading, Stack, Text } from "@vygruppen/spor-react";
 
 export default function DesignTokensPage() {
   return (
@@ -21,6 +21,175 @@ export default function DesignTokensPage() {
           og mer.
         </Text>
       </Stack>
+      <Divider mt={4} mb={9} />
+      <ColorTokens />
+      <TypographyTokens />
+      <SpacingTokens />
+      <RoundingTokens />
+      <ShadowTokens />
+      <OutlineTokens />
+      <BreakpointTokens />
+      <AnimationTokens />
+      <ZIndexTokens />
     </Box>
   );
+}
+
+function Divider(props: BoxProps) {
+  return (
+    <Box
+      as="hr"
+      height="2px"
+      border="0"
+      borderRadius="1px"
+      backgroundColor="palette.blackAlpha.200"
+      width="100%"
+      {...props}
+    />
+  );
+}
+
+type SharedTokenLayoutProps = {
+  title: string;
+  description?: React.ReactNode;
+  children?: React.ReactNode;
+};
+function SharedTokenLayout({
+  title,
+  description,
+  children,
+}: SharedTokenLayoutProps) {
+  return (
+    <Box>
+      <Heading as="h2" textStyles="xl-display" mb={2}>
+        {title}
+      </Heading>
+      <Text mb={6} textStyle="sm">
+        {description}
+      </Text>
+      {children}
+    </Box>
+  );
+}
+
+function ColorTokens() {
+  return (
+    <SharedTokenLayout
+      title="Farger"
+      description={
+        <Text>
+          Hovedfargene våre er de fargene vi bruker mest. Disse brukes som bla.
+          bakgrunnsfarger, i hovedfunksjonalitet, navigasjon og knapper – for å
+          lage et rammeverk for våre tjenester. Ved å bruke mest av disse
+          fargene, skaper vi en helhet og gjenkjennbarhet på tvers av våre
+          digitale flater.
+        </Text>
+      }
+    ></SharedTokenLayout>
+  );
+}
+function TypographyTokens() {
+  return (
+    <SharedTokenLayout
+      title="Typografi"
+      description={
+        <Stack>
+          <Text>
+            Vi har to “sett” med tekststiler; ett for mobil og ett for desktop.
+            Tekststilene for Mobil skal brukes i Vy-appen, og web på mobil, mens
+            liggende tablet, desktop og widescreen skal bruke tekststilene for
+            Desktop. Brekkpunktet er på skjermbredde større eller lik &gt;=756
+            piksler bredde. Linjehøyden skal alltid være 1.333 ganger
+            skriftstørrelsen rundet av til nærmeste pixel.
+          </Text>
+          <Text>
+            Fonten Vy Display er mindre lesbar i små størrelser, og skal derfor
+            helst bare brukes på overskrifter på Epi-sidene, mens vi i Elm- og
+            React-apper foretrekker Vy Sans.
+          </Text>
+        </Stack>
+      }
+    ></SharedTokenLayout>
+  );
+}
+function SpacingTokens() {
+  return (
+    <SharedTokenLayout
+      title="Spacing"
+      description={
+        <Text>
+          Vy bruker en spacing-skala basert på 6 px, i kombinasjon med et 3 px
+          baseline-grid for mindre komponenter. Det vil si at menyer, bokser,
+          marginer og padding tar utgangspunkt i 6 px. Mens komponenter som
+          knapper og ikoner tar utgangspunkt i 6 og 12 px.
+        </Text>
+      }
+    ></SharedTokenLayout>
+  );
+}
+function RoundingTokens() {
+  return (
+    <SharedTokenLayout
+      title="Rounding"
+      description={
+        <Text>
+          Avrundingen følger størrelsen på komponenten. Små komponenter har
+          liten avrunding, og store komponenter har større avrunding. Alle
+          komponenter som består av en “boks/kort” har rounding. Vi bruker
+          sjeldent helt firkantede komponenter (0 px rounding). En enkel måte å
+          se hvilken rounding du burde bruke, er å følge tommelfingerregelen:
+          komponenter med 1-2 linjer med tekst eller veldig kompakte elementer,
+          vil alltid ha rounding på 12 px. Når det er flere linjer horisontalt,
+          sånn som kort eller bokser, bruker vi rounding på 18 px. I tillegg
+          brukes 24 px rounding på skuffer, 30 px rounding på knapper og 36 px
+          rounding på header i appen.
+        </Text>
+      }
+    ></SharedTokenLayout>
+  );
+}
+function ShadowTokens() {
+  return (
+    <SharedTokenLayout
+      title="Skygger"
+      description={
+        <Text>
+          Skygge brukes for å løfte noe fra bakgrunnen (en handling) og for å
+          tydeliggjøre at noe er klikkbart. Det skal kun brukes skygge på
+          komponenter som er klikkbare. Vi bruker skygge for å skape et hierarki
+          av viktighet. Ikke alle klikkbare elementer har skygge, som f.eks
+          inputfelt og knapper. Noen ganger brukes skygge kun i enkelte states
+          av komponenter, for å tydeliggjøre en handling. Komponenter med sterke
+          farger eller outline trenger ikke skygge. Vi har tre nivåer av skygge:
+          Elevation 1, Elevation 2 og Elevation 3.
+        </Text>
+      }
+    ></SharedTokenLayout>
+  );
+}
+function OutlineTokens() {
+  return <SharedTokenLayout title="Outlines"></SharedTokenLayout>;
+}
+function BreakpointTokens() {
+  return <SharedTokenLayout title="Breakpoints"></SharedTokenLayout>;
+}
+function AnimationTokens() {
+  return (
+    <SharedTokenLayout
+      title="Animasjon"
+      description={
+        <Text>
+          Det er viktig at lengden på animasjonen og hvilke attributter som
+          animeres ikke virker forstyrrende eller gjør det vanskeligere å
+          navigere for brukeren. Vi har satt opp tre grunn-animasjoner man kan
+          bruke når man setter opp overganger mellom states. Disse definerer tre
+          ulike timinger og hvordan kurven på animasjonen skal utføres: Slow,
+          Medium, Fast.
+        </Text>
+      }
+    ></SharedTokenLayout>
+  );
+}
+function ZIndexTokens() {
+  return <SharedTokenLayout title="Z-indeks"></SharedTokenLayout>;
 }

--- a/apps/docs/app/routes/ressurser/design-tokens.tsx
+++ b/apps/docs/app/routes/ressurser/design-tokens.tsx
@@ -58,3 +58,4 @@ function Divider(props: BoxProps) {
     />
   );
 }
+

--- a/apps/docs/app/routes/ressurser/design-tokens.tsx
+++ b/apps/docs/app/routes/ressurser/design-tokens.tsx
@@ -1,4 +1,13 @@
 import { Box, BoxProps, Heading, Stack, Text } from "@vygruppen/spor-react";
+import { AnimationTokens } from "~/features/routes/ressurser/design-tokens/AnimationTokens";
+import { BreakpointTokens } from "~/features/routes/ressurser/design-tokens/BreakpointTokens";
+import { ColorTokens } from "~/features/routes/ressurser/design-tokens/ColorTokens";
+import { OutlineTokens } from "~/features/routes/ressurser/design-tokens/OutlineTokens";
+import { RoundingTokens } from "~/features/routes/ressurser/design-tokens/RoundingTokens";
+import { ShadowTokens } from "~/features/routes/ressurser/design-tokens/ShadowTokens";
+import { SpacingTokens } from "~/features/routes/ressurser/design-tokens/SpacingTokens";
+import { TypographyTokens } from "~/features/routes/ressurser/design-tokens/TypographyTokens";
+import { ZIndexTokens } from "~/features/routes/ressurser/design-tokens/ZIndexTokens";
 
 export default function DesignTokensPage() {
   return (
@@ -35,6 +44,7 @@ export default function DesignTokensPage() {
   );
 }
 
+// TODO: Make this its own package
 function Divider(props: BoxProps) {
   return (
     <Box
@@ -47,149 +57,4 @@ function Divider(props: BoxProps) {
       {...props}
     />
   );
-}
-
-type SharedTokenLayoutProps = {
-  title: string;
-  description?: React.ReactNode;
-  children?: React.ReactNode;
-};
-function SharedTokenLayout({
-  title,
-  description,
-  children,
-}: SharedTokenLayoutProps) {
-  return (
-    <Box>
-      <Heading as="h2" textStyles="xl-display" mb={2}>
-        {title}
-      </Heading>
-      <Text mb={6} textStyle="sm">
-        {description}
-      </Text>
-      {children}
-    </Box>
-  );
-}
-
-function ColorTokens() {
-  return (
-    <SharedTokenLayout
-      title="Farger"
-      description={
-        <Text>
-          Hovedfargene våre er de fargene vi bruker mest. Disse brukes som bla.
-          bakgrunnsfarger, i hovedfunksjonalitet, navigasjon og knapper – for å
-          lage et rammeverk for våre tjenester. Ved å bruke mest av disse
-          fargene, skaper vi en helhet og gjenkjennbarhet på tvers av våre
-          digitale flater.
-        </Text>
-      }
-    ></SharedTokenLayout>
-  );
-}
-function TypographyTokens() {
-  return (
-    <SharedTokenLayout
-      title="Typografi"
-      description={
-        <Stack>
-          <Text>
-            Vi har to “sett” med tekststiler; ett for mobil og ett for desktop.
-            Tekststilene for Mobil skal brukes i Vy-appen, og web på mobil, mens
-            liggende tablet, desktop og widescreen skal bruke tekststilene for
-            Desktop. Brekkpunktet er på skjermbredde større eller lik &gt;=756
-            piksler bredde. Linjehøyden skal alltid være 1.333 ganger
-            skriftstørrelsen rundet av til nærmeste pixel.
-          </Text>
-          <Text>
-            Fonten Vy Display er mindre lesbar i små størrelser, og skal derfor
-            helst bare brukes på overskrifter på Epi-sidene, mens vi i Elm- og
-            React-apper foretrekker Vy Sans.
-          </Text>
-        </Stack>
-      }
-    ></SharedTokenLayout>
-  );
-}
-function SpacingTokens() {
-  return (
-    <SharedTokenLayout
-      title="Spacing"
-      description={
-        <Text>
-          Vy bruker en spacing-skala basert på 6 px, i kombinasjon med et 3 px
-          baseline-grid for mindre komponenter. Det vil si at menyer, bokser,
-          marginer og padding tar utgangspunkt i 6 px. Mens komponenter som
-          knapper og ikoner tar utgangspunkt i 6 og 12 px.
-        </Text>
-      }
-    ></SharedTokenLayout>
-  );
-}
-function RoundingTokens() {
-  return (
-    <SharedTokenLayout
-      title="Rounding"
-      description={
-        <Text>
-          Avrundingen følger størrelsen på komponenten. Små komponenter har
-          liten avrunding, og store komponenter har større avrunding. Alle
-          komponenter som består av en “boks/kort” har rounding. Vi bruker
-          sjeldent helt firkantede komponenter (0 px rounding). En enkel måte å
-          se hvilken rounding du burde bruke, er å følge tommelfingerregelen:
-          komponenter med 1-2 linjer med tekst eller veldig kompakte elementer,
-          vil alltid ha rounding på 12 px. Når det er flere linjer horisontalt,
-          sånn som kort eller bokser, bruker vi rounding på 18 px. I tillegg
-          brukes 24 px rounding på skuffer, 30 px rounding på knapper og 36 px
-          rounding på header i appen.
-        </Text>
-      }
-    ></SharedTokenLayout>
-  );
-}
-function ShadowTokens() {
-  return (
-    <SharedTokenLayout
-      title="Skygger"
-      description={
-        <Text>
-          Skygge brukes for å løfte noe fra bakgrunnen (en handling) og for å
-          tydeliggjøre at noe er klikkbart. Det skal kun brukes skygge på
-          komponenter som er klikkbare. Vi bruker skygge for å skape et hierarki
-          av viktighet. Ikke alle klikkbare elementer har skygge, som f.eks
-          inputfelt og knapper. Noen ganger brukes skygge kun i enkelte states
-          av komponenter, for å tydeliggjøre en handling. Komponenter med sterke
-          farger eller outline trenger ikke skygge. Vi har tre nivåer av skygge:
-          Elevation 1, Elevation 2 og Elevation 3.
-        </Text>
-      }
-    ></SharedTokenLayout>
-  );
-}
-function OutlineTokens() {
-  return <SharedTokenLayout title="Outlines"></SharedTokenLayout>;
-}
-function BreakpointTokens() {
-  return <SharedTokenLayout title="Breakpoints"></SharedTokenLayout>;
-}
-function AnimationTokens() {
-  return (
-    <SharedTokenLayout
-      title="Animasjon"
-      description={
-        <Text>
-          Det er viktig at lengden på animasjonen og hvilke attributter som
-          animeres ikke virker forstyrrende eller gjør det vanskeligere å
-          navigere for brukeren. Vi har satt opp tre grunn-animasjoner man kan
-          bruke når man setter opp overganger mellom states. Disse definerer tre
-          ulike timinger og hvordan kurven på animasjonen skal utføres: Slow,
-          Medium, Fast.
-        </Text>
-      }
-    ></SharedTokenLayout>
-  );
-}
-function ZIndexTokens() {
-  return <SharedTokenLayout title="Z-indeks"></SharedTokenLayout>;
 }

--- a/apps/docs/app/routes/ressurser/design-tokens.tsx
+++ b/apps/docs/app/routes/ressurser/design-tokens.tsx
@@ -12,7 +12,7 @@ import { ZIndexTokens } from "~/features/routes/ressurser/design-tokens/ZIndexTo
 export default function DesignTokensPage() {
   return (
     <Box>
-      <Heading as="h1" textStyles="xl-display" mb={2}>
+      <Heading as="h1" textStyle="xl-display" mb={2}>
         Design tokens
       </Heading>
       <Stack spacing={6} fontSize={["mobile.sm", "desktop.sm"]}>
@@ -58,4 +58,3 @@ function Divider(props: BoxProps) {
     />
   );
 }
-

--- a/apps/docs/app/routes/ressurser/design-tokens.tsx
+++ b/apps/docs/app/routes/ressurser/design-tokens.tsx
@@ -31,15 +31,17 @@ export default function DesignTokensPage() {
         </Text>
       </Stack>
       <Divider mt={4} mb={9} />
-      <ColorTokens />
-      <TypographyTokens />
-      <SpacingTokens />
-      <RoundingTokens />
-      <ShadowTokens />
-      <OutlineTokens />
-      <BreakpointTokens />
-      <AnimationTokens />
-      <ZIndexTokens />
+      <Stack spacing={9}>
+        <ColorTokens />
+        <TypographyTokens />
+        <SpacingTokens />
+        <RoundingTokens />
+        <ShadowTokens />
+        <OutlineTokens />
+        <BreakpointTokens />
+        <AnimationTokens />
+        <ZIndexTokens />
+      </Stack>
     </Box>
   );
 }

--- a/apps/docs/app/routes/ressurser/design-tokens.tsx
+++ b/apps/docs/app/routes/ressurser/design-tokens.tsx
@@ -1,0 +1,26 @@
+import { Box, Heading, Stack, Text } from "@vygruppen/spor-react";
+
+export default function DesignTokensPage() {
+  return (
+    <Box>
+      <Heading as="h1" textStyles="xl-display" mb={2}>
+        Design tokens
+      </Heading>
+      <Stack spacing={6} fontSize={["mobile.sm", "desktop.sm"]}>
+        <Text>
+          Designtokens er alle verdiene man trenger for å konstruere og
+          vedlikeholde et designsystem. Disse verdiene kan representere alt som
+          er definert av design: en farge som en RGB-verdi, en opasitet som et
+          tall, en enkel animasjon som Bezier-koordinater. Vi bruker Tokens i
+          stedet for hardkodede verdier for å sikre fleksibilitet og enhet på
+          tvers av alle produktopplevelser.
+        </Text>
+        <Text>
+          Designtokens er direkte integrert i komponentbiblioteket vårt. De
+          dekker de ulike alternativene for vekter, fargetemaer, komponentstates
+          og mer.
+        </Text>
+      </Stack>
+    </Box>
+  );
+}

--- a/apps/docs/app/utils/userPreferences.server.ts
+++ b/apps/docs/app/utils/userPreferences.server.ts
@@ -1,7 +1,7 @@
 import { createCookieSessionStorage } from "remix";
 import {
   defaultUserPreferences,
-  isUserPreferences,
+  isValidUserPreferences,
   UserPreferences,
 } from "../features/user-preferences/UserPreferencesContext";
 
@@ -37,7 +37,7 @@ export async function getUserPreferenceSession(request: Request) {
         return defaultUserPreferences;
       }
       const parsedUserPreferences = JSON.parse(userPreferencesText);
-      if (isUserPreferences(parsedUserPreferences)) {
+      if (isValidUserPreferences(parsedUserPreferences)) {
         return parsedUserPreferences;
       }
       console.warn(

--- a/packages/spor-card-react/src/Card.tsx
+++ b/packages/spor-card-react/src/Card.tsx
@@ -2,7 +2,7 @@ import { As, BoxProps, forwardRef, useStyleConfig } from "@chakra-ui/react";
 import { Box } from "@vygruppen/spor-layout-react";
 import React from "react";
 
-type CardProps = BoxProps &
+export type CardProps = BoxProps &
   (
     | {
         variant: "elevated" | "outlined";

--- a/packages/spor-card-react/src/Card.tsx
+++ b/packages/spor-card-react/src/Card.tsx
@@ -1,5 +1,5 @@
-import { As, BoxProps, forwardRef, useStyleConfig } from "@chakra-ui/react";
-import { Box } from "@vygruppen/spor-layout-react";
+import { As, forwardRef, useStyleConfig } from "@chakra-ui/react";
+import { Box, BoxProps } from "@vygruppen/spor-layout-react";
 import React from "react";
 
 export type CardProps = BoxProps &

--- a/packages/spor-image-react/src/index.tsx
+++ b/packages/spor-image-react/src/index.tsx
@@ -1,1 +1,2 @@
 export { Image, Img } from "@chakra-ui/react";
+export type { ImageProps, ImgProps } from "@chakra-ui/react";

--- a/packages/spor-input-react/src/Checkbox.tsx
+++ b/packages/spor-input-react/src/Checkbox.tsx
@@ -5,6 +5,7 @@ import {
 } from "@chakra-ui/react";
 import React from "react";
 
+export type CheckboxProps = ChakraCheckboxProps;
 /**
  * Creates a checkbox.
  *
@@ -18,8 +19,6 @@ import React from "react";
  *
  * You can group several of these together with a `CheckboxGroup`.
  */
-export const Checkbox = forwardRef<ChakraCheckboxProps, "input">(
-  (props, ref) => {
-    return <ChakraCheckbox {...props} ref={ref} />;
-  }
-);
+export const Checkbox = forwardRef<CheckboxProps, "input">((props, ref) => {
+  return <ChakraCheckbox {...props} ref={ref} />;
+});

--- a/packages/spor-input-react/src/FormControl.tsx
+++ b/packages/spor-input-react/src/FormControl.tsx
@@ -4,6 +4,7 @@ import {
 } from "@chakra-ui/react";
 import React from "react";
 
-export const FormControl = (props: ChakraFormControlProps) => {
+export type FormControlProps = ChakraFormControlProps;
+export const FormControl = (props: FormControlProps) => {
   return <ChakraFormControl {...props} />;
 };

--- a/packages/spor-input-react/src/InputElement.tsx
+++ b/packages/spor-input-react/src/InputElement.tsx
@@ -1,10 +1,11 @@
 import {
-  InputElementProps,
+  InputElementProps as ChakraInputElementProps,
   InputLeftElement as ChakraInputLeftElement,
   InputRightElement as ChakraInputRightElement,
 } from "@chakra-ui/react";
 import React from "react";
 
+export type InputElementProps = ChakraInputElementProps;
 /**
  * Places an element inside the left side of an input field.
  *

--- a/packages/spor-input-react/src/PasswordInput.tsx
+++ b/packages/spor-input-react/src/PasswordInput.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "@vygruppen/spor-i18n-react";
 import React from "react";
 import { Input, InputGroup, InputProps, InputRightElement } from ".";
 
-type PasswordInputProps = InputProps;
+export type PasswordInputProps = InputProps;
 export const PasswordInput = (props: PasswordInputProps) => {
   const { isOpen: isShowingPassword, onToggle } = useDisclosure();
   const { t } = useTranslation();

--- a/packages/spor-input-react/src/index.tsx
+++ b/packages/spor-input-react/src/index.tsx
@@ -1,4 +1,5 @@
 export { FormErrorMessage, FormHelperText, InputGroup } from "@chakra-ui/react";
+export type { FormErrorMessageProps, InputGroupProps } from "@chakra-ui/react";
 export * from "./Checkbox";
 export * from "./CheckboxGroup";
 export * from "./ChoiceChip";

--- a/packages/spor-layout-react/src/index.tsx
+++ b/packages/spor-layout-react/src/index.tsx
@@ -13,3 +13,16 @@ export {
   Wrap,
   WrapItem,
 } from "@chakra-ui/react";
+export type {
+  BoxProps,
+  CenterProps,
+  ContainerProps,
+  FlexProps,
+  GridItemProps,
+  GridProps,
+  SimpleGridProps,
+  SpacerProps,
+  StackProps,
+  WrapItemProps,
+  WrapProps,
+} from "@chakra-ui/react";

--- a/packages/spor-logo-react/src/VyLogo.tsx
+++ b/packages/spor-logo-react/src/VyLogo.tsx
@@ -1,7 +1,7 @@
 import { Box, BoxProps } from "@chakra-ui/react";
 import React from "react";
 
-type VyLogoProps = {
+export type VyLogoProps = {
   /** The color of the logo
    *
    * Use `"light"` when the logo is used on a dark background.

--- a/packages/spor-theme-react/src/components/badge.ts
+++ b/packages/spor-theme-react/src/components/badge.ts
@@ -1,0 +1,50 @@
+import type {
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools";
+
+const baseStyle: SystemStyleObject = {
+  px: 2,
+  height: 4,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontSize: ["mobile.xs", "desktop.xs"],
+  borderRadius: "xl",
+  fontWeight: "bold",
+};
+
+const variantSolid: SystemStyleFunction = (props) => {
+  const { colorScheme: c } = props;
+
+  return {
+    backgroundColor: c === "red" ? "palette.red.600" : `palette.${c}.500`,
+    color: `alias.white`,
+  };
+};
+
+const variantOutline: SystemStyleFunction = (props) => {
+  const { colorScheme: c } = props;
+
+  return {
+    backgroundColor: `palette.${c}.50`,
+    color: `palette.${c}.600`,
+    boxShadow: `inset 0 0 0 1px currentColor`,
+  };
+};
+
+const variants = {
+  solid: variantSolid,
+  outline: variantOutline,
+};
+
+const defaultProps = {
+  variant: "solid",
+  colorScheme: "grey",
+};
+
+export default {
+  baseStyle,
+  variants,
+  defaultProps,
+};

--- a/packages/spor-theme-react/src/components/code.ts
+++ b/packages/spor-theme-react/src/components/code.ts
@@ -1,0 +1,17 @@
+import type { SystemStyleObject } from "@chakra-ui/theme-tools";
+import Badge from "./badge";
+
+const { variants, defaultProps } = Badge;
+
+const baseStyle: SystemStyleObject = {
+  fontFamily: "monospace",
+  fontSize: "xs",
+  borderRadius: "xs",
+  px: 1,
+};
+
+export default {
+  baseStyle,
+  variants,
+  defaultProps,
+};

--- a/packages/spor-theme-react/src/components/index.ts
+++ b/packages/spor-theme-react/src/components/index.ts
@@ -1,7 +1,9 @@
+export { default as Badge } from "./badge";
 export { default as Button } from "./button";
 export { default as Card } from "./card";
 export { default as Checkbox } from "./checkbox";
 export { default as ChoiceChip } from "./choice-chip";
+export { default as Code } from "./code";
 export { default as Form } from "./form";
 export { default as Input } from "./input";
 export { default as Modal } from "./modal";

--- a/packages/spor-typography-react/src/Badge.tsx
+++ b/packages/spor-typography-react/src/Badge.tsx
@@ -15,6 +15,6 @@ export type BadgeProps = Omit<ChakraBadgeProps, "variant" | "colorScheme"> & {
  *
  * You can specify two different variants - `solid` and `outline`. The default is `solid`, and there are no set rules about when to use what.
  */
-export const Badge = forwardRef<BadgeProps, As<"div">>((props, ref) => (
+export const Badge = forwardRef<BadgeProps, As<any>>((props, ref) => (
   <ChakraBadge {...props} ref={ref} />
 ));

--- a/packages/spor-typography-react/src/Badge.tsx
+++ b/packages/spor-typography-react/src/Badge.tsx
@@ -1,0 +1,20 @@
+import {
+  As,
+  Badge as ChakraBadge,
+  BadgeProps as ChakraBadgeProps,
+  forwardRef,
+} from "@chakra-ui/react";
+import React from "react";
+
+export type BadgeProps = Omit<ChakraBadgeProps, "variant" | "colorScheme"> & {
+  variant?: "solid" | "outline";
+  colorScheme?: "grey" | "teal" | "green" | "blue" | "yellow" | "orange";
+};
+/**
+ * Shows some additional information about the component it's used within.
+ *
+ * You can specify two different variants - `solid` and `outline`. The default is `solid`, and there are no set rules about when to use what.
+ */
+export const Badge = forwardRef<BadgeProps, As<"div">>((props, ref) => (
+  <ChakraBadge {...props} ref={ref} />
+));

--- a/packages/spor-typography-react/src/Code.tsx
+++ b/packages/spor-typography-react/src/Code.tsx
@@ -6,7 +6,7 @@ import {
 } from "@chakra-ui/react";
 import React from "react";
 
-export type CodeProps = {} & ChakraCodeProps;
+export type CodeProps = ChakraCodeProps;
 /**
  * Shows inline code.
  */

--- a/packages/spor-typography-react/src/Code.tsx
+++ b/packages/spor-typography-react/src/Code.tsx
@@ -10,6 +10,6 @@ export type CodeProps = ChakraCodeProps;
 /**
  * Shows inline code.
  */
-export const Code = forwardRef<CodeProps, As<"code">>((props, ref) => (
+export const Code = forwardRef<CodeProps, As<any>>((props, ref) => (
   <ChakraCode {...props} ref={ref} />
 ));

--- a/packages/spor-typography-react/src/Code.tsx
+++ b/packages/spor-typography-react/src/Code.tsx
@@ -1,0 +1,15 @@
+import {
+  As,
+  Code as ChakraCode,
+  CodeProps as ChakraCodeProps,
+  forwardRef,
+} from "@chakra-ui/react";
+import React from "react";
+
+export type CodeProps = {} & ChakraCodeProps;
+/**
+ * Shows inline code.
+ */
+export const Code = forwardRef<CodeProps, As<"code">>((props, ref) => (
+  <ChakraCode {...props} ref={ref} />
+));

--- a/packages/spor-typography-react/src/index.tsx
+++ b/packages/spor-typography-react/src/index.tsx
@@ -1,2 +1,4 @@
 export { Text } from "@chakra-ui/react";
+export * from "./Badge";
+export * from "./Code";
 export * from "./Heading";


### PR DESCRIPTION
This pull request starts implementing the design tokens docs. It sets up the page, all sections, implements the typography token documentation, and adds a few new components in the process.

It's still not ready for launch, but I wanted to create a pull request first, so I could create a new pull request for tables.

- Change the URLs for resource pages
- Implement a simple resource page design
- Add sections for all tokens
- Refactor all token sections into their own files
- Start implementing typography tokens
- Fix a bunch of bugs and deficiencies
- Add two new components - Badge and Code
- Add another user preference for tokens format
- Use badge instead of locally sourced label
- Implement 1st version of typography tokens view
- Expose all props type definitions from all packages
- Fix some type errors in Card, Badge and Code components
- Tweak a bit of spacing
- Space the sections out with a Stack
