### PR TITLE
Only show the clear search button if there is an onReset callback

### DIFF
--- a/.changeset/spicy-llamas-drum.md
+++ b/.changeset/spicy-llamas-drum.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-input-react": patch
+---
+
+Make the clear search button optional

--- a/packages/spor-input-react/src/SearchInput.tsx
+++ b/packages/spor-input-react/src/SearchInput.tsx
@@ -19,7 +19,7 @@ export type SearchInputProps = Exclude<
   /** Optional label. Defaults to the localized version of "search" */
   label?: string;
   /** Callback for when the clear button is clicked */
-  onReset: () => void;
+  onReset?: () => void;
 };
 /** Simple search input component.
  *
@@ -28,6 +28,7 @@ export type SearchInputProps = Exclude<
 export const SearchInput = forwardRef<SearchInputProps, "input">(
   ({ label, onReset, ...props }, ref) => {
     const { t } = useTranslation();
+    const showCloseButton = onReset && Boolean(props.value);
     return (
       <InputGroup position="relative">
         <InputLeftElement>
@@ -37,13 +38,19 @@ export const SearchInput = forwardRef<SearchInputProps, "input">(
           pl={7}
           pr={7}
           {...props}
+          type="search"
+          css={{
+            "&::-webkit-search-cancel-button": {
+              WebkitAppearance: "none",
+            },
+          }}
           ref={ref}
           placeholder=" " // This is needed to make the label work as expected
         />
         <FormLabel htmlFor={props.id} pointerEvents="none">
           {label ?? t(texts.label)}
         </FormLabel>
-        {Boolean(props.value) && (
+        {showCloseButton && (
           <InputRightElement width="fit-content">
             <IconButton
               variant="ghost"


### PR DESCRIPTION
This pull request alters the search input slightly, by making the onReset callback optional. If the onReset callback isn't provided, you won't see a clear search button either.

Also, this pull request sets the input field type to "search", which makes it easier to use on mobile devices, for instance.