### PR TITLE
Fiks bug der width ikke blir lagt til buttons

### DIFF
--- a/.changeset/hot-toys-fix.md
+++ b/.changeset/hot-toys-fix.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-button-react": patch
+---
+
+Add possibility for specifying the width of a button

--- a/packages/spor-button-react/src/Button.tsx
+++ b/packages/spor-button-react/src/Button.tsx
@@ -54,7 +54,6 @@ export type ButtonProps = Exclude<
 export const Button = forwardRef<ButtonProps, As<any>>(
   (
     {
-      width,
       size = "md",
       variant = "primary",
       children,
@@ -70,9 +69,9 @@ export const Button = forwardRef<ButtonProps, As<any>>(
 
     return (
       <ChakraButton
-        {...props}
         size={size}
         variant={variant}
+        {...props}
         ref={ref}
         aria-label={ariaLabel}
         aria-busy={isLoading}


### PR DESCRIPTION
Dette pull requestet fikser en bug der det ikke gikk an å sette en spesifikk bredde på Button-komponenten.
