### PR TITLE
Issue 232 Fix choice chips states styling

### DIFF
--- a/.changeset/thick-colts-care.md
+++ b/.changeset/thick-colts-care.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-theme-react": patch
+---
+
+Change the choice chip styling slightly

--- a/packages/spor-theme-react/src/components/choice-chip.ts
+++ b/packages/spor-theme-react/src/components/choice-chip.ts
@@ -19,14 +19,17 @@ const containerStyle: SystemStyleFunction = (props) => ({
   alignItems: "center",
   fontSize: "16px",
   px: 1,
+  _checked: {
+    background: "alias.seaMist",
+    boxShadow: `0 0 0 1px ${colors.alias.celadon}`,
+  },
   _focus: {
     boxShadow: `0 0 0 2px ${colors.alias.greenHaze}`,
   },
   _hover: {
     boxShadow: `0 0 0 2px ${colors.alias.greenHaze}`,
-  },
-  _checked: {
-    background: "alias.seaMist",
+    background: "alias.mint",
+    cursor: "pointer",
   },
 });
 

--- a/packages/spor-theme-react/src/components/choice-chip.ts
+++ b/packages/spor-theme-react/src/components/choice-chip.ts
@@ -23,7 +23,7 @@ const containerStyle: SystemStyleFunction = (props) => ({
     background: "alias.seaMist",
     boxShadow: `0 0 0 1px ${colors.alias.celadon}`,
   },
-  _focus: {
+  "input:focus-visible + &": {
     boxShadow: `0 0 0 2px ${colors.alias.greenHaze}`,
   },
   _hover: {


### PR DESCRIPTION
Ref to issue https://github.com/nsbno/spor/issues/232 for description

### Comment:
It's kinda weird Chakra adds focus-visible to checkbox even though the checkbox is not checked. This results in the 2px focus border still being visible after unselecting..