### PR TITLE
Application configuration

### DIFF
--- a/apps/docs/.dockerignore
+++ b/apps/docs/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# Whitelist folders
+!node_modules/**/*
+!build/**/*
+!public/**/*
+!package.json
+!entrypoint.sh

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -2,10 +2,10 @@ FROM node:16-alpine
 
 WORKDIR /app
 
-COPY node_modules node_modules
-COPY package.json .
-COPY build build
-COPY public public
+RUN wget -O /usr/local/bin/aws-env https://github.com/telia-oss/aws-env/releases/download/v0.3.0/aws-env-linux-amd64 && \
+    chmod +x /usr/local/bin/aws-env
+
+COPY . /app
 
 EXPOSE 3000
-CMD npm start
+CMD ["./entrypoint.sh"]

--- a/apps/docs/entrypoint.sh
+++ b/apps/docs/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [ -z "$AWS_REGION" ] && [ -z "$AWS_DEFAULT_REGION" ]; then
+export AWS_REGION="eu-west-1"
+fi
+exec /usr/local/bin/aws-env exec npm start

--- a/apps/docs/terraform/template/.terraform.lock.hcl
+++ b/apps/docs/terraform/template/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.3.0"
+  hashes = [
+    "h1:OePPETAA8BIGTCgGQ54F3oAZnOFH5lxyDdP0cyLXdU4=",
+    "zh:087c67e5429f343a164221c05a83f152322f411e7394f8a39ed81a75982af1f2",
+    "zh:2e852a1b107e5324524874e1cd98bcf3a69284b4fe04750aa373054177c54214",
+    "zh:4b9a54b5895f945827832e6ddd16ff107301fedf47acbd83d17d4e18bbf10bb1",
+    "zh:64dfc02bc85f5df2f51ff942fc78d72fcd0db17b0f53e1fae380e58adbd239b3",
+    "zh:766f9aef619cfd23e924aee523791acccd30b6d8f1cc0ed1a7b5c953bf8c5392",
+    "zh:90048d87ff3071a4356cf91916b46a7ec69ba55bcba5765b598d3fe545d4c6ca",
+    "zh:c51f5b238af37c63e9033a12fd7fedc87c03eb966f5f5c7786eb6246e8bf3071",
+    "zh:d0df94d3112a25de609dfb55c5e3b0d119dea519a2bdd8099e64a8d63f22b683",
+    "zh:de166ecfeed70f570cea72ec094f00c2f997496b3226fa08518e7cd4a73884e1",
+    "zh:e31c31d00f42ea2dbaab1ad4c245da5cfff63e28399b5a5795b5e6a826c6c8af",
+    "zh:f93725afd8410194ede51d83505327aa1ae6a9b4280cf31db649c62c7dc203ae",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/apps/docs/terraform/template/main.tf
+++ b/apps/docs/terraform/template/main.tf
@@ -4,6 +4,12 @@ locals {
 
 data "aws_caller_identity" "current" {}
 
+##################################
+#                                #
+# ECR and access role            #
+#                                #
+##################################
+
 module "ecr" {
   source      = "github.com/nsbno/terraform-aws-ecr?ref=71ca5e2"
   name_prefix = "${var.name_prefix}-${var.application_name}"
@@ -13,45 +19,6 @@ module "ecr" {
   trusted_accounts = [
     data.aws_caller_identity.current.account_id
   ]
-
-  tags = var.tags
-}
-
-resource "random_string" "session_secret" {
-  length  = 32
-  special = false
-}
-
-resource "aws_apprunner_service" "service" {
-  service_name = "${var.name_prefix}-${var.application_name}"
-
-  source_configuration {
-    authentication_configuration {
-      access_role_arn = aws_iam_role.ecr_access_role.arn
-    }
-    image_repository {
-      image_configuration {
-        port = "3000"
-        runtime_environment_variables = {
-          SESSION_SECRET = random_string.session_secret.result
-        }
-      }
-      image_identifier      = "${module.ecr.url}:${local.image_tag}"
-      image_repository_type = "ECR"
-    }
-    auto_deployments_enabled = true
-  }
-
-  auto_scaling_configuration_arn = aws_apprunner_auto_scaling_configuration_version.autoscaling.arn
-
-  tags = var.tags
-}
-
-resource "aws_apprunner_auto_scaling_configuration_version" "autoscaling" {
-  auto_scaling_configuration_name = "limited-scaling"
-  max_concurrency                 = 100
-  min_size                        = 1
-  max_size                        = 2
 
   tags = var.tags
 }
@@ -99,6 +66,93 @@ resource "aws_iam_role_policy_attachment" "access_role_policy_attachment" {
   role       = aws_iam_role.ecr_access_role.name
   policy_arn = aws_iam_policy.access_policy.arn
 }
+
+
+##################################
+#                                #
+# Application KMS key            #
+#                                #
+##################################
+
+resource "aws_kms_key" "application_key" {
+  description = "Key for ${var.name_prefix}-${var.application_name}"
+}
+
+resource "aws_kms_alias" "application_key_alias" {
+  name          = "alias/${var.name_prefix}-${var.application_name}-new"
+  target_key_id = aws_kms_key.application_key.id
+}
+
+##################################
+#                                #
+# Application config             #
+# in parameter store             #
+#                                #
+##################################
+
+resource "aws_ssm_parameter" "cms_api_key" {
+  name   = "/config/${var.application_name}/cms_api_key"
+  type   = "SecureString"
+  value  = "null"
+  key_id = aws_kms_key.application_key.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+##################################
+#                                #
+# App Runner resources           #
+#                                #
+##################################
+
+resource "aws_apprunner_service" "service" {
+  service_name = "${var.name_prefix}-${var.application_name}"
+
+  source_configuration {
+    authentication_configuration {
+      access_role_arn = aws_iam_role.ecr_access_role.arn
+    }
+    image_repository {
+      image_configuration {
+        port = "3000"
+        runtime_environment_variables = {
+          SESSION_SECRET = random_string.session_secret.result
+          CMS_API_KEY    = aws_ssm_parameter.cms_api_key.value
+        }
+      }
+      image_identifier      = "${module.ecr.url}:${local.image_tag}"
+      image_repository_type = "ECR"
+    }
+    auto_deployments_enabled = true
+  }
+
+  auto_scaling_configuration_arn = aws_apprunner_auto_scaling_configuration_version.autoscaling.arn
+
+  tags = var.tags
+}
+
+resource "aws_apprunner_auto_scaling_configuration_version" "autoscaling" {
+  auto_scaling_configuration_name = "limited-scaling"
+  max_concurrency                 = 100
+  min_size                        = 1
+  max_size                        = 2
+
+  tags = var.tags
+}
+
+resource "random_string" "session_secret" {
+  length  = 32
+  special = false
+}
+
+##################################
+#                                #
+# Custom domain name             #
+# and TLS validation records     #
+#                                #
+##################################
 
 resource "aws_apprunner_custom_domain_association" "service" {
   domain_name          = aws_route53_record.record.name


### PR DESCRIPTION
Lagt til noen kommentar-blokker for å gjøre det enklere å navigere i Terraform filen.

Oppretter parametere i Systems Manager (SSM) som skal inneholde konfigurasjonshemmeligheter. Disse blir initiert til strengen "null", og oppdateres manuelt med den faktiske verdien etterpå. 

Som en work-around på App Runners manglende støtte til å lese hemmeligheter ut selv så bruker vi `aws-env`. Denne applikasjonen leter etter miljøvariabler som starter med "ssm://", leser parameteret ut av SSM og erstatter miljøvariablen med den faktiske verdien.