### PR TITLE
endre style for expandable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32535,7 +32535,7 @@
     },
     "packages/spor-accordion-react-native": {
       "name": "@vygruppen/spor-accordion-react-native",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-icon-react-native": "*",
@@ -33919,7 +33919,7 @@
     },
     "packages/spor-badge-react-native": {
       "name": "@vygruppen/spor-badge-react-native",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-icon-react-native": "*",
@@ -35329,7 +35329,7 @@
     },
     "packages/spor-button-react-native": {
       "name": "@vygruppen/spor-button-react-native",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-design-tokens": "*",
@@ -35376,7 +35376,7 @@
     },
     "packages/spor-card-react-native": {
       "name": "@vygruppen/spor-card-react-native",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-layout-react-native": "*",
@@ -38415,7 +38415,7 @@
     },
     "packages/spor-loader-react-native": {
       "name": "@vygruppen/spor-loader-react-native",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-loader": "*"
@@ -39820,9 +39820,10 @@
     },
     "packages/spor-message-box-react-native": {
       "name": "@vygruppen/spor-message-box-react-native",
-      "version": "0.0.1",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
+        "@vygruppen/spor-button-react-native": "*",
         "@vygruppen/spor-icon-react-native": "*",
         "@vygruppen/spor-layout-react-native": "*",
         "@vygruppen/spor-theme-react-native": "*",
@@ -41284,7 +41285,7 @@
     },
     "packages/spor-provider-react-native": {
       "name": "@vygruppen/spor-provider-react-native",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
@@ -41349,7 +41350,7 @@
     },
     "packages/spor-react-native": {
       "name": "@vygruppen/spor-react-native",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@shopify/restyle": "^2.1.0",
@@ -41467,7 +41468,7 @@
     },
     "packages/spor-theme-react-native": {
       "name": "@vygruppen/spor-theme-react-native",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-design-tokens": "*"
@@ -53150,6 +53151,7 @@
       "version": "file:packages/spor-message-box-react-native",
       "requires": {
         "@shopify/restyle": "^2.1.0",
+        "@vygruppen/spor-button-react-native": "*",
         "@vygruppen/spor-icon-react-native": "*",
         "@vygruppen/spor-layout-react-native": "*",
         "@vygruppen/spor-theme-react-native": "*",

--- a/packages/spor-accordion-react-native/src/Expandable.tsx
+++ b/packages/spor-accordion-react-native/src/Expandable.tsx
@@ -71,7 +71,7 @@ export const Expandable = ({
   }
 
   return (
-    <Box style={style as any} m={2}>
+    <Box style={style as any}>
       <Pressable
         style={isPressed ? pressedStyle : { padding: 12 }}
         onPress={handlePress}
@@ -79,10 +79,12 @@ export const Expandable = ({
         onPressOut={() => setPressed(false)}
       >
         <Box flexDirection="row" justifyContent="space-between">
-          {leftIcon}
-          <Text variant={size} fontWeight="bold">
-            {title}
-          </Text>
+          <Box flexDirection="row" >
+            {leftIcon}
+            <Text variant={size} fontWeight="bold" ml="sm">
+              {title}
+            </Text>
+          </Box>
           {getDropdownIcon(isExpanded, size as string)}
         </Box>
       </Pressable>


### PR DESCRIPTION
## Bakgrunn 

Skulle implementere Expandable i salgsappen och så da at jeg fikk for mye margin 

## Løsning 

Fjerner margin 
Legger til en Box rundt Ikon og titel slik at texten ikke havner i midten av Expandable komponenten når det finns et ikon. 
 

## Bilde 
![Simulator Screen Shot - iPhone 12 - 2022-07-14 at 14 08 50](https://user-images.githubusercontent.com/24417944/178979050-65a13987-3d58-42e2-aa32-211b7a1b5c2c.png)

