### PR TITLE
Make build work on windows and ignore .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ packages/*/tmp
 # misc
 .DS_Store
 *.pem
+.idea/
 
 # debug
 npm-debug.log*

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "remix build",
-    "dev": "node -r dotenv/config ../../node_modules/.bin/remix dev",
+    "dev": "node -r dotenv/config ../../node_modules/@remix-run/dev/cli.js dev",
     "postinstall": "remix setup node",
     "start": "remix-serve build"
   },


### PR DESCRIPTION
* Added .idea folder to gitignore (automatically created by intelliJ)
* Made the build work on windows. This is a known issue on remix: https://github.com/remix-run/remix/issues/914