### PR TITLE
Fjern `display: block;` fra alle SVGer

### DIFF
--- a/.changeset/fair-icons-exist.md
+++ b/.changeset/fair-icons-exist.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-icon-react": patch
+"@vygruppen/spor-provider-react": patch
+---
+
+Fix an issue where all svg images were made to display: block

--- a/packages/spor-icon-react/bin/generate.ts
+++ b/packages/spor-icon-react/bin/generate.ts
@@ -121,7 +121,9 @@ async function generateComponent(iconData: IconData) {
       componentName: iconData.componentName,
     }
   );
-  jsCode = jsCode.replace("<svg", '<Box as="svg"').replace("</svg>", "</Box>");
+  jsCode = jsCode
+    .replace("<svg", '<Box as="svg" display="block"')
+    .replace("</svg>", "</Box>");
   return createComponentFile(iconData, jsCode);
 }
 

--- a/packages/spor-provider-react/src/SporProvider.tsx
+++ b/packages/spor-provider-react/src/SporProvider.tsx
@@ -58,7 +58,10 @@ export const SporProvider = ({
       <ChakraProvider theme={theme} {...props}>
         <Global styles={fontFaces} />
         <Global
-          styles={`html, body { color: ${theme.colors.alias.darkGrey}; }`}
+          styles={`
+          html, body { color: ${theme.colors.alias.darkGrey}; }
+          svg { display: initial; }
+          `}
         />
         {children}
       </ChakraProvider>


### PR DESCRIPTION
Chakra UI antar at SVGene på hele siden skal være `display: block`, men det stemmer ikke alltid.

Denne endringen setter SVG display tilbake til browser-defaulten. Unntaket er ikoner, som beholder block-standarden sin.

Fixes #357 