### PR TITLE
Set the default text color to darkGrey

### DIFF
--- a/.changeset/forty-wolves-happen.md
+++ b/.changeset/forty-wolves-happen.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-provider-react": patch
+---
+
+Set the default text color to darkGrey

--- a/packages/spor-provider-react/src/SporProvider.tsx
+++ b/packages/spor-provider-react/src/SporProvider.tsx
@@ -57,6 +57,9 @@ export const SporProvider = ({
     <LanguageProvider value={language}>
       <ChakraProvider theme={theme} {...props}>
         <Global styles={fontFaces} />
+        <Global
+          styles={`html, body { color: ${theme.colors.alias.darkGrey}; }`}
+        />
         {children}
       </ChakraProvider>
     </LanguageProvider>


### PR DESCRIPTION
This sets the default text color to `darkGrey` across the site.