### PR TITLE
Rename Link component to TextLink

### DIFF
--- a/.changeset/clever-bags-raise.md
+++ b/.changeset/clever-bags-raise.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-link-react": patch
+---
+
+Rename Link component to TextLink, deprecate Link

--- a/packages/spor-link-react/src/TextLink.tsx
+++ b/packages/spor-link-react/src/TextLink.tsx
@@ -12,7 +12,7 @@ type LinkProps = Omit<ChakraLinkProps, "variant"> & {
  *
  * You can specify the `variant` prop to get different link designs. `tertiary` should only be used on dark backgrounds.
  */
-export const Link = ({ children, ...props }: LinkProps) => {
+export const TextLink = ({ children, ...props }: LinkProps) => {
   const isExternal =
     props.isExternal !== undefined
       ? props.isExternal
@@ -24,3 +24,9 @@ export const Link = ({ children, ...props }: LinkProps) => {
     </ChakraLink>
   );
 };
+
+/** Link to different sites or parts of sites.
+ *
+ * @deprecated Use `TextLink` instead. Will be removed in v1.0.0
+ */
+export const Link = TextLink;

--- a/packages/spor-link-react/src/index.tsx
+++ b/packages/spor-link-react/src/index.tsx
@@ -1,1 +1,1 @@
-export * from "./Link";
+export * from "./TextLink";


### PR DESCRIPTION
This PR will rename the Link component in favor of TextLink. This makes it a bit easier to use with React Router's Link or Next's Link.
