### PR TITLE
Add shortcut for focusing the search box

### DIFF
--- a/apps/docs/app/features/content-menu/SearchInput.tsx
+++ b/apps/docs/app/features/content-menu/SearchInput.tsx
@@ -6,12 +6,38 @@ export type SearchInputProps = {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onKeyUp: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 };
-export const SearchInput = ({ value, onChange, onKeyUp }: SearchInputProps) => (
-  <Input
-    label="Søk"
-    leftIcon={<SearchOutline24Icon />}
-    value={value}
-    onChange={onChange}
-    onKeyUp={onKeyUp}
-  />
-);
+export const SearchInput = ({ value, onChange, onKeyUp }: SearchInputProps) => {
+  const inputRef = useSearchHotkey();
+  return (
+    <Input
+      ref={inputRef}
+      label="Søk"
+      leftIcon={<SearchOutline24Icon />}
+      value={value}
+      onChange={onChange}
+      onKeyUp={onKeyUp}
+    />
+  );
+};
+
+const useSearchHotkey = () => {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const previousFocusRef = React.useRef<any>(null);
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const isInputFocused = document.activeElement === inputRef.current;
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        if (!isInputFocused) {
+          previousFocusRef.current = document.activeElement;
+        }
+        e.preventDefault();
+        inputRef.current?.focus();
+      } else if (isInputFocused && e.key === "Escape") {
+        previousFocusRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+  return inputRef;
+};


### PR DESCRIPTION
This pull request adds support for typing cmd+k or ctrl+k to focus the search box.

When you're in the search box, and you have focused something previously, you can press escape to return focus
