### PR TITLE
revert endring av filpath for type i react-native-package.json

### DIFF
--- a/.changeset/many-mugs-repeat.md
+++ b/.changeset/many-mugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react-native": patch
+---
+
+revert en endring for å fikse lintfeil som dukker opp i salgsappen ved importering av spor komponenter

--- a/packages/spor-react-native/package.json
+++ b/packages/spor-react-native/package.json
@@ -2,7 +2,7 @@
   "name": "@vygruppen/spor-react-native",
   "version": "0.3.4",
   "main": "./dist/index.js",
-  "types": "./dist/types.d.ts",
+  "types": "./dist/index.d.ts",
   "license": "MIT",
   "files": [
     "dist"


### PR DESCRIPTION
## Bakgrunn 
Lintingen feiler ved bruk av nyere version av spor enn 0.3.1. Denne endringen ble innført mellom 0.3.1 og 0.3.2 tester derfor å reverte denne slik at nyere version av spor kan tas i bruk. 


## Løsning 
- Endre tilbake til index