### PR TITLE
Button children type

### DIFF
--- a/packages/spor-button-react-native/src/Button.tsx
+++ b/packages/spor-button-react-native/src/Button.tsx
@@ -47,7 +47,7 @@ const restyleFunctions = composeRestyleFunctions<Theme, RestyleProps>([
 type ButtonProps = Exclude<RestyleProps, "variant"> & {
   onPress: () => void;
   variant: ButtonVariant;
-  children?: string;
+  children?: React.ReactNode;
   isDisabled?: boolean;
   isLoading?: boolean;
   accessibilityLabel?: string;

--- a/packages/spor-button-react-native/src/Button.tsx
+++ b/packages/spor-button-react-native/src/Button.tsx
@@ -17,7 +17,7 @@ import {
   Text,
   TextStyle,
 } from "react-native";
-import { Box } from "@vygruppen/spor-layout-react-native";
+import { BoxProps, Box } from "@vygruppen/spor-layout-react-native";
 
 const variants = createVariant({
   themeKey: "buttonVariants",
@@ -32,7 +32,8 @@ type ButtonVariant =
   | "additional"
   | "ghost";
 
-type RestyleProps = SpacingProps<Theme> &
+type RestyleProps = BoxProps &
+  SpacingProps<Theme> &
   VariantProps<Theme, "buttonVariants", "variant"> &
   VariantProps<Theme, "buttonSizes", "size">;
 
@@ -47,7 +48,7 @@ const restyleFunctions = composeRestyleFunctions<Theme, RestyleProps>([
 type ButtonProps = Exclude<RestyleProps, "variant"> & {
   onPress: () => void;
   variant: ButtonVariant;
-  children?: React.ReactNode;
+  children?: JSX.Element;
   isDisabled?: boolean;
   isLoading?: boolean;
   accessibilityLabel?: string;


### PR DESCRIPTION
## Bakgrunn 

Det er ønske om å ha children i en button komponent som er av andre typer enn typen string. Det er også et ønske om å ha sirkulære knapper.  for eksempel : Mediaspillerknapp og kontrollskjermknapp i appen. 



## Løsning 

-Endrer fra typen string til React.ReactNode
-Legger til BoxProps slik at man kan bruke style. 


### Spørsmål 

Skal vi heller legge til en ny props der sirkulærknapp er definert i variant. 
Det finns også et behov får å legge til icon i midten for mediaspiller. 
