### PR TITLE
input field docs

### DIFF
--- a/.changeset/fifty-ads-allow.md
+++ b/.changeset/fifty-ads-allow.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-input-react": minor
+---
+
+Add support for leftIcon and rightIcon props

--- a/.changeset/light-tomatoes-return.md
+++ b/.changeset/light-tomatoes-return.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-input-react": patch
+"@vygruppen/spor-theme-react": patch
+---
+
+Fix a bunch of edge cases where inputs and selects would render weirdly

--- a/apps/docs/app/features/component-docs/ComponentDocs.tsx
+++ b/apps/docs/app/features/component-docs/ComponentDocs.tsx
@@ -16,7 +16,7 @@ export const ComponentDocs = ({
         <Heading as="h1" textStyle="xl-display">
           {title}
         </Heading>
-        <Text>{description}</Text>
+        <Text textStyle="sm">{description}</Text>
       </Stack>
       <Stack spacing={8}>{children}</Stack>
     </Stack>

--- a/apps/docs/app/features/component-playground/ComponentPlayground.tsx
+++ b/apps/docs/app/features/component-playground/ComponentPlayground.tsx
@@ -5,13 +5,15 @@ import {
   AccordionItem,
   AccordionPanel,
   Box,
-  Center,
   ExpandableItem,
   SimpleGrid,
   Stack,
 } from "@vygruppen/spor-react";
-import nightOwlLight from "prism-react-renderer/themes/nightOwlLight";
-import { LiveEditor, LiveError, LivePreview, LiveProvider } from "react-live";
+import React from "react";
+import { LiveEditor } from "../interactive-code/LiveEditor";
+import { LiveError } from "../interactive-code/LiveError";
+import { LivePreview } from "../interactive-code/LivePreview";
+import { LiveProvider } from "../interactive-code/LiveProvider";
 import { useUserPreferences } from "../user-preferences/UserPreferencesContext";
 import { EditableProp } from "./EditableProp";
 import { PropSpec } from "./usePlaygroundProps";
@@ -21,13 +23,6 @@ type ComponentPlaygroundProps = {
    * The code you render in the preview window
    **/
   code: string;
-  /**
-   * A map of components that should be in scope.
-   *
-   * If you want to render the Button component, for instance, you would pass in
-   * `scope={{ Button }}`.
-   */
-  scope: Record<string, any>;
   /**
    * A list of props and how they're specified
    *
@@ -47,23 +42,14 @@ type ComponentPlaygroundProps = {
 };
 export const ComponentPlayground = ({
   code,
-  scope,
   propList = [],
   currentProps = {},
   onPropsChange = () => {},
 }: ComponentPlaygroundProps) => {
   const { userPreferences } = useUserPreferences();
   return (
-    <LiveProvider code={code} scope={scope} theme={nightOwlLight}>
-      <Center
-        borderRadius="sm"
-        border="sm"
-        borderColor="alias.osloGrey"
-        minHeight="240px"
-        mb={2}
-      >
-        <LivePreview />
-      </Center>
+    <LiveProvider code={code}>
+      <LivePreview minHeight="240px" mb={2} />
       <Accordion allowToggle variant="outline" size="lg">
         <Stack spacing={2}>
           {propList && (
@@ -88,9 +74,9 @@ export const ComponentPlayground = ({
                   <AccordionIcon />
                 </AccordionButton>
               </Box>
-              <AccordionPanel fontFamily="monospace" fontSize="desktop.sm">
-                <LiveEditor />
-                <LiveError />
+              <AccordionPanel backgroundColor="alias.darkGrey" p={0}>
+                <LiveEditor border="0" />
+                <LiveError color="alias.white" />
               </AccordionPanel>
             </AccordionItem>
           )}

--- a/apps/docs/app/features/content-menu/SearchInput.tsx
+++ b/apps/docs/app/features/content-menu/SearchInput.tsx
@@ -1,10 +1,4 @@
-import {
-  FormControl,
-  Input,
-  InputGroup,
-  InputLeftElement,
-  SearchOutline24Icon,
-} from "@vygruppen/spor-react";
+import { Input, SearchOutline24Icon } from "@vygruppen/spor-react";
 import React from "react";
 
 export type SearchInputProps = {
@@ -12,12 +6,10 @@ export type SearchInputProps = {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 };
 export const SearchInput = ({ value, onChange }: SearchInputProps) => (
-  <FormControl>
-    <InputGroup>
-      <InputLeftElement width="48px">
-        <SearchOutline24Icon />
-      </InputLeftElement>
-      <Input label="Søk" pl="48px" value={value} onChange={onChange} />
-    </InputGroup>
-  </FormControl>
+  <Input
+    label="Søk"
+    leftIcon={<SearchOutline24Icon />}
+    value={value}
+    onChange={onChange}
+  />
 );

--- a/apps/docs/app/features/content-menu/menuStructure.ts
+++ b/apps/docs/app/features/content-menu/menuStructure.ts
@@ -71,7 +71,11 @@ export const menuStructure: MenuStructure[] = [
         href: "/komponenter/form-control",
         keywords: ["form control"],
       },
-      { title: "Tekstfelt", href: "/komponenter/input", keywords: ["input"] },
+      {
+        title: "Tekstfelt",
+        href: "/komponenter/tekstfelt",
+        keywords: ["input"],
+      },
       {
         title: "Passordfelt",
         href: "/komponenter/password-input",

--- a/apps/docs/app/features/interactive-code/InteractiveCode.tsx
+++ b/apps/docs/app/features/interactive-code/InteractiveCode.tsx
@@ -1,0 +1,25 @@
+import { Box, BoxProps, Stack } from "@vygruppen/spor-react";
+import { LiveEditor } from "./LiveEditor";
+import { LiveError } from "./LiveError";
+import { LivePreview } from "./LivePreview";
+import { LiveProvider } from "./LiveProvider";
+
+type InteractiveCodeProps = {
+  children: string;
+} & BoxProps;
+export const InteractiveCode = ({
+  children,
+  ...rest
+}: InteractiveCodeProps) => {
+  return (
+    <Box {...rest}>
+      <LiveProvider code={children.trim()}>
+        <Stack spacing={2}>
+          <LivePreview />
+          <LiveEditor />
+          <LiveError />
+        </Stack>
+      </LiveProvider>
+    </Box>
+  );
+};

--- a/apps/docs/app/features/interactive-code/LiveEditor.tsx
+++ b/apps/docs/app/features/interactive-code/LiveEditor.tsx
@@ -1,0 +1,19 @@
+import { Box, BoxProps } from "@vygruppen/spor-react";
+import { LiveEditor as ReactLiveEditor } from "react-live";
+
+export const LiveEditor = (props: BoxProps) => {
+  return (
+    <Box
+      borderRadius="sm"
+      border="sm"
+      borderColor="alias.osloGrey"
+      backgroundColor="alias.darkGrey"
+      fontFamily="monospace"
+      fontSize="sm"
+      p={2}
+      {...props}
+    >
+      <ReactLiveEditor />
+    </Box>
+  );
+};

--- a/apps/docs/app/features/interactive-code/LiveError.tsx
+++ b/apps/docs/app/features/interactive-code/LiveError.tsx
@@ -1,0 +1,10 @@
+import { Box, BoxProps } from "@vygruppen/spor-react";
+import { LiveError as ReactLiveError } from "react-live";
+
+export const LiveError = (props: BoxProps) => {
+  return (
+    <Box textStyle="sm" p={2} {...props}>
+      <ReactLiveError />
+    </Box>
+  );
+};

--- a/apps/docs/app/features/interactive-code/LivePreview.tsx
+++ b/apps/docs/app/features/interactive-code/LivePreview.tsx
@@ -1,0 +1,16 @@
+import { BoxProps, Center } from "@vygruppen/spor-react";
+import { LivePreview as ReactLivePreview } from "react-live";
+
+export const LivePreview = (props: BoxProps) => {
+  return (
+    <Center
+      borderRadius="sm"
+      border="sm"
+      borderColor="alias.osloGrey"
+      p={4}
+      {...props}
+    >
+      <ReactLivePreview />
+    </Center>
+  );
+};

--- a/apps/docs/app/features/interactive-code/LiveProvider.tsx
+++ b/apps/docs/app/features/interactive-code/LiveProvider.tsx
@@ -1,0 +1,16 @@
+import * as sporReact from "@vygruppen/spor-react";
+import { LiveProvider as ReactLiveProvider } from "react-live";
+
+// For some reason, a default export is generated for the `spor-react` package. // That can't be included to the `scope` below, because reasons.
+// Therefore, we need to remove it from the set of all components
+const { default: removed, ...allComponents } = sporReact as any;
+
+type LiveProviderProps = {
+  code: string;
+  children: React.ReactNode;
+};
+export const LiveProvider = ({ children, code }: LiveProviderProps) => (
+  <ReactLiveProvider code={code.trim()} scope={allComponents}>
+    {children}
+  </ReactLiveProvider>
+);

--- a/apps/docs/app/routes/komponenter/knapper.tsx
+++ b/apps/docs/app/routes/komponenter/knapper.tsx
@@ -60,7 +60,6 @@ const DemoArea = (props: BoxProps) => {
     <Box {...props}>
       <ComponentPlayground
         code={code}
-        scope={{ Button }}
         propList={propList}
         currentProps={currentProps}
         onPropsChange={onPropsChange}

--- a/apps/docs/app/routes/komponenter/tekstfelt.tsx
+++ b/apps/docs/app/routes/komponenter/tekstfelt.tsx
@@ -1,0 +1,74 @@
+import {
+  Box,
+  BoxProps,
+  FormControl,
+  Heading,
+  Input,
+  Stack,
+  Text,
+} from "@vygruppen/spor-react";
+import { ComponentDocs } from "~/features/component-docs/ComponentDocs";
+import { ComponentPlayground } from "~/features/component-playground/ComponentPlayground";
+import { usePlaygroundProps } from "~/features/component-playground/usePlaygroundProps";
+import { toPropsString } from "~/features/component-playground/utils";
+import { InteractiveCode } from "~/features/interactive-code/InteractiveCode";
+
+export default function InputsDocsPage() {
+  return (
+    <ComponentDocs
+      title="Tekstfelt"
+      description="Tekstfelt brukes for å innhente informasjon fra brukerne."
+    >
+      <DemoArea />
+      <Guidelines />
+    </ComponentDocs>
+  );
+}
+
+const DemoArea = (props: BoxProps) => {
+  const { currentProps, propList, onPropsChange } = usePlaygroundProps([
+    { name: "label", defaultValue: "Fornavn", type: "input" },
+    { name: "isInvalid", defaultValue: false, type: "choiceChip" },
+    { name: "isDisabled", defaultValue: false, type: "choiceChip" },
+  ]);
+  const code = `
+<FormControl>
+  <Input 
+    ${toPropsString(currentProps, "    ")}
+  />
+</FormControl>`;
+  return (
+    <Box {...props}>
+      <ComponentPlayground
+        code={code}
+        scope={{ Input, FormControl }}
+        propList={propList}
+        currentProps={currentProps}
+        onPropsChange={onPropsChange}
+      />
+    </Box>
+  );
+};
+
+const Guidelines = (props: BoxProps) => {
+  return (
+    <Stack {...props} spacing={8}>
+      <Stack spacing={3}>
+        <Heading as="h2" textStyle="xl-display">
+          Retningslinjer
+        </Heading>
+        <Text>Inputbokser brukes når vi skal legge inn tekst i felt.</Text>
+        <Heading as="h3" textStyle="lg" fontWeight="bold">
+          Ikoner
+        </Heading>
+        <Text>
+          Noen ganger kan det være smart å bruke et ikon for å indikere hva
+          slags felt det er snakk om.
+        </Text>
+        <InteractiveCode>
+          {`<Input label="Søk" leftIcon={<SearchOutline24Icon />} />`}
+        </InteractiveCode>
+      </Stack>
+    </Stack>
+  );
+};

--- a/apps/docs/app/routes/komponenter/tekstfelt.tsx
+++ b/apps/docs/app/routes/komponenter/tekstfelt.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  BoxProps,
-  FormControl,
-  Heading,
-  Input,
-  Stack,
-  Text,
-} from "@vygruppen/spor-react";
+import { Box, BoxProps, Heading, Stack, Text } from "@vygruppen/spor-react";
 import { ComponentDocs } from "~/features/component-docs/ComponentDocs";
 import { ComponentPlayground } from "~/features/component-playground/ComponentPlayground";
 import { usePlaygroundProps } from "~/features/component-playground/usePlaygroundProps";
@@ -32,16 +24,13 @@ const DemoArea = (props: BoxProps) => {
     { name: "isDisabled", defaultValue: false, type: "choiceChip" },
   ]);
   const code = `
-<FormControl>
-  <Input 
-    ${toPropsString(currentProps, "    ")}
-  />
-</FormControl>`;
+<Input 
+  ${toPropsString(currentProps, "    ")}
+/>`;
   return (
     <Box {...props}>
       <ComponentPlayground
         code={code}
-        scope={{ Input, FormControl }}
         propList={propList}
         currentProps={currentProps}
         onPropsChange={onPropsChange}

--- a/packages/spor-input-react/src/Input.tsx
+++ b/packages/spor-input-react/src/Input.tsx
@@ -2,48 +2,52 @@ import {
   FormLabel,
   forwardRef,
   Input as ChakraInput,
+  InputGroup,
+  InputLeftElement,
   InputProps as ChakraInputProps,
+  InputRightElement,
 } from "@chakra-ui/react";
 import React from "react";
 
 export type InputProps = Exclude<ChakraInputProps, "variant" | "size"> & {
+  /** The input's label */
   label: string;
+  /** Icon that shows up to the left */
+  leftIcon?: React.ReactNode;
+  /** Icon that shows up to the right */
+  rightIcon?: React.ReactNode;
 };
 /**
- * Input field that works with the `FormControl` component.
+ * Inputs let you enter text or other data.
  *
- * Note that it requires you to pass a label.
+ * You need to specify the label as a prop, since it doubles as the placeholder.
  *
  * ```tsx
- * <FormControl>
- *   <Input label="E-mail" />
- * </FormControl>
+ * <Input label="E-mail" />
  * ```
  *
- * You can also wrap the component in an `InputGroup` and add addons and elements to each side.
+ * You can also add icons to the left and right of the input. Please use the 24 px icons for this.
  *
  * ```tsx
- * <FormControl>
- *   <InputGroup>
- *     <Input label="E-mail" />
- *     <InputRightElement>
- *       <IconButton icon={SearchIcon} />
- *     </InputRightElement>
- *   </InputGroup>
- * </FormControl>
+ * <Input label="E-mail" leftIcon={<EmailOutline24Icon />} />
  * ```
  */
 export const Input = forwardRef<InputProps, "input">(
-  ({ label, ...props }, ref) => {
+  ({ label, leftIcon, rightIcon, ...props }, ref) => {
+    const Container = leftIcon || rightIcon ? InputGroup : React.Fragment;
     return (
-      <>
+      <Container>
+        {leftIcon && <InputLeftElement>{leftIcon}</InputLeftElement>}
         <ChakraInput
+          pl={leftIcon ? 7 : undefined}
+          pr={rightIcon ? 7 : undefined}
           {...props}
           ref={ref}
           placeholder=" " // This is needed to make the label work as expected
         />
         <FormLabel>{label}</FormLabel>
-      </>
+        {rightIcon && <InputRightElement>{rightIcon}</InputRightElement>}
+      </Container>
     );
   }
 );

--- a/packages/spor-input-react/src/Input.tsx
+++ b/packages/spor-input-react/src/Input.tsx
@@ -35,7 +35,6 @@ export type InputProps = Exclude<ChakraInputProps, "variant" | "size"> & {
  */
 export const Input = forwardRef<InputProps, "input">(
   ({ label, ...props }, ref) => {
-    const leftPadding = props.pl || props.paddingLeft;
     return (
       <>
         <ChakraInput
@@ -43,52 +42,8 @@ export const Input = forwardRef<InputProps, "input">(
           ref={ref}
           placeholder=" " // This is needed to make the label work as expected
         />
-        <FormLabel pl={calculateCorrectLabelPadding(leftPadding)}>
-          {label}
-        </FormLabel>
+        <FormLabel>{label}</FormLabel>
       </>
     );
   }
 );
-
-/** Does a best effort approach to figure out the correct label padding */
-const calculateCorrectLabelPadding = (paddingValue?: any): any => {
-  // If no padding is specified, no padding is required
-  if (!paddingValue) {
-    return 0;
-  }
-
-  // If the padding is a number, it's a part of the spacing scale
-  const paddingValueAsNumber = Number(paddingValue);
-  if (
-    typeof paddingValueAsNumber === "number" &&
-    !Number.isNaN(paddingValueAsNumber)
-  ) {
-    return paddingValueAsNumber < 2 ? 2 : Number(paddingValue) - 2;
-  }
-
-  // If the padding is a responsive array, calculate each value recursively 😎
-  if (Array.isArray(paddingValue)) {
-    return paddingValue.flatMap((partValue) =>
-      calculateCorrectLabelPadding(partValue)
-    );
-  }
-
-  // If the padding is a responsive object, calculate each value recursively 😎
-  if (typeof paddingValue === "object") {
-    return Object.entries(paddingValue).reduce(
-      (acc, [key, value]) => ({
-        ...acc,
-        [key]: calculateCorrectLabelPadding(value),
-      }),
-      {} as any
-    );
-  }
-  // If the padding contains a number, it's a numeric unit we can use with calc
-  if (/\d+/.test(paddingValue.toString())) {
-    return `calc(${paddingValue} - 16px)`;
-  }
-
-  // If all else fails, just return the padding value
-  return paddingValue;
-};

--- a/packages/spor-input-react/src/PasswordInput.tsx
+++ b/packages/spor-input-react/src/PasswordInput.tsx
@@ -12,15 +12,15 @@ export const PasswordInput = (props: PasswordInputProps) => {
       <Input
         {...props}
         type={isShowingPassword ? "text" : "password"}
-        pr="4.5em !important"
+        pr={10}
       />
-      <InputRightElement width="4.5em">
+      <InputRightElement width="fit-content">
         <Button
           variant="ghost"
           type="button"
-          px={4}
           onClick={onToggle}
           borderRadius="sm"
+          mr={1}
         >
           {isShowingPassword ? t(texts.hidePassword) : t(texts.showPassword)}
         </Button>

--- a/packages/spor-input-react/src/Select.tsx
+++ b/packages/spor-input-react/src/Select.tsx
@@ -1,6 +1,7 @@
 import {
   Select as ChakraSelect,
   SelectProps as ChakraSelectProps,
+  useMultiStyleConfig,
 } from "@chakra-ui/react";
 import React from "react";
 import { FormControl, FormLabel } from ".";
@@ -24,9 +25,10 @@ export type SelectProps = Exclude<
  * ```
  */
 export const Select = ({ label, ...props }: SelectProps) => {
+  const styles = useMultiStyleConfig("Select", props);
   return (
     <FormControl>
-      <ChakraSelect {...props} />
+      <ChakraSelect {...props} rootProps={{ __css: styles.root }} />
       {label && <FormLabel>{label}</FormLabel>}
     </FormControl>
   );

--- a/packages/spor-theme-react/src/components/form.ts
+++ b/packages/spor-theme-react/src/components/form.ts
@@ -15,7 +15,7 @@ const baseStyleRequiredIndicator: SystemStyleFunction = (props) => {
 const baseStyleHelperText: SystemStyleFunction = (props) => {
   return {
     mt: 2,
-    color: mode("gray.500", "whiteAlpha.600")(props),
+    color: mode("alias.osloGrey", "palette.whiteAlpha.600")(props),
     lineHeight: "normal",
     fontSize: "sm",
   };
@@ -27,32 +27,6 @@ const baseStyleContainer: SystemStyleFunction = () => {
     position: "relative",
     transitionProperty: "common",
     transitionDuration: "fast",
-    "input + label": {
-      top: "0",
-    },
-    "input + label, .chakra-select__wrapper + label": {
-      fontSize: ["mobile.sm", "desktop.sm"],
-      top: "2px",
-      left: "16px",
-      zIndex: 2,
-      position: "absolute",
-      mx: 0,
-      my: 2,
-      transition: ".1s ease-out",
-      transformOrigin: "top left",
-    },
-    "input:not(:placeholder-shown) + label": {
-      transform: "scale(0.825) translateY(-10px)",
-    },
-    ".chakra-select__wrapper + label": {
-      transform: [
-        "scale(0.825) translateY(-12px)",
-        "scale(0.825) translateY(-14px)",
-      ],
-    },
-    "input:not(:placeholder-shown)": {
-      pt: "16px",
-    },
   };
 };
 

--- a/packages/spor-theme-react/src/components/input.ts
+++ b/packages/spor-theme-react/src/components/input.ts
@@ -1,8 +1,8 @@
 import { inputAnatomy as parts } from "@chakra-ui/anatomy";
-import type { PartsStyleObject } from "@chakra-ui/theme-tools";
+import type { PartsStyleFunction } from "@chakra-ui/theme-tools";
 import { colors } from "../foundations";
 
-const baseStyle: PartsStyleObject<typeof parts> = {
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   field: {
     width: "100%",
     outline: "none",
@@ -11,7 +11,7 @@ const baseStyle: PartsStyleObject<typeof parts> = {
     borderRadius: "sm",
     transition: ".1s ease-out",
     position: "relative",
-    px: "16px",
+    px: 3,
     height: "54px",
     fontSize: "18px",
 
@@ -36,11 +36,27 @@ const baseStyle: PartsStyleObject<typeof parts> = {
         boxShadow: `inset 0 0 0 2px ${colors.outline.greenHaze}`,
       },
     },
+    " + label": {
+      fontSize: ["mobile.sm", "desktop.sm"],
+      top: "2px",
+      left: props.paddingLeft || props.pl || 3,
+      zIndex: 2,
+      position: "absolute",
+      my: 2,
+      transition: ".1s ease-out",
+      transformOrigin: "top left",
+    },
+    "&:not(:placeholder-shown)": {
+      pt: "16px",
+      "& + label": {
+        transform: "scale(0.825) translateY(-10px)",
+      },
+    },
   },
   element: {
     height: "100%",
   },
-};
+});
 
 export default {
   parts: parts.keys,

--- a/packages/spor-theme-react/src/components/select.ts
+++ b/packages/spor-theme-react/src/components/select.ts
@@ -1,9 +1,30 @@
-import { selectAnatomy as parts } from "@chakra-ui/anatomy";
+import { selectAnatomy } from "@chakra-ui/anatomy";
 import type {
   PartsStyleObject,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools";
 import Input from "./input";
+
+const parts = selectAnatomy.extend("root");
+
+const baseStyleRoot: SystemStyleObject = {
+  width: "100%",
+  height: "fit-content",
+  position: "relative",
+  "& + label": {
+    fontSize: ["mobile.sm", "desktop.sm"],
+    top: "2px",
+    left: 3,
+    zIndex: 2,
+    position: "absolute",
+    my: 2,
+    transformOrigin: "top left",
+    transform: [
+      "scale(0.825) translateY(-12px)",
+      "scale(0.825) translateY(-14px)",
+    ],
+  },
+};
 
 const baseStyleField: SystemStyleObject = {
   ...Input.baseStyle.field,
@@ -29,6 +50,7 @@ const baseStyleIcon: SystemStyleObject = {
 };
 
 const baseStyle: PartsStyleObject<typeof parts> = {
+  root: baseStyleRoot,
   field: baseStyleField,
   icon: baseStyleIcon,
 };


### PR DESCRIPTION
Lots of "oh crap I'll just fix that tiny bug" stuff in this PR. I'll try to add context in the comments.

Basically, this PR fixes a lot of issues with the input implementation, and documents it in the process.

- Fix lots of edge cases with input and select rendering
- Add leftIcon and rightIcon props
- Refactor and improve the password input
- Create a more reusable code example component
- Upgrade the component playground to use the new reusable code example components
- Make the intro text slightly larger
- Simplify search field implementation
- Remove now unnecessary prop
- Add basic documentation for input fields
