### PR TITLE
fjerne config och rn-demo link fra changset som gjør at bygget failer

### DIFF
--- a/.changeset/spicy-crabs-admire.md
+++ b/.changeset/spicy-crabs-admire.md
@@ -1,7 +1,5 @@
 ---
 "@vygruppen/spor-modal-react-native": major
-"@vygruppen/rn-demo": patch
-"@vygruppen/config": patch
 "@vygruppen/spor-button-react-native": patch
 "@vygruppen/spor-react-native": patch
 ---


### PR DESCRIPTION
## Bakgrunn 

Det ble innført et changset "Spicy crabs" hvilket gjør at bygget failer. 

## Løsning 
Fjerner rn-demo link og config fila. 
