### PR TITLE
Fikse bug med card i scroll-view

### DIFF
--- a/.changeset/tender-dragons-grin.md
+++ b/.changeset/tender-dragons-grin.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-card-react-native": patch
+---
+
+Card onPress now works correctly while in a scroll-view

--- a/packages/spor-card-react-native/src/Card.tsx
+++ b/packages/spor-card-react-native/src/Card.tsx
@@ -150,11 +150,14 @@ export const Card = ({
     };
     const handlePressOut = () => {
       setPressed(false);
-      onPress();
     };
 
     return (
-      <Pressable onPressIn={handlePressIn} onPressOut={handlePressOut}>
+      <Pressable
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        onPress={onPress}
+      >
         <Box
           style={style as any}
           flexDirection="row"


### PR DESCRIPTION
Jeg har flyttet kallet på `card` sin `onPress` funksjon fra `onPressOut` til `OnPress`

Dette fikset bugen som gjorde at man utførte `onPress` når man egentlig bare ønsket å scrolle 