### PR TITLE
Add default element of elevated cards

### DIFF
--- a/.changeset/swift-forks-design.md
+++ b/.changeset/swift-forks-design.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-theme-react": patch
+"@vygruppen/spor-card-react": patch
+---
+
+Add a background color for elevated cards

--- a/packages/spor-theme-react/src/components/card.ts
+++ b/packages/spor-theme-react/src/components/card.ts
@@ -36,7 +36,7 @@ type Variant = "elevated" | "filled" | "outlined";
 const variants: Record<Variant, SystemStyleInterpolation> = {
   elevated: {
     backgroundColor: "alias.white",
-    boxShadow: "md",
+    boxShadow: `${shadows.md}, 0 0 0 1px ${colors.alias.silver}`,
 
     "button&, a&": {
       _hover: {


### PR DESCRIPTION
Liten endring på default state av Elevated cards, den skal være synlig på alle bakgrunner:
Color: white- #FFFFFF
Stroke: silver, 1px
Effects: Elevation 2