### PR TITLE
Fix loader overflow

### DIFF
--- a/.changeset/perfect-pandas-poke.md
+++ b/.changeset/perfect-pandas-poke.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-button-react": patch
+---
+
+Fix a bug where the loader animation would go outside of the button on small button sizes

--- a/packages/spor-button-react/src/Button.tsx
+++ b/packages/spor-button-react/src/Button.tsx
@@ -8,7 +8,6 @@ import {
 } from "@chakra-ui/react";
 import { useTranslation } from "@vygruppen/spor-i18n-react";
 import { ColorInlineLoader } from "@vygruppen/spor-loader-react";
-import { Props } from "framer-motion/types/types";
 import React from "react";
 
 export type ButtonProps = Exclude<
@@ -109,7 +108,7 @@ export const Button = forwardRef<ButtonProps, As<any>>(
   }
 );
 
-const sizeToWidthMap: Record<Props["size"], string> = {
+const sizeToWidthMap: Record<string, string> = {
   xs: "4rem",
   sm: "4rem",
   md: "5rem",

--- a/packages/spor-button-react/src/Button.tsx
+++ b/packages/spor-button-react/src/Button.tsx
@@ -8,6 +8,7 @@ import {
 } from "@chakra-ui/react";
 import { useTranslation } from "@vygruppen/spor-i18n-react";
 import { ColorInlineLoader } from "@vygruppen/spor-loader-react";
+import { Props } from "framer-motion/types/types";
 import React from "react";
 
 export type ButtonProps = Exclude<
@@ -95,7 +96,11 @@ export const Button = forwardRef<ButtonProps, As<any>>(
       >
         {isLoading && (
           <Center position="absolute" top="0" right="0" bottom="0" left="0">
-            <ColorInlineLoader maxWidth="6rem" width="100%" mx={2} />
+            <ColorInlineLoader
+              maxWidth={sizeToWidthMap[size] || "4rem"}
+              width="100%"
+              mx={2}
+            />
           </Center>
         )}
         <Box visibility={isLoading ? "hidden" : "visible"}>{children}</Box>
@@ -103,6 +108,13 @@ export const Button = forwardRef<ButtonProps, As<any>>(
     );
   }
 );
+
+const sizeToWidthMap: Record<Props["size"], string> = {
+  xs: "4rem",
+  sm: "4rem",
+  md: "5rem",
+  lg: "6rem",
+};
 
 function useCorrectAriaLabel(props: ButtonProps) {
   const { t } = useTranslation();


### PR DESCRIPTION
Denne PRen "fikser" en bug der loading-indikatoren på små knapper ville overflowe og stikke utenfor selve knappen, om teksten var lang nok.

Det er ikke den beste fiksen jeg har laget - men det fikser problemet i alle fall.