### PR TITLE
fix focus traps

### DIFF
--- a/apps/docs/app/features/code-block/CodeBlock.tsx
+++ b/apps/docs/app/features/code-block/CodeBlock.tsx
@@ -48,9 +48,7 @@ export const CodeBlockContainer = ({
   ...props
 }: CodeBlockContainerProps) => {
   const copyButtonRef = useRef<HTMLButtonElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
   const handleKeyUp = (e: React.KeyboardEvent) => {
-    console.log(e.key, e.shiftKey);
     if (e.key === "Escape") {
       if (e.shiftKey) {
         const previousElement = getPreviousFocusableElement();
@@ -74,7 +72,6 @@ export const CodeBlockContainer = ({
       maxWidth="calc(100vw - var(--spor-space-4))"
       __css={{ "pre > div": { whiteSpace: "initial", maxWidth: "100%" } }}
       onKeyUp={handleKeyUp}
-      ref={containerRef}
       {...props}
     >
       <Box width="100%" overflowX="hidden">

--- a/apps/docs/app/features/code-block/CodeBlock.tsx
+++ b/apps/docs/app/features/code-block/CodeBlock.tsx
@@ -1,6 +1,7 @@
-import { DarkMode, useClipboard } from "@chakra-ui/react";
+import { DarkMode, forwardRef, useClipboard } from "@chakra-ui/react";
 import { Box, BoxProps, Button } from "@vygruppen/spor-react";
 import Highlight, { defaultProps } from "prism-react-renderer";
+import { useRef } from "react";
 import { theme } from "./codeTheme";
 
 type CodeBlockProps = Omit<BoxProps, "children"> & {
@@ -46,6 +47,19 @@ export const CodeBlockContainer = ({
   code,
   ...props
 }: CodeBlockContainerProps) => {
+  const copyButtonRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const handleKeyUp = (e: React.KeyboardEvent) => {
+    console.log(e.key, e.shiftKey);
+    if (e.key === "Escape") {
+      if (e.shiftKey) {
+        const previousElement = getPreviousFocusableElement();
+        previousElement.focus();
+      } else {
+        copyButtonRef.current?.focus();
+      }
+    }
+  };
   return (
     <Box
       borderRadius="sm"
@@ -59,32 +73,51 @@ export const CodeBlockContainer = ({
       zIndex="0"
       maxWidth="calc(100vw - var(--spor-space-4))"
       __css={{ "pre > div": { whiteSpace: "initial", maxWidth: "100%" } }}
+      onKeyUp={handleKeyUp}
+      ref={containerRef}
       {...props}
     >
       <Box width="100%" overflowX="hidden">
         {children}
       </Box>
-      <CopyCodeButton code={code} />
+      <CopyCodeButton ref={copyButtonRef} code={code} />
     </Box>
   );
 };
 
-type CopyCodeButtonProps = { code: string };
-export const CopyCodeButton = ({ code }: CopyCodeButtonProps) => {
-  const { onCopy, hasCopied } = useClipboard(code);
-  return (
-    <DarkMode>
-      <Button
-        variant="additional"
-        size="xs"
-        onClick={onCopy}
-        position="absolute"
-        top={2}
-        right={2}
-        fontFamily="body"
-      >
-        {hasCopied ? "Kopiert" : "Kopiér"}
-      </Button>
-    </DarkMode>
+function getPreviousFocusableElement() {
+  const allTabbableElements = Array.from(
+    document.querySelectorAll(
+      'a, button, input, select, textarea, [contenteditable], [tabindex]:not([tabindex^="-"])'
+    )
   );
-};
+
+  const currentlyFocusedElementIndex = allTabbableElements.findIndex(
+    (el) => el === document.activeElement
+  );
+
+  return allTabbableElements[currentlyFocusedElementIndex - 1] as HTMLElement;
+}
+
+type CopyCodeButtonProps = { code: string };
+export const CopyCodeButton = forwardRef<CopyCodeButtonProps, "button">(
+  ({ code }, ref) => {
+    const { onCopy, hasCopied } = useClipboard(code);
+    return (
+      <DarkMode>
+        <Button
+          variant="additional"
+          size="xs"
+          onClick={onCopy}
+          position="absolute"
+          top={2}
+          right={2}
+          fontFamily="body"
+          ref={ref}
+        >
+          {hasCopied ? "Kopiert" : "Kopiér"}
+        </Button>
+      </DarkMode>
+    );
+  }
+);

--- a/apps/docs/package-lock.json
+++ b/apps/docs/package-lock.json
@@ -2022,9 +2022,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "node_modules/@types/react": {
-      "version": "17.0.42",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.42.tgz",
-      "integrity": "sha512-nuab3x3CpJ7VFeNA+3HTUuEkvClYHXqWtWd7Ud6AZYW7Z3NH9WKtgU+tFB0ZLcHq+niB/HnzLcaZPqMJ95+k5Q==",
+      "version": "17.0.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
+      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3496,9 +3496,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.92",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.92.tgz",
-      "integrity": "sha512-YAVbvQIcDE/IJ/vzDMjD484/hsRbFPW2qXJPaYTfOhtligmfYEYOep+5QojpaEU9kq6bMvNeC2aG7arYvTHYsA==",
+      "version": "1.4.93",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.93.tgz",
+      "integrity": "sha512-ywq9Pc5Gwwpv7NG767CtoU8xF3aAUQJjH9//Wy3MBCg4w5JSLbJUq2L8IsCdzPMjvSgxuue9WcVaTOyyxCL0aQ==",
       "peer": true
     },
     "node_modules/emoji-regex": {
@@ -8951,9 +8951,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11080,9 +11080,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.42",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.42.tgz",
-      "integrity": "sha512-nuab3x3CpJ7VFeNA+3HTUuEkvClYHXqWtWd7Ud6AZYW7Z3NH9WKtgU+tFB0ZLcHq+niB/HnzLcaZPqMJ95+k5Q==",
+      "version": "17.0.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
+      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -12156,9 +12156,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.4.92",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.92.tgz",
-      "integrity": "sha512-YAVbvQIcDE/IJ/vzDMjD484/hsRbFPW2qXJPaYTfOhtligmfYEYOep+5QojpaEU9kq6bMvNeC2aG7arYvTHYsA==",
+      "version": "1.4.93",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.93.tgz",
+      "integrity": "sha512-ywq9Pc5Gwwpv7NG767CtoU8xF3aAUQJjH9//Wy3MBCg4w5JSLbJUq2L8IsCdzPMjvSgxuue9WcVaTOyyxCL0aQ==",
       "peer": true
     },
     "emoji-regex": {
@@ -16134,9 +16134,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27221,7 +27221,8 @@
       "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "@vygruppen/spor-i18n-react": "*"
+        "@vygruppen/spor-i18n-react": "*",
+        "@vygruppen/spor-icon-react": "*"
       },
       "devDependencies": {
         "@chakra-ui/react": "^1.7.3",
@@ -31930,6 +31931,7 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@vygruppen/spor-i18n-react": "*",
+        "@vygruppen/spor-icon-react": "*",
         "framer-motion": "^6.0.0",
         "react": ">17.0.0",
         "react-dom": ">17.0.0",


### PR DESCRIPTION
This pull request fixes a focus trap on our component pages. React Live doesn't give us a way to override its default tab behavior, so we roll our own instead.

To get out of an editor, use the escape (or shift-escape) keys.

- Fix a focus trap by adding escape and shift-escape support
- Update package-lock files
