### PR TITLE
Legg til støtte for RN og Elm kodeeksempler

### DIFF
--- a/apps/docs/app/features/code-block/CodeBlock.tsx
+++ b/apps/docs/app/features/code-block/CodeBlock.tsx
@@ -22,6 +22,9 @@ export const CodeBlock = ({
   language = "jsx",
   ...props
 }: CodeBlockProps) => {
+  if (!code) {
+    return null;
+  }
   return (
     <CodeBlockContainer
       maxWidth={`calc(100vw - var(--spor-space-6))`}

--- a/apps/docs/app/features/code-block/CodeBlock.tsx
+++ b/apps/docs/app/features/code-block/CodeBlock.tsx
@@ -1,14 +1,21 @@
 import { DarkMode, forwardRef, useClipboard } from "@chakra-ui/react";
 import { Box, BoxProps, Button } from "@vygruppen/spor-react";
-import Highlight, { defaultProps } from "prism-react-renderer";
+import Highlight, { defaultProps, Prism } from "prism-react-renderer";
 import { useRef } from "react";
 import { theme } from "./codeTheme";
+
+// This includes Elm highlighting support
+// It's pretty hacky, so it doesn't play well with TS
+// @ts-ignore
+(typeof global !== "undefined" ? global : window).Prism = Prism;
+require("prismjs/components/prism-elm");
+// Back to normalcy
 
 type CodeBlockProps = Omit<BoxProps, "children"> & {
   /** The code to highlight */
   code: string;
   /** The code language to highlight */
-  language?: "jsx";
+  language?: "jsx" | "elm";
 };
 export const CodeBlock = ({
   code,
@@ -26,7 +33,7 @@ export const CodeBlock = ({
         {...defaultProps}
         theme={theme}
         code={code}
-        language={language}
+        language={language as any}
       >
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <Box as="pre" className={className} style={style}>

--- a/apps/docs/app/features/code-block/codeTheme.ts
+++ b/apps/docs/app/features/code-block/codeTheme.ts
@@ -4,7 +4,7 @@ import { PrismTheme } from "prism-react-renderer";
 export const theme: PrismTheme = {
   plain: {
     color: "#C5C8C6",
-    backgroundColor: "#1D1F21",
+    backgroundColor: "transparent",
   },
   styles: [
     {

--- a/apps/docs/app/features/portable-text/PortableText.tsx
+++ b/apps/docs/app/features/portable-text/PortableText.tsx
@@ -205,17 +205,56 @@ const components: Partial<PortableTextReactComponents> = {
         />
       );
     },
-    codeExample: ({ value }) =>
-      value.layout === "code-only" ? (
-        <CodeBlock mt={6} language="jsx" code={value.reactCode.code} />
+    codeExample: ({ value }) => {
+      const { userPreferences } = useUserPreferences();
+      if (userPreferences.userType === "designer") {
+        return (
+          <InteractiveCode
+            mt={3}
+            layout="preview-only"
+            code={value.reactCode.code}
+          />
+        );
+      }
+      let code, language;
+      switch (userPreferences.technology) {
+        case "react": {
+          code = value.reactCode?.code ?? "";
+          language = "jsx";
+          break;
+        }
+        case "react-native": {
+          code = value.reactNativeCode?.code ?? "";
+          language = "jsx";
+          break;
+        }
+        case "elm": {
+          code = value.elmCode?.code ?? "";
+          language = "elm";
+          break;
+        }
+        default:
+          return null;
+      }
+
+      const showCodeBlock =
+        value.layout === "code-only" || userPreferences.technology !== "react";
+
+      return showCodeBlock ? (
+        <CodeBlock
+          mt={6}
+          language={userPreferences.technology === "elm" ? "elm" : "jsx"}
+          code={code}
+        />
       ) : (
         <InteractiveCode
           layout={value.layout}
           mt={3}
           maxWidth={`calc(100vw - var(--spor-space-6))`}
-          code={value.reactCode.code}
+          code={code}
         />
-      ),
+      );
+    },
     component: ({ value }) => (
       <Box key={value.name} mt={6} as="article">
         <LinkableHeading as="h3" textStyle="md" fontWeight="bold" mb={-2}>

--- a/apps/studio/schemas/objects/codeExample.tsx
+++ b/apps/studio/schemas/objects/codeExample.tsx
@@ -27,7 +27,26 @@ export const codeExample: ObjectField = {
       },
       validation: (Rule) => Rule.required(),
     },
-    // TODO: Add support for other targets, like React Native and Elm
+    {
+      name: "reactNativeCode",
+      title: "React Native Code Example",
+      type: "code",
+      options: {
+        language: "react",
+        languageAlternatives: [{ title: "React", value: "react" }],
+      },
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "elmCode",
+      title: "Elm Code Example",
+      type: "code",
+      options: {
+        language: "elm",
+        languageAlternatives: [{ title: "Elm", value: "elm" }],
+      },
+      validation: (Rule) => Rule.required(),
+    },
   ],
   preview: {
     select: {

--- a/apps/studio/schemas/objects/codeExample.tsx
+++ b/apps/studio/schemas/objects/codeExample.tsx
@@ -15,7 +15,6 @@ export const codeExample: ObjectField = {
         list: ["simple", "preview-only", "code-only", "advanced"],
       },
       initialValue: "simple",
-      validation: (Rule) => Rule.required(),
     },
     {
       name: "reactCode",
@@ -25,7 +24,6 @@ export const codeExample: ObjectField = {
         language: "react",
         languageAlternatives: [{ title: "React", value: "react" }],
       },
-      validation: (Rule) => Rule.required(),
     },
     {
       name: "reactNativeCode",
@@ -35,7 +33,6 @@ export const codeExample: ObjectField = {
         language: "react",
         languageAlternatives: [{ title: "React", value: "react" }],
       },
-      validation: (Rule) => Rule.required(),
     },
     {
       name: "elmCode",
@@ -45,7 +42,6 @@ export const codeExample: ObjectField = {
         language: "elm",
         languageAlternatives: [{ title: "Elm", value: "elm" }],
       },
-      validation: (Rule) => Rule.required(),
     },
   ],
   preview: {

--- a/apps/studio/schemas/objects/codeExample.tsx
+++ b/apps/studio/schemas/objects/codeExample.tsx
@@ -31,7 +31,7 @@ export const codeExample: ObjectField = {
       type: "code",
       options: {
         language: "react",
-        languageAlternatives: [{ title: "React", value: "react" }],
+        languageAlternatives: [{ title: "React Native", value: "react" }],
       },
     },
     {


### PR DESCRIPTION
Denne endringen lar oss legge til kodeeksempler for React Native og Elm også. Slik ser det ut i Sanity:

![Sanity-UIet for å legge til flere forskjellige kodesnutter](https://user-images.githubusercontent.com/1307267/184886018-fe572fd2-c030-4251-81a2-50c21ee5204a.png)

Dessverre er det ikke noen gode muligheter per i dag for å ha live komponent-previews for Elm eller React Native, så enn så lenge viser vi kun kodeeksemplene her.

Her er et eksempel fra Elm-kodehighlightingen:

![Hvordan syntaks-highlightingen ser ut for Elm](https://user-images.githubusercontent.com/1307267/184887243-7fc1e26a-2f5c-463e-9fb8-474615be511b.png)
