### PR TITLE
Fix underline on multiline links

### DIFF
--- a/.changeset/khaki-pillows-cry.md
+++ b/.changeset/khaki-pillows-cry.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-theme-react": patch
+"@vygruppen/spor-link-react": patch
+---
+
+Fix a bug with the link component that made it misbehave when broken over several lines

--- a/packages/spor-theme-react/src/components/link.ts
+++ b/packages/spor-theme-react/src/components/link.ts
@@ -9,9 +9,10 @@ const baseStyle: SystemStyleObject = {
   transitionTimingFunction: "ease-out",
   cursor: "pointer",
   outline: "none",
-  borderRadius: "xs",
+  borderRadius: "0",
+  borderBottom: "1px solid",
   color: "inherit",
-  display: "inline-flex",
+  display: "inline",
   alignItems: "center",
   position: "relative",
   textDecoration: "none",
@@ -30,16 +31,6 @@ const baseStyle: SystemStyleObject = {
     _after: {
       display: "none",
     },
-  },
-
-  _after: {
-    content: '""',
-    display: "block",
-    width: "100%",
-    height: "1px",
-    position: "absolute",
-    bottom: "-2px",
-    backgroundColor: "currentColor",
   },
 
   svg: {

--- a/packages/spor-theme-react/src/components/link.ts
+++ b/packages/spor-theme-react/src/components/link.ts
@@ -8,35 +8,25 @@ const baseStyle: SystemStyleObject = {
   transitionDuration: "fast",
   transitionTimingFunction: "ease-out",
   cursor: "pointer",
-  outline: "none",
-  borderRadius: "0",
-  borderBottom: "1px solid",
+  backgroundImage: "linear-gradient(currentColor, currentColor)",
+  backgroundSize: "100% 2px",
+  backgroundPosition: "0 100%",
+  backgroundRepeat: "no-repeat",
+  pb: "2px",
   color: "inherit",
   display: "inline",
-  alignItems: "center",
   position: "relative",
-  textDecoration: "none",
 
   "&:focus": {
-    _after: {
-      display: "none",
-    },
-  },
-  "&:focus:not(:focus-visible)": {
-    _after: {
-      display: "block",
-    },
-  },
-  "&:focus-visible": {
-    _after: {
-      display: "none",
-    },
+    outline: "none",
   },
 
   svg: {
     display: "inline-block",
-    width: "1.25em",
-    height: "1.25em",
+    width: "1.125em",
+    height: "1.125em",
+    position: "relative",
+    bottom: "-0.2em",
   },
 };
 


### PR DESCRIPTION
This is a suggestion on how to fix multiline links. It does not look exacly the same. The underline is thinner, but going with 2px gets to thick. So feel free to propose how to change it.

Tested with the following code:
```
<Box width="150px">
  <Link
    children="Her er en lenke med litt lengre tekst"
    href="https://w/komponenter/lenker"
    variant="primary"
    fontSize="16px"
  />
</Box>
```

Before:
![image](https://user-images.githubusercontent.com/2163425/157437877-459912e4-bc66-49a0-95dd-33306839f00c.png)

After this fix:
![image](https://user-images.githubusercontent.com/2163425/157437679-346fe346-c914-4610-bd3f-5255e223f536.png)
