### PR TITLE
Fikset slik at hover/click fungerer på ikonene i SearchInput

### DIFF
--- a/packages/spor-input-react/src/SearchInput.tsx
+++ b/packages/spor-input-react/src/SearchInput.tsx
@@ -31,7 +31,7 @@ export const SearchInput = forwardRef<SearchInputProps, "input">(
     const showCloseButton = onReset && Boolean(props.value);
     return (
       <InputGroup position="relative">
-        <InputLeftElement>
+        <InputLeftElement pointerEvents="none">
           <SearchOutline24Icon />
         </InputLeftElement>
         <ChakraInput
@@ -51,7 +51,7 @@ export const SearchInput = forwardRef<SearchInputProps, "input">(
           {label ?? t(texts.label)}
         </FormLabel>
         {showCloseButton && (
-          <InputRightElement width="fit-content">
+          <InputRightElement width="fit-content" pointerEvents="none">
             <IconButton
               variant="ghost"
               type="button"


### PR DESCRIPTION
Ikonene ble ikke aktivert ikke når man klikket på eller hoveret over dem. Vi synes at det hadde vært fint om den gjorde det i headeren, og foreslår derfor å fikse det ved å sende med en `pointerEvents="none"` til både InputLeftElement og InputRightElement. 

Vet ikke om alle SearchInputs burde ha dette (vil tro det?), men send meg gjerne en melding hvis ikke slik at vi kan fikse dette lokalt. 


