### PR TITLE
Make input fields easier to focus even without FormControl wrapping

### DIFF
--- a/.changeset/long-owls-sip.md
+++ b/.changeset/long-owls-sip.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-input-react": patch
+---
+
+Fix a bug where the label in input fields would get in the way of clicking parts of the input field when not wrapped in a FormControl

--- a/package-lock.json
+++ b/package-lock.json
@@ -14678,7 +14678,7 @@
     },
     "packages/spor-accordion-react": {
       "name": "@vygruppen/spor-accordion-react",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^1.7.3",
@@ -14700,7 +14700,7 @@
     },
     "packages/spor-button-react": {
       "name": "@vygruppen/spor-button-react",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*"
@@ -14849,7 +14849,7 @@
     },
     "packages/spor-input-react": {
       "name": "@vygruppen/spor-input-react",
-      "version": "0.2.3",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*"
@@ -14932,7 +14932,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "0.8.0",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@leile/lobo-t": "^1.0.5",
@@ -15002,7 +15002,7 @@
     },
     "packages/spor-theme-react": {
       "name": "@vygruppen/spor-theme-react",
-      "version": "0.2.3",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/theme-tools": "^1.3.1",
@@ -17304,7 +17304,7 @@
         "eslint": "7.32.0",
         "framer-motion": "^6.0.0",
         "fs-extra": "^10.0.0",
-        "match-sorter": "*",
+        "match-sorter": "^6.3.1",
         "prism-react-renderer": "^1.3.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",

--- a/packages/spor-input-react/src/Input.tsx
+++ b/packages/spor-input-react/src/Input.tsx
@@ -34,7 +34,7 @@ export type InputProps = Exclude<ChakraInputProps, "variant" | "size"> & {
  * ```
  */
 export const Input = forwardRef<InputProps, "input">(
-  ({ label, leftIcon, rightIcon, ...props }, ref) => {
+  ({ label, leftIcon, rightIcon, id, ...props }, ref) => {
     const Container = leftIcon || rightIcon ? InputGroup : Box;
     return (
       <Container position="relative">
@@ -42,11 +42,14 @@ export const Input = forwardRef<InputProps, "input">(
         <ChakraInput
           pl={leftIcon ? 7 : undefined}
           pr={rightIcon ? 7 : undefined}
+          id={id}
           {...props}
           ref={ref}
           placeholder=" " // This is needed to make the label work as expected
         />
-        <FormLabel>{label}</FormLabel>
+        <FormLabel htmlFor={id} pointerEvents="none">
+          {label}
+        </FormLabel>
         {rightIcon && <InputRightElement>{rightIcon}</InputRightElement>}
       </Container>
     );


### PR DESCRIPTION
This fixes a bug where - if you didn't wrap your `<Input />` component in a `<FormControl />` component, and didn't provide your own ID - you couldn't click the overlaying label to focus the input.