### PR TITLE
Legg til støtte for `leftIcon` prop på Expandable og ExpandableIcon komponentene

### DIFF
--- a/.changeset/polite-needles-visit.md
+++ b/.changeset/polite-needles-visit.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react": patch
+---
+
+Add a displayName to all icons in development

--- a/.changeset/serious-ties-work.md
+++ b/.changeset/serious-ties-work.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-accordion-react": minor
+---
+
+Add support for specifying icons on Expandable and ExpandableIcon components

--- a/packages/spor-accordion-react/README.md
+++ b/packages/spor-accordion-react/README.md
@@ -15,55 +15,14 @@ import {
   Accordion,
   AccordionItem,
   AccordionButton,
-  AccordionItem,
+  AccordionIcon,
   AccordionPanel,
   Expandable,
   ExpandableItem,
 } from "@vygruppen/spor-accordion-react";
 ```
 
-You have a few different options when it comes to creating expandable panels.
-
-If you only have a single expandable item, you can use the `Expandable` component:
-
-```tsx
-<Expandable variant="list" size="sm" title="A title">
-  Hello expanded content
-</Expandable>
-```
-
-If you have several related expandable items, you need to use an `Accordion` component, together with the `ExpandableItem` component:
-
-```tsx
-<Accordion variant="outline" size="md">
-  <ExpandableItem title="A longer title!">
-    Hello expanded content
-  </ExpandableItem>
-  <ExpandableItem title="Another title">
-    You're back again, I see
-  </ExpandableItem>
-</Accordion>
-```
-
-Sometimes, however, you need more control. In that case, you can put together your own expandable items with its building blocks - `AccordionItem`, `AccordionButton`, `AccordionIcon` and `AccordionPanel`:
-
-```tsx
-<Accordion variant="list" size="sm">
-  <AccordionItem>
-    <h2>
-      <AccordionButton>
-        Click to read more
-        <AccordionIcon />
-      </AccordionButton>
-    </h2>
-    <AccordionPanel>Here is more info</AccordionPanel>
-  </AccordionItem>
-</Accordion>
-```
-
-There are three different variants available - `list`, `outline` and `card`. These are specified at the `Accordion` or `Expandable` components.
-
-There are also three different sizes available - `sm`, `md` and `lg`.
+Please refer to the documentation page for more information.
 
 ## Development
 

--- a/packages/spor-accordion-react/src/Accordion.tsx
+++ b/packages/spor-accordion-react/src/Accordion.tsx
@@ -3,6 +3,7 @@ import {
   AccordionProps as ChakraAccordionProps,
 } from "@chakra-ui/react";
 import React from "react";
+import { AccordionProvider } from "./AccordionContext";
 export {
   AccordionButton,
   AccordionIcon,
@@ -43,5 +44,9 @@ export type AccordionProps = Omit<ChakraAccordionProps, "variant" | "size"> & {
  * If you only have one expandable item, you can use the `<Expandable />` component instead.
  */
 export const Accordion = (props: AccordionProps) => {
-  return <ChakraAccordion {...props} />;
+  return (
+    <AccordionProvider size={props.size}>
+      <ChakraAccordion {...props} />
+    </AccordionProvider>
+  );
 };

--- a/packages/spor-accordion-react/src/AccordionContext.tsx
+++ b/packages/spor-accordion-react/src/AccordionContext.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { AccordionProps } from "./Accordion";
+
+type AccordionContextType = {
+  size: AccordionProps["size"];
+};
+const AccordionContext = React.createContext<AccordionContextType | null>(null);
+type AccordionProviderProps = {
+  children: React.ReactNode;
+  size: AccordionProps["size"];
+};
+export const AccordionProvider = ({
+  size,
+  ...props
+}: AccordionProviderProps) => {
+  return <AccordionContext.Provider value={{ size }} {...props} />;
+};
+
+export const useAccordionContext = () => {
+  const context = React.useContext(AccordionContext);
+  if (context === null) {
+    throw new Error(
+      "useAccordionContext must be used within AccordionProvider"
+    );
+  }
+  return context;
+};

--- a/packages/spor-accordion-react/src/Expandable.tsx
+++ b/packages/spor-accordion-react/src/Expandable.tsx
@@ -5,6 +5,7 @@ import {
   AccordionItemProps,
   AccordionPanel,
   Box,
+  Flex,
 } from "@chakra-ui/react";
 import React from "react";
 import { Accordion, AccordionProps } from "./Accordion";
@@ -17,6 +18,12 @@ type ExpandableProps = AccordionProps & {
   title: React.ReactNode;
   /** The semantic heading level of the toggle button */
   headingLevel?: HeadingLevel;
+  /**
+   * Icon shown to the left of the title
+   *
+   * Make sure it's the 30px outlined version of the icon
+   */
+  leftIcon?: React.ReactNode;
 };
 /**
  * A standalone expandable component.
@@ -34,11 +41,17 @@ export const Expandable = ({
   children,
   headingLevel,
   title,
+  leftIcon,
   ...rest
 }: ExpandableProps) => {
+  console.log(leftIcon);
   return (
     <Accordion {...rest}>
-      <ExpandableItem headingLevel={headingLevel} title={title}>
+      <ExpandableItem
+        headingLevel={headingLevel}
+        title={title}
+        leftIcon={leftIcon}
+      >
         {children}
       </ExpandableItem>
     </Accordion>
@@ -46,9 +59,18 @@ export const Expandable = ({
 };
 
 export type ExpandableItemProps = AccordionItemProps & {
+  /** The hidden content */
   children: React.ReactNode;
+  /** The title that's shown inside the toggle button */
   title: React.ReactNode;
+  /** The semantic heading level of the toggle button */
   headingLevel?: HeadingLevel;
+  /**
+   * Icon shown to the left of the title
+   *
+   * Make sure it's the 30px outlined version of the icon
+   */
+  leftIcon?: React.ReactNode;
 };
 /**
  * An item in a set of Expandables. Must be wrapped in an `<Accordion>` component.
@@ -70,13 +92,17 @@ export const ExpandableItem = ({
   children,
   title,
   headingLevel = "h3",
+  leftIcon,
   ...rest
 }: ExpandableItemProps) => {
   return (
     <AccordionItem {...rest}>
       <Box as={headingLevel}>
         <AccordionButton>
-          {title}
+          <Flex>
+            {leftIcon && <Box mr={2}>{leftIcon}</Box>}
+            {title}
+          </Flex>
           <AccordionIcon />
         </AccordionButton>
       </Box>

--- a/packages/spor-accordion-react/src/Expandable.tsx
+++ b/packages/spor-accordion-react/src/Expandable.tsx
@@ -21,7 +21,10 @@ type ExpandableProps = AccordionProps & {
   /**
    * Icon shown to the left of the title
    *
-   * Make sure it's the 30px outlined version of the icon
+   * Make sure it's the outlined version of the icon.
+   *
+   * If the size is set to `sm` or `md` the icon should be 24px.
+   * If the size is set to `lg`, the icon should be 30px.
    */
   leftIcon?: React.ReactNode;
 };
@@ -42,11 +45,12 @@ export const Expandable = ({
   headingLevel,
   title,
   leftIcon,
+  size = "md",
   ...rest
 }: ExpandableProps) => {
-  console.log(leftIcon);
+  verifyIconAndSize({ icon: leftIcon, size });
   return (
-    <Accordion {...rest}>
+    <Accordion {...rest} size={size}>
       <ExpandableItem
         headingLevel={headingLevel}
         title={title}
@@ -56,6 +60,46 @@ export const Expandable = ({
       </ExpandableItem>
     </Accordion>
   );
+};
+
+type VerifyIconAndSizeArgs = {
+  icon: any;
+  size: AccordionProps["size"];
+};
+const verifyIconAndSize = ({ icon, size }: VerifyIconAndSizeArgs) => {
+  if (process.env.NODE_ENV !== "production") {
+    const displayName = icon?.type?.render?.displayName;
+    if (!displayName) {
+      return;
+    }
+    if (displayName.includes("Fill")) {
+      console.warn(
+        `You passed a filled icon. This component requires outlined icons. You passed ${displayName}, replace it with ${displayName.replace(
+          "Fill",
+          "Outline"
+        )}.`
+      );
+      return;
+    }
+    if (size === "lg" && !displayName.includes("30Icon")) {
+      console.warn(
+        `The icon you passed was of the wrong size for the ${size} size. You passed ${displayName}, replace it with ${displayName.replace(
+          /(\d{2})Icon/,
+          "30Icon"
+        )}.`
+      );
+      return;
+    }
+    if (["md" || "sm"].includes(size!) && !displayName.includes("24Icon")) {
+      console.warn(
+        `The icon you passed was of the wrong size for the ${size} size. You passed ${displayName}, replace it with ${displayName.replace(
+          /(\d{2})Icon/,
+          "24Icon"
+        )}.`
+      );
+      return;
+    }
+  }
 };
 
 export type ExpandableItemProps = AccordionItemProps & {

--- a/packages/spor-accordion-react/src/Expandable.tsx
+++ b/packages/spor-accordion-react/src/Expandable.tsx
@@ -9,6 +9,7 @@ import {
 } from "@chakra-ui/react";
 import React from "react";
 import { Accordion, AccordionProps } from "./Accordion";
+import { useAccordionContext } from "./AccordionContext";
 
 type HeadingLevel = "h2" | "h3" | "h4" | "h5" | "h6";
 type ExpandableProps = AccordionProps & {
@@ -48,7 +49,6 @@ export const Expandable = ({
   size = "md",
   ...rest
 }: ExpandableProps) => {
-  verifyIconAndSize({ icon: leftIcon, size });
   return (
     <Accordion {...rest} size={size}>
       <ExpandableItem
@@ -60,46 +60,6 @@ export const Expandable = ({
       </ExpandableItem>
     </Accordion>
   );
-};
-
-type VerifyIconAndSizeArgs = {
-  icon: any;
-  size: AccordionProps["size"];
-};
-const verifyIconAndSize = ({ icon, size }: VerifyIconAndSizeArgs) => {
-  if (process.env.NODE_ENV !== "production") {
-    const displayName = icon?.type?.render?.displayName;
-    if (!displayName) {
-      return;
-    }
-    if (displayName.includes("Fill")) {
-      console.warn(
-        `You passed a filled icon. This component requires outlined icons. You passed ${displayName}, replace it with ${displayName.replace(
-          "Fill",
-          "Outline"
-        )}.`
-      );
-      return;
-    }
-    if (size === "lg" && !displayName.includes("30Icon")) {
-      console.warn(
-        `The icon you passed was of the wrong size for the ${size} size. You passed ${displayName}, replace it with ${displayName.replace(
-          /(\d{2})Icon/,
-          "30Icon"
-        )}.`
-      );
-      return;
-    }
-    if (["md" || "sm"].includes(size!) && !displayName.includes("24Icon")) {
-      console.warn(
-        `The icon you passed was of the wrong size for the ${size} size. You passed ${displayName}, replace it with ${displayName.replace(
-          /(\d{2})Icon/,
-          "24Icon"
-        )}.`
-      );
-      return;
-    }
-  }
 };
 
 export type ExpandableItemProps = AccordionItemProps & {
@@ -139,6 +99,8 @@ export const ExpandableItem = ({
   leftIcon,
   ...rest
 }: ExpandableItemProps) => {
+  const { size } = useAccordionContext();
+  warnAboutMismatchingIcon({ icon: leftIcon, size });
   return (
     <AccordionItem {...rest}>
       <Box as={headingLevel}>
@@ -153,4 +115,43 @@ export const ExpandableItem = ({
       <AccordionPanel>{children}</AccordionPanel>
     </AccordionItem>
   );
+};
+
+type WarnAboutMismatchingIcon = {
+  icon: any;
+  size: AccordionProps["size"];
+};
+const warnAboutMismatchingIcon = ({ icon, size }: WarnAboutMismatchingIcon) => {
+  if (process.env.NODE_ENV !== "production") {
+    const displayName = icon?.type?.render?.displayName;
+    if (!displayName) {
+      return;
+    }
+    if (displayName.includes("Fill")) {
+      console.warn(
+        `You passed a filled icon. This component requires outlined icons. You passed ${displayName}, replace it with ${displayName.replace(
+          "Fill",
+          "Outline"
+        )}.`
+      );
+      return;
+    }
+    if (size === "lg" && !displayName.includes("30Icon")) {
+      console.warn(
+        `The icon you passed was of the wrong size for the lg size. You passed ${displayName}, replace it with ${displayName.replace(
+          /(\d{2})Icon/,
+          "30Icon"
+        )}.`
+      );
+      return;
+    }
+    if (["md" || "sm"].includes(size!) && !displayName.includes("24Icon")) {
+      console.warn(
+        `The icon you passed was of the wrong size for the ${size} size. You passed ${displayName}, replace it with ${displayName.replace(
+          /(\d{2})Icon/,
+          "24Icon"
+        )}.`
+      );
+    }
+  }
 };

--- a/packages/spor-icon-react/bin/componentTemplate.ts
+++ b/packages/spor-icon-react/bin/componentTemplate.ts
@@ -42,6 +42,10 @@ ${variables.interfaces};
 const ${variables.componentName} = (${variables.props}) => (
   ${variables.jsx}
 );
+
+if (process.env.NODE_ENV !== "production") {
+  ${variables.componentName}.displayName = "${variables.componentName}";
+}
  
 ${variables.exports};
 `;


### PR DESCRIPTION
Denne endringen gjør det mye lettere å bruke ikoner med Expandable, ved at man kan kunne spesifisere ikonet med den nye `leftIcon` propen!

```tsx
<Expandable
  leftIcon={<InformationOutline30Icon />}
  title="Informasjon"
>
  Her er litt info
</Expandable>
```