### PR TITLE
Rette opp i farge Selected for Card

### DIFF
--- a/.changeset/moody-coins-jump.md
+++ b/.changeset/moody-coins-jump.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-theme-react-native": patch
+---
+
+Change selected color border for Card

--- a/packages/spor-theme-react-native/src/components/card.tsx
+++ b/packages/spor-theme-react-native/src/components/card.tsx
@@ -106,7 +106,7 @@ export const cardSelectedColorSchemes = {
   defaults: {},
   white: {
     backgroundColor: "green.50",
-    borderColor: "silver",
+    borderColor: "green.500",
   },
   grey: {
     backgroundColor: "green.50",


### PR DESCRIPTION
## Bakgrunn 

I følge figma skal selected ha mørkere grøn border, se [Figma typografi](https://www.figma.com/file/mNzRMrE8U96Q7gCmGwt5iC/Farger%2C-typografi%2C-stiler-og-effekter?node-id=2820%3A40941)


## Endring
![Simulator Screen Shot - iPhone 12 - 2022-08-10 at 14 36 28](https://user-images.githubusercontent.com/24417944/183904010-4ca7a052-a43c-4496-9b6a-60e44ac60eea.png)

