### PR TITLE
Små tweaks på Button

### DIFF
--- a/packages/spor-button-react-native/src/Button.tsx
+++ b/packages/spor-button-react-native/src/Button.tsx
@@ -112,8 +112,8 @@ export const Button = ({
         {leftIcon && (
           <Box
             style={{
-              marginLeft: children ? -6 : 0,
-              marginRight: children ? 6 : 0,
+              paddingLeft: children ? -6 : 0,
+              paddingRight: children ? 6 : 0,
             }}
           >
             <leftIcon.type {...leftIcon.props} {...{ color }} />
@@ -129,7 +129,12 @@ export const Button = ({
           {children}
         </Text>
         {rightIcon && (
-          <Box marginLeft={1} style={{ marginRight: -6 }}>
+          <Box
+            style={{
+              paddingLeft: children ? 6 : 0,
+              paddingRight: children ? -6 : 0,
+            }}
+          >
             <rightIcon.type {...rightIcon.props} {...{ color }} />
           </Box>
         )}

--- a/packages/spor-button-react-native/src/Button.tsx
+++ b/packages/spor-button-react-native/src/Button.tsx
@@ -110,7 +110,12 @@ export const Button = ({
         }}
       >
         {leftIcon && (
-          <Box marginRight={1} style={{ marginLeft: children ? -6 : 0 }}>
+          <Box
+            style={{
+              marginLeft: children ? -6 : 0,
+              marginRight: children ? 6 : 0,
+            }}
+          >
             <leftIcon.type {...leftIcon.props} {...{ color }} />
           </Box>
         )}

--- a/packages/spor-button-react-native/src/Button.tsx
+++ b/packages/spor-button-react-native/src/Button.tsx
@@ -102,44 +102,38 @@ export const Button = ({
       }}
       {...rest}
     >
-      {variant === "ghost" && leftIcon ? (
-        <Box>
-          <leftIcon.type {...leftIcon.props} {...{ color }} />
-        </Box>
-      ) : (
-        <Box
-          style={{
-            flexDirection: "row",
-            alignItems: "center",
-            opacity: isLoading ? 0 : 1,
-          }}
-        >
-          {leftIcon && (
-            <Box
-              style={{
-                marginLeft: children ? -6 : 0,
-                marginRight: children ? 6 : 0,
-              }}
-            >
-              <leftIcon.type {...leftIcon.props} {...{ color }} />
-            </Box>
-          )}
-          <Text
+      <Box
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          opacity: isLoading ? 0 : 1,
+        }}
+      >
+        {leftIcon && (
+          <Box
             style={{
-              color,
-              fontSize,
-              fontWeight,
+              marginLeft: children ? -6 : 0,
+              marginRight: children ? 6 : 0,
             }}
           >
-            {children}
-          </Text>
-          {rightIcon && (
-            <Box marginLeft={1} style={{ marginRight: -6 }}>
-              <rightIcon.type {...rightIcon.props} {...{ color }} />
-            </Box>
-          )}
-        </Box>
-      )}
+            <leftIcon.type {...leftIcon.props} {...{ color }} />
+          </Box>
+        )}
+        <Text
+          style={{
+            color,
+            fontSize,
+            fontWeight,
+          }}
+        >
+          {children}
+        </Text>
+        {rightIcon && (
+          <Box marginLeft={1} style={{ marginRight: -6 }}>
+            <rightIcon.type {...rightIcon.props} {...{ color }} />
+          </Box>
+        )}
+      </Box>
 
       {isLoading && (
         <Box

--- a/packages/spor-button-react-native/src/Button.tsx
+++ b/packages/spor-button-react-native/src/Button.tsx
@@ -102,38 +102,44 @@ export const Button = ({
       }}
       {...rest}
     >
-      <Box
-        style={{
-          flexDirection: "row",
-          alignItems: "center",
-          opacity: isLoading ? 0 : 1,
-        }}
-      >
-        {leftIcon && (
-          <Box
-            style={{
-              marginLeft: children ? -6 : 0,
-              marginRight: children ? 6 : 0,
-            }}
-          >
-            <leftIcon.type {...leftIcon.props} {...{ color }} />
-          </Box>
-        )}
-        <Text
+      {variant === "ghost" && leftIcon ? (
+        <Box>
+          <leftIcon.type {...leftIcon.props} {...{ color }} />
+        </Box>
+      ) : (
+        <Box
           style={{
-            color,
-            fontSize,
-            fontWeight,
+            flexDirection: "row",
+            alignItems: "center",
+            opacity: isLoading ? 0 : 1,
           }}
         >
-          {children}
-        </Text>
-        {rightIcon && (
-          <Box marginLeft={1} style={{ marginRight: -6 }}>
-            <rightIcon.type {...rightIcon.props} {...{ color }} />
-          </Box>
-        )}
-      </Box>
+          {leftIcon && (
+            <Box
+              style={{
+                marginLeft: children ? -6 : 0,
+                marginRight: children ? 6 : 0,
+              }}
+            >
+              <leftIcon.type {...leftIcon.props} {...{ color }} />
+            </Box>
+          )}
+          <Text
+            style={{
+              color,
+              fontSize,
+              fontWeight,
+            }}
+          >
+            {children}
+          </Text>
+          {rightIcon && (
+            <Box marginLeft={1} style={{ marginRight: -6 }}>
+              <rightIcon.type {...rightIcon.props} {...{ color }} />
+            </Box>
+          )}
+        </Box>
+      )}
 
       {isLoading && (
         <Box

--- a/packages/spor-button-react-native/src/Button.tsx
+++ b/packages/spor-button-react-native/src/Button.tsx
@@ -112,7 +112,6 @@ export const Button = ({
         {leftIcon && (
           <Box
             style={{
-              paddingLeft: children ? -6 : 0,
               paddingRight: children ? 6 : 0,
             }}
           >
@@ -132,7 +131,6 @@ export const Button = ({
           <Box
             style={{
               paddingLeft: children ? 6 : 0,
-              paddingRight: children ? -6 : 0,
             }}
           >
             <rightIcon.type {...rightIcon.props} {...{ color }} />

--- a/packages/spor-button-react-native/src/Button.tsx
+++ b/packages/spor-button-react-native/src/Button.tsx
@@ -110,11 +110,7 @@ export const Button = ({
         }}
       >
         {leftIcon && (
-          <Box
-            style={{
-              paddingRight: children ? 6 : 0,
-            }}
-          >
+          <Box marginRight={children ? 1 : 0}>
             <leftIcon.type {...leftIcon.props} {...{ color }} />
           </Box>
         )}
@@ -128,11 +124,7 @@ export const Button = ({
           {children}
         </Text>
         {rightIcon && (
-          <Box
-            style={{
-              paddingLeft: children ? 6 : 0,
-            }}
-          >
+          <Box marginLeft={children ? 1 : 0}>
             <rightIcon.type {...rightIcon.props} {...{ color }} />
           </Box>
         )}

--- a/packages/spor-theme-react-native/src/components/button.tsx
+++ b/packages/spor-theme-react-native/src/components/button.tsx
@@ -38,14 +38,6 @@ export const buttonVariants = {
     color: "darkGrey",
     fontWeight: "normal",
     px: 0,
-    // wrapt around content
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 0,
-    margin: 0,
-    borderWidth: 0,
-    borderRadius: 0,
   },
 };
 

--- a/packages/spor-theme-react-native/src/components/button.tsx
+++ b/packages/spor-theme-react-native/src/components/button.tsx
@@ -37,6 +37,15 @@ export const buttonVariants = {
     backgroundColor: "transparent",
     color: "darkGrey",
     fontWeight: "normal",
+    px: 0,
+    // wrapt around content
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 0,
+    margin: 0,
+    borderWidth: 0,
+    borderRadius: 0,
   },
 };
 


### PR DESCRIPTION
**Endre paddingen i knappen slik at innholdet blir midtstilt i alle tilfeller**
1. leftIcon + tekst
2. leftIcon uten tekst
3. rightIcon + tekst
4. rightIcon uten tekst.

**ghost buttons har ikke lenger formen til en knapp med margin, og wrapper nå tett rundt innhold.**

### Endre sentrering
Jeg endret fra margin til padding slik at ikon + tekst er perfekt midtstilt. Legg gjerne inn en kommentar hvis det ikke var ønskelig. 

_Original sentrering_
<img width="328" alt="Screen Shot 2022-07-13 at 08 34 00" src="https://user-images.githubusercontent.com/42439472/178668102-582f85fa-0d85-4249-8ae6-87f8c597d426.png">

_Ny sentrering_
<img width="310" alt="Screen Shot 2022-07-13 at 08 34 34" src="https://user-images.githubusercontent.com/42439472/178668195-423cefb4-0f7a-42e7-b706-54cf9187bf5f.png">
<img width="325" alt="Screen Shot 2022-07-13 at 08 28 49" src="https://user-images.githubusercontent.com/42439472/178668405-af506e2a-05f3-4713-9e18-84d775ce83b8.png">

