### PR TITLE
💄Endre farge på onPress border for Card komponenten

### DIFF
--- a/.changeset/shy-swans-allow.md
+++ b/.changeset/shy-swans-allow.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-theme-react-native": patch
+---
+
+endre farge på onPress border for Card komponenten

--- a/packages/spor-theme-react-native/src/components/card.tsx
+++ b/packages/spor-theme-react-native/src/components/card.tsx
@@ -75,7 +75,7 @@ export const cardOnPressColorSchemes = {
   defaults: {},
   white: {
     backgroundColor: "green.50",
-    borderColor: "green.200",
+    borderColor: "coralGreen",
   },
   grey: {
     backgroundColor: "green.50",

--- a/packages/spor-theme-react-native/src/components/card.tsx
+++ b/packages/spor-theme-react-native/src/components/card.tsx
@@ -75,7 +75,7 @@ export const cardOnPressColorSchemes = {
   defaults: {},
   white: {
     backgroundColor: "green.50",
-    borderColor: "blackAlpha.200",
+    borderColor: "green.200",
   },
   grey: {
     backgroundColor: "green.50",


### PR DESCRIPTION
## Bakgrunn 
I følge typografi, stiler og effekter i Figma skal border rundt card komponenten ha coral Green farge. 
![Screen Shot 2022-08-03 at 4 33 38 PM](https://user-images.githubusercontent.com/24417944/182635969-5a1f2f51-02b1-4936-8caf-2c705e7a0c96.png)

## Løsning 
Endrer farger på border for Card komponenten 
## Video 

Starten av videoen viser den nye fargen, senere i videon vises den gamle fargen. 
https://user-images.githubusercontent.com/24417944/182635492-02fd68a0-9d1a-4e0b-9f9a-d6f8d999fee6.mp4


