### PR TITLE
Text variant required

### DIFF
--- a/.changeset/olive-buckets-teach.md
+++ b/.changeset/olive-buckets-teach.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-loader-react-native": patch
+"@vygruppen/spor-theme-react-native": patch
+---
+
+Updated loader with a textVariant, and varianttheme with a default textcolor

--- a/apps/rn-demo/app/App.tsx
+++ b/apps/rn-demo/app/App.tsx
@@ -3,7 +3,6 @@ import {
   SporProvider,
   Stack,
   Text,
-  ContentLoader,
 } from "@vygruppen/spor-react-native";
 import React from "react";
 import { SafeAreaView } from "react-native";
@@ -22,14 +21,13 @@ const App = () => {
           justifyContent="center"
           spacing={3}
         >
-          <Heading variant="2xl" textAlign="center">
+          <Heading color="darkGrey" variant="2xl" textAlign="center">
             Spor Demo app
           </Heading>
-          <Text variant="md" color="darkGrey" textAlign="center">
+          <Text color="darkGrey" variant="md" textAlign="center">
             Velkommen! Denne appen brukes til demonstrasjon og utvikling av
             forskjellige komponenter i Spor sitt designsystem for React Native.
           </Text>
-          <ContentLoader>Leter etter reiseforslag...</ContentLoader>
         </Stack>
       </SafeAreaView>
     </SporProvider>

--- a/apps/rn-demo/app/App.tsx
+++ b/apps/rn-demo/app/App.tsx
@@ -3,6 +3,7 @@ import {
   SporProvider,
   Stack,
   Text,
+  ContentLoader,
 } from "@vygruppen/spor-react-native";
 import React from "react";
 import { SafeAreaView } from "react-native";
@@ -21,13 +22,14 @@ const App = () => {
           justifyContent="center"
           spacing={3}
         >
-          <Heading color="darkGrey" variant="2xl" textAlign="center">
+          <Heading variant="2xl" textAlign="center">
             Spor Demo app
           </Heading>
-          <Text color="darkGrey" variant="md" textAlign="center">
+          <Text variant="md" color="darkGrey" textAlign="center">
             Velkommen! Denne appen brukes til demonstrasjon og utvikling av
             forskjellige komponenter i Spor sitt designsystem for React Native.
           </Text>
+          <ContentLoader>Leter etter reiseforslag...</ContentLoader>
         </Stack>
       </SafeAreaView>
     </SporProvider>

--- a/packages/spor-loader-react-native/src/ContentLoader.tsx
+++ b/packages/spor-loader-react-native/src/ContentLoader.tsx
@@ -28,7 +28,7 @@ export const ContentLoader = ({ children, ...props }: ContentLoaderProps) => {
       </Box>
       {children && (
         <Box maxWidth={200} width="100%" alignSelf="center">
-          <Text textAlign="center" fontWeight="bold">
+          <Text variant="sm" textAlign="center" fontWeight="bold">
             {children}
           </Text>
         </Box>

--- a/packages/spor-theme-react-native/src/components/text.tsx
+++ b/packages/spor-theme-react-native/src/components/text.tsx
@@ -5,12 +5,13 @@ const headingLineHeight = tokens.size["line-height"].heading.value.number;
 const bodyLineHeight = tokens.size["line-height"].body.value.number;
 
 export const textVariants = {
-  defaults: {},
+  defaults: {
+    color: "darkGrey",
+  },
   "2xl": {
     fontFamily: removeQuotes(tokens.font.style.xxl["font-family"].value),
     fontSize: tokens.font.style.xxl["font-size"].mobile.value.number,
     fontWeight: "normal",
-    color: "darkGrey",
     lineHeight:
       tokens.font.style.xxl["font-size"].mobile.value.number *
       headingLineHeight,
@@ -24,7 +25,6 @@ export const textVariants = {
       tokens.font.style["xl-display"]["font-size"].mobile.value.number *
       headingLineHeight,
     fontWeight: "normal",
-    color: "darkGrey",
   },
   "xl-sans": {
     fontFamily: removeQuotes(tokens.font.style["xl-sans"]["font-family"].value),
@@ -32,34 +32,29 @@ export const textVariants = {
     lineHeight:
       tokens.font.style["xl-sans"]["font-size"].mobile.value.number *
       headingLineHeight,
-    color: "darkGrey",
   },
   lg: {
     fontFamily: removeQuotes(tokens.font.style.lg["font-family"].value),
     fontSize: tokens.font.style.lg["font-size"].mobile.value.number,
     lineHeight:
       tokens.font.style.lg["font-size"].mobile.value.number * bodyLineHeight,
-    color: "darkGrey",
   },
   md: {
     fontFamily: removeQuotes(tokens.font.style.md["font-family"].value),
     fontSize: tokens.font.style.md["font-size"].mobile.value.number,
     lineHeight:
       tokens.font.style.md["font-size"].mobile.value.number * bodyLineHeight,
-    color: "darkGrey",
   },
   sm: {
     fontFamily: removeQuotes(tokens.font.style.sm["font-family"].value),
     fontSize: tokens.font.style.sm["font-size"].mobile.value.number,
     lineHeight:
       tokens.font.style.sm["font-size"].mobile.value.number * bodyLineHeight,
-    color: "darkGrey",
   },
   xs: {
     fontFamily: removeQuotes(tokens.font.style.xs["font-family"].value),
     fontSize: tokens.font.style.xs["font-size"].mobile.value.number,
     lineHeight:
       tokens.font.style.xs["font-size"].mobile.value.number * bodyLineHeight,
-    color: "darkGrey",
   },
 };


### PR DESCRIPTION
Oppdatert text sin theme til å ha tekstfarge `darkGrey` som default. La til variant for `<Text>` komponenten til ContentLoader for å få tekststørrelse i samsvar med Figma.

|Før|Etter|
|--|--|
|![Simulator Screen Shot - iPhone 13 - 2022-07-13 at 10 18 21](https://user-images.githubusercontent.com/100707649/178691880-06e4cd4d-509e-46a8-8b44-4b6f293b859a.png)|![Simulator Screen Shot - iPhone 13 - 2022-07-13 at 10 18 54](https://user-images.githubusercontent.com/100707649/178691958-d2fcd890-ccdd-4b44-be90-e32be0f21d61.png)|