### PR TITLE
Multiline accordion item titles

### DIFF
--- a/.changeset/gold-moose-bathe.md
+++ b/.changeset/gold-moose-bathe.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-accordion-react": patch
+---
+
+Fix a bug where multiple line accordion items was center aligned

--- a/.changeset/gold-moose-bathe.md
+++ b/.changeset/gold-moose-bathe.md
@@ -1,5 +1,6 @@
 ---
 "@vygruppen/spor-accordion-react": patch
+"@vygruppen/spor-theme-react": patch
 ---
 
-Fix a bug where multiple line accordion items was center aligned
+Fix a bug where multiple line accordion items was center aligned and lost padding

--- a/packages/spor-accordion-react/src/Expandable.tsx
+++ b/packages/spor-accordion-react/src/Expandable.tsx
@@ -104,7 +104,7 @@ export const ExpandableItem = ({
   return (
     <AccordionItem {...rest}>
       <Box as={headingLevel}>
-        <AccordionButton textAlign="left">
+        <AccordionButton>
           <Flex alignItems="center">
             {leftIcon && <Box mr={2}>{leftIcon}</Box>}
             {title}

--- a/packages/spor-accordion-react/src/Expandable.tsx
+++ b/packages/spor-accordion-react/src/Expandable.tsx
@@ -104,7 +104,7 @@ export const ExpandableItem = ({
   return (
     <AccordionItem {...rest}>
       <Box as={headingLevel}>
-        <AccordionButton>
+        <AccordionButton textAlign="left">
           <Flex alignItems="center">
             {leftIcon && <Box mr={2}>{leftIcon}</Box>}
             {title}

--- a/packages/spor-theme-react/src/components/accordion.ts
+++ b/packages/spor-theme-react/src/components/accordion.ts
@@ -20,6 +20,7 @@ const baseStyleButton: SystemStyleFunction = ({ theme }) => ({
   display: "flex",
   justifyContent: "space-between",
   color: "alias.darkGrey",
+  textAlign: "left",
   _focus: {
     boxShadow: `inset 0 0 0 2px ${theme.colors.alias.greenHaze}`,
   },
@@ -108,7 +109,6 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   sm: {
     button: {
       fontSize: "desktop.xs",
-      minHeight: "36px",
       px: 2,
       py: 1,
     },
@@ -119,7 +119,6 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   md: {
     button: {
       fontSize: "desktop.sm",
-      minHeight: "42px",
       px: 3,
       py: 1,
     },
@@ -130,7 +129,6 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   lg: {
     button: {
       fontSize: "desktop.sm",
-      minHeight: "54px",
       px: 3,
       py: 2,
     },

--- a/packages/spor-theme-react/src/components/accordion.ts
+++ b/packages/spor-theme-react/src/components/accordion.ts
@@ -110,6 +110,7 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
       fontSize: "desktop.xs",
       minHeight: "36px",
       px: 2,
+      py: 1,
     },
     panel: {
       px: 2,
@@ -120,6 +121,7 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
       fontSize: "desktop.sm",
       minHeight: "42px",
       px: 3,
+      py: 1,
     },
     panel: {
       px: 3,
@@ -130,6 +132,7 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
       fontSize: "desktop.sm",
       minHeight: "54px",
       px: 3,
+      py: 2,
     },
     panel: {
       px: 3,


### PR DESCRIPTION
Denne PRen fikser et problem med accordion item titles som går over flere linjer. 

Fixes #331
