### PR TITLE
Fiks en bug i React Native content loaders

### DIFF
--- a/.changeset/modern-phones-hide.md
+++ b/.changeset/modern-phones-hide.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-loader-react-native": patch
+---
+
+Fix some bugs in the content loader

--- a/packages/spor-loader-react-native/package.json
+++ b/packages/spor-loader-react-native/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@vygruppen/spor-layout-react-native": "*",
+    "@vygruppen/spor-typography-react-native": "*",
     "lottie-ios": "3.2.3",
     "lottie-react-native": "^5.1.3",
     "react": ">17.0.0",
@@ -31,6 +32,7 @@
   },
   "peerDependencies": {
     "@vygruppen/spor-layout-react-native": "*",
+    "@vygruppen/spor-typography-react-native": "*",
     "lottie-ios": "3.2.3",
     "lottie-react-native": "^5.1.3",
     "react": ">17.0.0",

--- a/packages/spor-loader-react-native/src/ContentLoader.tsx
+++ b/packages/spor-loader-react-native/src/ContentLoader.tsx
@@ -17,11 +17,17 @@ export type ContentLoaderProps = BoxProps & { children?: React.ReactNode };
 export const ContentLoader = ({ children, ...props }: ContentLoaderProps) => {
   return (
     <Box {...props}>
-      <Box maxWidth={140} width="100%" alignSelf="auto">
+      <Box
+        maxWidth={140}
+        width="100%"
+        height="100%"
+        maxHeight={140}
+        alignSelf="center"
+      >
         <Lottie source={contentLoaderData} loop autoPlay />
       </Box>
       {children && (
-        <Box maxWidth={200} width="100%" alignSelf="auto">
+        <Box maxWidth={200} width="100%" alignSelf="center">
           <Text textAlign="center" fontWeight="bold">
             {children}
           </Text>


### PR DESCRIPTION
Denne endringen fikser et problem med ContentLoader-komponenten i React Native. 

Det manglet noen avhengigheter, og jeg tweaket litt på designet i samme slengen.