### PR TITLE
Add icon prop to badge

### DIFF
--- a/.changeset/witty-cooks-sip.md
+++ b/.changeset/witty-cooks-sip.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-typography-react": minor
+---
+
+Add icon prop to the Badge component

--- a/packages/spor-typography-react/src/Badge.tsx
+++ b/packages/spor-typography-react/src/Badge.tsx
@@ -28,6 +28,11 @@ export type BadgeProps = Omit<ChakraBadgeProps, "variant" | "colorScheme"> & {
    * Can be specified as `md` to render a larger badge.
    */
   size?: "sm" | "md";
+  /** Optional badge icon. Will be rendered to the left of the text.
+   *
+   * Make sure you pass in the 18px version of the icon.
+   */
+  icon?: React.ReactElement;
 };
 /**
  * Shows some additional information about the component it's used within.
@@ -45,14 +50,19 @@ export type BadgeProps = Omit<ChakraBadgeProps, "variant" | "colorScheme"> & {
  * <Badge colorScheme="red" size="md" variant="outline">Special</Badge>
  * ```
  *
- * If you want an icon, just pass it as a child:
+ * If you want an icon, pass it in through the `icon` prop:
  *
  * ```tsx
- * <Badge colorScheme="blue">
- *   <InformationOutline24Icon /> Information
+ * <Badge colorScheme="blue" icon={<InformationOutline18Icon />}>
+ *   Information
  * </Badge>
- * ```
+ * ```
  */
-export const Badge = forwardRef<BadgeProps, As<any>>((props, ref) => (
-  <ChakraBadge {...props} ref={ref} />
-));
+export const Badge = forwardRef<BadgeProps, As<any>>(
+  ({ icon, children, ...props }, ref) => (
+    <ChakraBadge {...props} ref={ref}>
+      {icon && React.cloneElement(icon, { mr: 1 })}
+      {children}
+    </ChakraBadge>
+  )
+);


### PR DESCRIPTION
This pull request adds an `icon` prop to the Badge React component.

Previously, if you wanted an icon in your Badge component, you passed it in as children. This worked well, but required the user to specify the spacing between then icon and the text themselves. 

There were no technical guidelines to help you out on placing the icon either. You should always be placing the icon to the left.

Although you technically can misuse the API to misplace icons, it's now much easier to do the right thing by default.