### PR TITLE
Make spor-react include its own batteries

### DIFF
--- a/.changeset/tall-shirts-drum.md
+++ b/.changeset/tall-shirts-drum.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Include all dependencies directly instead of requiring them as peer deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -35079,6 +35079,9 @@
       "version": "0.12.9",
       "license": "MIT",
       "dependencies": {
+        "@chakra-ui/react": "^2.0.2",
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
         "@leile/lobo-t": "^1.0.5",
         "@vygruppen/spor-accordion-react": "*",
         "@vygruppen/spor-button-react": "*",
@@ -35098,7 +35101,8 @@
         "@vygruppen/spor-tab-react": "*",
         "@vygruppen/spor-table-react": "*",
         "@vygruppen/spor-theme-react": "*",
-        "@vygruppen/spor-typography-react": "*"
+        "@vygruppen/spor-typography-react": "*",
+        "framer-motion": "^6.3.3"
       },
       "devDependencies": {
         "@chakra-ui/react": "^2.0.2",
@@ -35110,10 +35114,6 @@
         "tsup": "^5.11.11"
       },
       "peerDependencies": {
-        "@chakra-ui/react": "^2.0.2",
-        "@emotion/react": "^11.7.1",
-        "@emotion/styled": "^11.6.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">= 17.0.0",
         "react-dom": ">= 17.0.0"
       }

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -15,6 +15,9 @@
     "directory": "packages/spor-react"
   },
   "dependencies": {
+    "@chakra-ui/react": "^2.0.2",
+    "@emotion/react": "^11.7.1",
+    "@emotion/styled": "^11.6.0",
     "@leile/lobo-t": "^1.0.5",
     "@vygruppen/spor-accordion-react": "*",
     "@vygruppen/spor-button-react": "*",
@@ -34,7 +37,8 @@
     "@vygruppen/spor-provider-react": "*",
     "@vygruppen/spor-tab-react": "*",
     "@vygruppen/spor-typography-react": "*",
-    "@vygruppen/spor-stepper-react": "*"
+    "@vygruppen/spor-stepper-react": "*",
+    "framer-motion": "^6.3.3"
   },
   "devDependencies": {
     "@chakra-ui/react": "^2.0.2",
@@ -46,10 +50,6 @@
     "tsup": "^5.11.11"
   },
   "peerDependencies": {
-    "@chakra-ui/react": "^2.0.2",
-    "@emotion/react": "^11.7.1",
-    "@emotion/styled": "^11.6.0",
-    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">= 17.0.0",
     "react-dom": ">= 17.0.0"
   }


### PR DESCRIPTION
This pull request makes spor-react include its own dependencies, instead of having them as peer dependencies.