### PR TITLE
Close the mobile menu when you click something

### DIFF
--- a/apps/docs/app/features/layouts/docs-layout/left-sidebar/LeftSidebar.tsx
+++ b/apps/docs/app/features/layouts/docs-layout/left-sidebar/LeftSidebar.tsx
@@ -5,7 +5,7 @@ import { SearchableContentMenu } from "~/features/content-menu/SearchableContent
 export const LeftSidebar = () => {
   return (
     <Box
-      display={["none", "none", "block"]}
+      display={["none", "block"]}
       as="nav"
       aria-label="content"
       flex="1"

--- a/apps/docs/app/features/site-header/SiteHeader.tsx
+++ b/apps/docs/app/features/site-header/SiteHeader.tsx
@@ -11,7 +11,8 @@ import {
   ModalOverlay,
   VyLogo,
 } from "@vygruppen/spor-react";
-import { Link } from "remix";
+import { useEffect } from "react";
+import { Link, useLocation } from "remix";
 import { SearchableContentMenu } from "../content-menu/SearchableContentMenu";
 import { NavigationLink, SiteNavigation } from "./SiteNavigation";
 import { UserPreferenceSwitcher } from "./UserPreferenceSwitcher";
@@ -66,6 +67,12 @@ const DesktopNavigation = () => {
 
 const MobileNavigation = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const location = useLocation();
+  useEffect(() => {
+    // This doesn't close the menu when you're on the page you're clicking on,
+    // but that's on you!
+    onClose();
+  }, [location.pathname]);
   return (
     <Flex display={["flex", "flex", "none"]}>
       <IconButton


### PR DESCRIPTION
This PR fixes a bug where the mobile navigation didn't close when you clicked a link
