### PR TITLE
Make icons their original size by default

### DIFF
--- a/.changeset/angry-pens-yawn.md
+++ b/.changeset/angry-pens-yawn.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react": patch
+---
+
+Make icons their stated size, instead of the current font size.

--- a/packages/spor-icon-react/bin/generate.ts
+++ b/packages/spor-icon-react/bin/generate.ts
@@ -97,7 +97,7 @@ async function generateComponent(iconData: IconData) {
   let jsCode = await transform(
     iconData.icon,
     {
-      icon: true,
+      icon: false,
       expandProps: "end",
       ref: true,
       titleProp: false,


### PR DESCRIPTION
Typically, you want icons to be the same size as the text they're next to. That's what `icon: true` does in the svgr tool.

However, we have specified sizes for all our icons, so that doesn't really make sense in our context. Thanks to @annalytic for pointing this out.

You might want to check over all your icons, so that they are the expected size.