### PR TITLE
Forbedre React Native og Elm støtte på dokumentasjonssiden

### DIFF
--- a/apps/docs/app/features/portable-text/PortableText.tsx
+++ b/apps/docs/app/features/portable-text/PortableText.tsx
@@ -31,6 +31,7 @@ import { urlBuilder } from "~/utils/sanity/utils";
 import { CodeBlock } from "../code-block/CodeBlock";
 import { InteractiveCode } from "../interactive-code/InteractiveCode";
 import { LinkableHeading } from "../linkable-heading/LinkableHeading";
+import { useUserPreferences } from "../user-preferences/UserPreferencesContext";
 
 const components: Partial<PortableTextReactComponents> = {
   marks: {
@@ -266,7 +267,32 @@ const components: Partial<PortableTextReactComponents> = {
         )}
       </Box>
     ),
-    imports: ({ value }) => <CodeBlock code={value.reactImport} mt={3} />,
+    imports: ({ value }) => {
+      const { userPreferences } = useUserPreferences();
+      if (userPreferences.userType === "designer") {
+        return null;
+      }
+      let imports;
+      switch (userPreferences.technology) {
+        case "react":
+          imports = value.reactImport;
+          break;
+        case "react-native":
+          imports = value.reactNativeImport;
+          break;
+        case "elm":
+          imports = value.elmImport;
+          break;
+        default:
+          return null;
+      }
+
+      if (!imports) {
+        return null;
+      }
+
+      return <CodeBlock code={imports} mt={3} />;
+    },
     tipsPanel: ({ value }) => (
       <Box
         as="article"

--- a/apps/docs/app/features/site-header/UserPreferenceSwitcher.tsx
+++ b/apps/docs/app/features/site-header/UserPreferenceSwitcher.tsx
@@ -16,6 +16,7 @@ import { ChangeEvent } from "react";
 import {
   Technology,
   TokensFormat,
+  UserPreferences,
   UserType,
   useUserPreferences,
 } from "../user-preferences/UserPreferencesContext";
@@ -27,16 +28,29 @@ export const UserPreferenceSwitcher = () => {
     <>
       <Flex as="button" onClick={onOpen} gap={2}>
         <Box whiteSpace="nowrap">
-          Vis som{" "}
-          <strong>
-            {userPreferences.userType === "designer" ? "designer" : "utvikler"}
-          </strong>
+          Vis som <strong>{getUserTypeLabel(userPreferences)}</strong>
         </Box>
         <SettingsX1Fill24Icon />
       </Flex>
       <UserPreferencesModal isOpen={isOpen} onClose={onClose} />
     </>
   );
+};
+
+const getUserTypeLabel = (userPreferences: UserPreferences) => {
+  if (userPreferences.userType === "designer") {
+    return "designer";
+  }
+  switch (userPreferences.technology) {
+    case "elm":
+      return "Elm-utvikler";
+    case "react-native":
+      return "App-utvikler";
+    case "react":
+      return "React-utvikler";
+    default:
+      return "utvikler";
+  }
 };
 
 type UserPreferencesModalProps = { isOpen: boolean; onClose: () => void };

--- a/apps/docs/app/root.tsx
+++ b/apps/docs/app/root.tsx
@@ -74,7 +74,7 @@ export type LoaderData = {
 export const loader: LoaderFunction = async ({ request }) => {
   const [session, initialSanityData] = await Promise.all([
     getUserPreferencesSession(request),
-    getInitialSanityData(),
+    getInitialSanityData(request),
   ]);
 
   return {

--- a/apps/docs/app/routes/$category/$slug/index.tsx
+++ b/apps/docs/app/routes/$category/$slug/index.tsx
@@ -57,7 +57,7 @@ export const loader: LoaderFunction = async ({
       title,
       "slug": slug.current
     },
-    resourceLinks[linkType == $technologyPreference],
+    resourceLinks[linkType == $technologyPreference || linkType == "figma"],
     content[]{
       _type == 'reference' => @->,
       _type != 'reference' => @,
@@ -106,14 +106,24 @@ export default function ArticlePage() {
   const { data: article, isPreview } = usePreviewableData<Data>();
   const { preferredTechnology } = useLoaderData<LoaderData>();
   const showNoImplementationWarning =
-    article.category?.title === "Komponenter" && !article.resourceLinks?.length;
+    preferredTechnology !== "figma" &&
+    article.category?.title === "Komponenter" &&
+    article.resourceLinks?.filter((link) => link.linkType !== "figma")
+      .length === 0;
   return (
     <>
       <HStack mb={1} justifyContent="space-between">
-        {article.category?.title && (
-          <Badge colorScheme="green">{article.category?.title}</Badge>
-        )}
-        {isPreview && <Badge colorScheme="red">Preview</Badge>}
+        <HStack>
+          {article.category?.title && (
+            <Badge colorScheme="green">{article.category?.title}</Badge>
+          )}
+          {isPreview && <Badge colorScheme="yellow">Preview</Badge>}
+          {showNoImplementationWarning && (
+            <Badge colorScheme="red">
+              Ikke tilgjengelig i {mapLinkToLabel(preferredTechnology)}
+            </Badge>
+          )}
+        </HStack>
         <Flex flexWrap="wrap" gap={2}>
           {article.resourceLinks?.map((link) => (
             <Button
@@ -127,11 +137,6 @@ export default function ArticlePage() {
               {mapLinkToLabel(link.linkType)}
             </Button>
           ))}
-          {showNoImplementationWarning && (
-            <Badge colorScheme="red">
-              Ikke tilgjengelig i {mapLinkToLabel(preferredTechnology)}
-            </Badge>
-          )}
         </Flex>
       </HStack>
       <Box>

--- a/apps/docs/app/routes/$category/$slug/index.tsx
+++ b/apps/docs/app/routes/$category/$slug/index.tsx
@@ -1,6 +1,5 @@
 import { PortableText } from "@portabletext/react";
 import type { LoaderFunction, MetaFunction } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
 import {
   Badge,
   Box,
@@ -12,6 +11,7 @@ import {
   HStack,
 } from "@vygruppen/spor-react";
 import invariant from "tiny-invariant";
+import { useUserPreferences } from "~/features/user-preferences/UserPreferencesContext";
 import { getClient } from "~/utils/sanity/client";
 import {
   PreviewableLoaderData,
@@ -35,9 +35,7 @@ type Data = {
   resourceLinks?: ResourceLink[];
   content: any[];
 };
-type LoaderData = PreviewableLoaderData<Data> & {
-  preferredTechnology: "react" | "react-native" | "elm" | "figma";
-};
+type LoaderData = PreviewableLoaderData<Data>;
 
 export const loader: LoaderFunction = async ({
   params,
@@ -85,10 +83,6 @@ export const loader: LoaderFunction = async ({
     isPreview,
     query: isPreview ? query : null,
     queryParams: isPreview ? queryParams : null,
-    preferredTechnology:
-      userPreferences.userType === "developer"
-        ? userPreferences.technology
-        : "figma",
   };
 };
 
@@ -104,9 +98,9 @@ export const meta: MetaFunction = ({ data }: { data: LoaderData }) => {
 
 export default function ArticlePage() {
   const { data: article, isPreview } = usePreviewableData<Data>();
-  const { preferredTechnology } = useLoaderData<LoaderData>();
+  const { userPreferences } = useUserPreferences();
   const showNoImplementationWarning =
-    preferredTechnology !== "figma" &&
+    userPreferences.userType === "developer" &&
     article.category?.title === "Komponenter" &&
     article.resourceLinks?.filter((link) => link.linkType !== "figma")
       .length === 0;
@@ -120,7 +114,7 @@ export default function ArticlePage() {
           {isPreview && <Badge colorScheme="yellow">Preview</Badge>}
           {showNoImplementationWarning && (
             <Badge colorScheme="red">
-              Ikke tilgjengelig i {mapLinkToLabel(preferredTechnology)}
+              Ikke tilgjengelig i {mapLinkToLabel(userPreferences.technology)}
             </Badge>
           )}
         </HStack>

--- a/apps/studio/schemas/objects/imports.tsx
+++ b/apps/studio/schemas/objects/imports.tsx
@@ -3,6 +3,8 @@ import { ObjectField, StringField } from "../schemaTypes";
 
 type Imports = {
   reactImport: StringField;
+  reactNativeImport: StringField;
+  elmImport: StringField;
 };
 export const imports: ObjectField<Imports> = {
   name: "imports",
@@ -15,8 +17,21 @@ export const imports: ObjectField<Imports> = {
       title: "React import string",
       description: "The import string used in a React context",
       type: "text",
-      initialValue: 'import {  } from "@vygruppen/spor-react";',
-      validation: (Rule) => Rule.required(),
+      initialValue: 'import {   } from "@vygruppen/spor-react";',
+    },
+    {
+      name: "reactNativeImport",
+      title: "React Native import string",
+      description: "The import string used in a React Native context",
+      type: "text",
+      initialValue: 'import {  } from "@vygruppen/spor-react-native";',
+    },
+    {
+      name: "elmImport",
+      title: "Elm import string",
+      description: "The import string used in an Elm context",
+      type: "text",
+      initialValue: "import Spor. as  exposing ()",
     },
   ],
   preview: {


### PR DESCRIPTION
Denne PRen legger til forbedret støtte for å velge hvordan teknologi du vil se innhold om.

Man får blant annet støtte for følgende:


- Velger man en teknologi (react, elm, react-native), så vil man kun få opp de komponentene som har en implementasjon i den teknologien
- Man kan nå fylle ut import statements for både react, react native og elm, og man vil nå vise den riktige basert på valgt teknologi
- Man får bare opp lenker til én teknologi (ikke til alle som er tilgjengelige, som før)

![skjermdump av hvordan ting ser ut når man endrer teknologi](https://user-images.githubusercontent.com/1307267/184638885-f90135c4-02f2-4758-8f97-f759696fdbe7.gif)
