### PR TITLE
Fiks React Native ikoner og farger!

### DIFF
--- a/.changeset/five-fireants-ring.md
+++ b/.changeset/five-fireants-ring.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react-native": patch
+---
+
+Add a color prop to all icons

--- a/apps/rn-demo/ios/Podfile.lock
+++ b/apps/rn-demo/ios/Podfile.lock
@@ -351,6 +351,8 @@ PODS:
     - React-jsi (= 0.68.1)
     - React-logger (= 0.68.1)
     - React-perflogger (= 0.68.1)
+  - RNSVG (12.3.0):
+    - React-Core
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -413,6 +415,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - RNSVG (from `../node_modules/react-native-svg`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -498,6 +501,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNSVG:
+    :path: "../node_modules/react-native-svg"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -547,6 +552,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 9e344c840176b0af9c84d5019eb4fed8b3c105a1
   React-runtimeexecutor: 7285b499d0339104b2813a1f58ad1ada4adbd6c0
   ReactCommon: bf2888a826ceedf54b99ad1b6182d1bc4a8a3984
+  RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 17cd9a50243093b547c1e539c749928dd68152da
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/apps/rn-demo/package-lock.json
+++ b/apps/rn-demo/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "spor-rn-demo",
+  "name": "@vygruppen/rn-demo",
   "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "spor-rn-demo",
+      "name": "@vygruppen/rn-demo",
       "version": "0.0.2",
       "dependencies": {
         "@vygruppen/spor-design-tokens": "*",

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -112,7 +112,7 @@ async function generateComponent(iconData: IconData) {
       },
       native: true,
       replaceAttrValues: {
-        "#2B2B2C": "currentColor",
+        '#2B2B2C': `{props.color ?? "#2B2B2C"}`,
       },
     },
     {

--- a/packages/spor-icon/package.json
+++ b/packages/spor-icon/package.json
@@ -15,6 +15,8 @@
     "directory": "packages/spor-icon"
   },
   "scripts": {
+    "clean": "rimraf dist",
+    "prebuild": "npm run clean",
     "build": "mkdir dist && bestzip dist/spor-icons.zip svg/*"
   },
   "devDependencies": {


### PR DESCRIPTION
Dette pull requesten fikser et issues hvor ikoner av en eller annen grunn ble lyseblå. 

Man legger også til støtte for å definere denne fargen selv, via en ny `color`-prop.