### PR TITLE
Add react native design tokens support

### DIFF
--- a/.changeset/hip-hornets-roll.md
+++ b/.changeset/hip-hornets-roll.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-design-tokens": patch
+---
+
+Add support for React Native tokens

--- a/packages/spor-design-tokens/.gitignore
+++ b/packages/spor-design-tokens/.gitignore
@@ -1,5 +1,6 @@
 # Built tokens
 elmsrc/Vy/Design/Tokens.elm
+react-native
 
 # Dependencies
 elm-stuff

--- a/packages/spor-design-tokens/config.json
+++ b/packages/spor-design-tokens/config.json
@@ -1,6 +1,19 @@
 {
   "source": ["tokens/**/*.json"],
   "platforms": {
+    "rn": {
+      "transforms": ["name/cti/camel", "size/object", "color/css"],
+      "files": [
+        {
+          "format": "javascript/module",
+          "destination": "react-native/index.js"
+        },
+        {
+          "format": "typescript/typings",
+          "destination": "react-native/tokens.d.ts"
+        }
+      ]
+    },
     "javascript": {
       "transforms": [
         "attribute/cti",

--- a/packages/spor-design-tokens/config.json
+++ b/packages/spor-design-tokens/config.json
@@ -9,8 +9,8 @@
           "destination": "react-native/index.js"
         },
         {
-          "format": "typescript/typings",
-          "destination": "react-native/tokens.d.ts"
+          "format": "typescript/rn-typings",
+          "destination": "react-native/index.d.ts"
         }
       ]
     },

--- a/packages/spor-design-tokens/package.json
+++ b/packages/spor-design-tokens/package.json
@@ -14,7 +14,8 @@
   },
   "files": [
     "dist",
-    "assets"
+    "assets",
+    "react-native"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/packages/spor-design-tokens/scripts/build.ts
+++ b/packages/spor-design-tokens/scripts/build.ts
@@ -1,6 +1,7 @@
 import StyleDictionaryFactory from "style-dictionary";
 import { elmFormatter } from "./formatters/elm/module";
 import { typescriptTypingsFormatter } from "./formatters/typescript/typings";
+import { reactNativeTypescriptTypingsFormatter } from "./formatters/typescript/rn-typings";
 import { pxTransformer } from "./transforms/size/px";
 import { pxToRemTransformer } from "./transforms/size/pxToRem";
 
@@ -9,6 +10,7 @@ const styleDictionary = StyleDictionaryFactory.extend("config.json");
 // Register formatters
 // Read about formatters @ https://amzn.github.io/style-dictionary/#/formats
 styleDictionary.registerFormat(typescriptTypingsFormatter);
+styleDictionary.registerFormat(reactNativeTypescriptTypingsFormatter);
 styleDictionary.registerFormat(elmFormatter);
 
 // Register transforms

--- a/packages/spor-design-tokens/scripts/formatters/typescript/rn-typings.ts
+++ b/packages/spor-design-tokens/scripts/formatters/typescript/rn-typings.ts
@@ -1,0 +1,16 @@
+import JsonToTS from "json-to-ts";
+import { Format } from "style-dictionary";
+import { Named } from "style-dictionary/types/_helpers";
+
+/** Creates much more correct typescript typings than regular TS formatter */
+export const reactNativeTypescriptTypingsFormatter: Named<Format> = {
+  name: "typescript/rn-typings",
+  formatter: ({ dictionary }) => {
+    return (
+      'declare module "@vygruppen/spor-design-tokens/react-native";\n' +
+      "declare const root: RootObject\n" +
+      "export default root\n" +
+      JsonToTS(dictionary.properties).join("\n")
+    );
+  },
+};


### PR DESCRIPTION
To use tokens in React Native, use `import * as tokens from "@vygruppen/design-tokens/react-native";`
