### PR TITLE
Fiks allowMultiple bug for accordion

### DIFF
--- a/.changeset/rare-bulldogs-march.md
+++ b/.changeset/rare-bulldogs-march.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-accordion-react": patch
+---
+
+Fix a bug where allowMultiple doesn't play along with defaultIndex

--- a/packages/spor-accordion-react/src/Accordion.tsx
+++ b/packages/spor-accordion-react/src/Accordion.tsx
@@ -44,9 +44,16 @@ export type AccordionProps = Omit<ChakraAccordionProps, "variant" | "size"> & {
  * If you only have one expandable item, you can use the `<Expandable />` component instead.
  */
 export const Accordion = (props: AccordionProps) => {
+  const defaultIndex =
+    typeof props.defaultIndex === "number" && props.allowMultiple
+      ? [props.defaultIndex]
+      : props.defaultIndex;
   return (
     <AccordionProvider size={props.size}>
-      <ChakraAccordion {...props} />
+      <ChakraAccordion
+        {...props}
+        defaultIndex={defaultIndex as number[] | undefined}
+      />
     </AccordionProvider>
   );
 };


### PR DESCRIPTION
Denne endringen fikser en bug (i Chakra tror jeg) der allowMultiple ikke fungerer når man har spesifisert en defaultIndex.

Fixes #346 
