### PR TITLE
Make unavailable menu items disabled

### DIFF
--- a/apps/docs/app/features/content-menu/ContentMenu.tsx
+++ b/apps/docs/app/features/content-menu/ContentMenu.tsx
@@ -48,6 +48,7 @@ export const ContentMenu = () => {
                     href={subItem.href}
                     height={5}
                     isActive={subItem.href === location.pathname}
+                    isDisabled={!subItem.isAvailable}
                   >
                     {subItem.title}
                   </MenuItem>

--- a/apps/docs/app/features/content-menu/MenuItem.tsx
+++ b/apps/docs/app/features/content-menu/MenuItem.tsx
@@ -6,6 +6,7 @@ type MenuItemProps = FlexProps & {
   href: string;
   children: React.ReactNode;
   isActive?: boolean;
+  isDisabled?: boolean;
 };
 /**
  * Menu item in the `ContentMenu`, and search result in the `SearchResults`.
@@ -14,13 +15,24 @@ export const MenuItem = ({
   href,
   children,
   isActive,
+  isDisabled,
   ...rest
 }: MenuItemProps) => (
   <Flex
     key={href}
     as={Link}
-    to={href}
+    to={isDisabled ? "" : href}
     px={2}
+    disabled={isDisabled}
+    _disabled={{
+      pointerEvents: "none",
+      textDecoration: "line-through",
+      color: "alias.osloGrey",
+      "&:hover, &:focus, &:active": {
+        backgroundColor: "transparent",
+        outlineColor: "transparent",
+      },
+    }}
     fontSize="mobile.xs"
     borderRadius="sm"
     alignItems="center"

--- a/apps/docs/app/features/content-menu/SearchResults.tsx
+++ b/apps/docs/app/features/content-menu/SearchResults.tsx
@@ -13,7 +13,12 @@ export const SearchResults = ({ query }: SearchResultsProps) => {
   return (
     <Box mt={2}>
       {hits.map((item) => (
-        <MenuItem key={item.href} href={item.href} height={5}>
+        <MenuItem
+          key={item.href}
+          href={item.href}
+          height={5}
+          isDisabled={!item.isAvailable}
+        >
           {item.category}: {item.title}
         </MenuItem>
       ))}

--- a/apps/docs/app/features/content-menu/menuStructure.ts
+++ b/apps/docs/app/features/content-menu/menuStructure.ts
@@ -1,5 +1,10 @@
 type MenuDivider = { divider: true };
-type MenuStructureItem = { title: string; href: string; keywords?: string[] };
+type MenuStructureItem = {
+  title: string;
+  href: string;
+  keywords?: string[];
+  isAvailable?: boolean;
+};
 type MenuStructure =
   | {
       title: string;
@@ -18,6 +23,7 @@ export const menuStructure: MenuStructure[] = [
         title: "Introduksjon",
         href: "/kom-i-gang",
         keywords: ["intro"],
+        isAvailable: true,
       },
       {
         title: "Hva er Spor?",
@@ -39,8 +45,19 @@ export const menuStructure: MenuStructure[] = [
   {
     title: "Ressurser",
     items: [
+      {
+        title: "Designprosessen",
+        href: "/ressurser/design-prosessen",
+        keywords: ["process", "prosess"],
+        isAvailable: true,
+      },
       { title: "Profil", href: "/ressurser/profil", keywords: ["visuell"] },
-      { title: "Ikoner", href: "/ressurser/ikoner", keywords: ["icon"] },
+      {
+        title: "Ikoner",
+        href: "/ressurser/ikoner",
+        keywords: ["icon"],
+        isAvailable: true,
+      },
       {
         title: "Design tokens",
         href: "/ressurser/design-tokens",
@@ -62,7 +79,9 @@ export const menuStructure: MenuStructure[] = [
           "padding",
           "margin",
         ],
+        isAvailable: true,
       },
+
       { title: "FAQ", href: "/ressurser/faq" },
       { title: "Bidra", href: "/ressurser/bidra" },
     ],
@@ -72,14 +91,10 @@ export const menuStructure: MenuStructure[] = [
     title: "Skjema",
     items: [
       {
-        title: "Skjemafelt",
-        href: "/komponenter/form-control",
-        keywords: ["form control"],
-      },
-      {
         title: "Tekstfelt",
         href: "/komponenter/tekstfelt",
         keywords: ["input"],
+        isAvailable: true,
       },
       {
         title: "Passordfelt",
@@ -163,6 +178,7 @@ export const menuStructure: MenuStructure[] = [
           "additional",
           "tillegg",
         ],
+        isAvailable: true,
       },
       {
         title: "Chips",
@@ -178,6 +194,7 @@ export const menuStructure: MenuStructure[] = [
         title: "Lenker",
         href: "/komponenter/lenker",
         keywords: ["link", "a", "lenke", "knapper", "buttons"],
+        isAvailable: true,
       },
     ],
   },


### PR DESCRIPTION
As we're getting ready to launch the site, we want users to know what parts are implemented and what isn't. This PR disables any menu items that aren't explicitly marked as available in the menu structure.

As we move toward getting all of our content from Sanity, we can delete this code at a later point (if we want to), but it makes sense as of now.