### PR TITLE
La npm run dev starte webstacken

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:rn": "turbo run build --filter=@vygruppen/spor*-react-native",
     "build:web": "turbo run build --filter=@vygruppen/spor*-react",
     "test": "turbo run test --parallel",
-    "dev": "turbo run dev --no-cache --parallel --filter=@vygruppen/*",
+    "dev": "npm run dev:web",
     "dev:web": "turbo run dev --no-cache --parallel --filter=@vygruppen/spor*-react --filter=@vygruppen/docs --filter=@vygruppen/studio",
     "dev:rn": "turbo run dev --no-cache --parallel --filter=@vygruppen/spor*-react-native --filter=@vygruppen/rn-demo",
     "postinstall": "patch-package",


### PR DESCRIPTION
Denne endringen gjør at `npm run dev` kun starter web-stacken (sanity + remix + watching av pakker), istedenfor å dra opp react native også.