### PR TITLE
Fjerne center av successIconet som default

### DIFF
--- a/.changeset/tidy-pandas-join.md
+++ b/.changeset/tidy-pandas-join.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-card-react-native": patch
+---
+
+Sucessfilled icon is default not centered

--- a/apps/rn-demo/app/App.tsx
+++ b/apps/rn-demo/app/App.tsx
@@ -3,6 +3,8 @@ import {
   SporProvider,
   Stack,
   Text,
+  Card,
+  Box,
 } from "@vygruppen/spor-react-native";
 import React from "react";
 import { SafeAreaView } from "react-native";
@@ -26,11 +28,32 @@ const App = () => {
             <Heading color="darkGrey" variant="2xl" textAlign="center">
               Spor Demo app
             </Heading>
-            <Text color="darkGrey" variant="md" textAlign="center">
-              Velkommen! Denne appen brukes til demonstrasjon og utvikling av
-              forskjellige komponenter i Spor sitt designsystem for React
-              Native.
-            </Text>
+            <Card
+              size="sm"
+              colorScheme="white"
+              onPress={() => console.log("test")}
+              isSelected={true}
+              style={{
+                flexDirection: "row",
+                justifyContent: "space-between",
+              }}
+            >
+              <Box
+                style={{
+                  flexDirection: "row",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
+                {
+                  <Text variant={"sm"} fontWeight={"bold"}>
+                    ProductText
+                  </Text>
+                }
+                <Text variant={"sm"}>1003</Text>
+              </Box>
+              {true && <Text variant={"sm"}>seasonTicket.infoMessage</Text>}
+            </Card>
           </Stack>
         </SafeAreaView>
       </SafeAreaProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@vygruppen/spor-design-tokens": "*",
         "@vygruppen/spor-icon": "*",
         "@vygruppen/spor-icon-react": "*",
-        "@vygruppen/spor-react": "^0.13.20",
+        "@vygruppen/spor-react": "^0.13.21",
         "framer-motion": "^6.2.8",
         "match-sorter": "^6.3.1",
         "picosanity": "^4.0.0",
@@ -1040,7 +1040,7 @@
         "@sanity/desk-tool": "^2.27.1",
         "@sanity/eslint-config-studio": "^2.0.0",
         "@sanity/vision": "^2.27.1",
-        "@vygruppen/spor-design-tokens": "^2.4.3",
+        "@vygruppen/spor-design-tokens": "^2.4.4",
         "eslint": "^8.6.0",
         "framer-motion": "^6.2.8",
         "prop-types": "^15.7",
@@ -34656,7 +34656,7 @@
     },
     "packages/spor-accordion-react": {
       "name": "@vygruppen/spor-accordion-react",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^1.7.3",
@@ -34678,7 +34678,7 @@
     },
     "packages/spor-accordion-react-native": {
       "name": "@vygruppen/spor-accordion-react-native",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-icon-react-native": "*",
@@ -36062,7 +36062,7 @@
     },
     "packages/spor-alert-react-native": {
       "name": "@vygruppen/spor-alert-react-native",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-button-react-native": "*",
@@ -37449,7 +37449,7 @@
     },
     "packages/spor-badge-react-native": {
       "name": "@vygruppen/spor-badge-react-native",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-icon-react-native": "*",
@@ -38833,7 +38833,7 @@
     },
     "packages/spor-button-react": {
       "name": "@vygruppen/spor-button-react",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
@@ -38859,7 +38859,7 @@
     },
     "packages/spor-button-react-native": {
       "name": "@vygruppen/spor-button-react-native",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-design-tokens": "*",
@@ -38882,7 +38882,7 @@
     },
     "packages/spor-card-react": {
       "name": "@vygruppen/spor-card-react",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-layout-react": "*"
@@ -38907,7 +38907,7 @@
     },
     "packages/spor-card-react-native": {
       "name": "@vygruppen/spor-card-react-native",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-button-react-native": "*",
@@ -40291,7 +40291,7 @@
     },
     "packages/spor-datepicker-react": {
       "name": "@vygruppen/spor-datepicker-react",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@internationalized/date": "^3.0.1",
@@ -40324,7 +40324,7 @@
     },
     "packages/spor-design-tokens": {
       "name": "@vygruppen/spor-design-tokens",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "MIT",
       "devDependencies": {
         "json-to-ts": "^1.7.0",
@@ -40337,7 +40337,7 @@
     },
     "packages/spor-i18n-react": {
       "name": "@vygruppen/spor-i18n-react",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@leile/lobo-t": "^1.0.5"
@@ -40381,7 +40381,7 @@
     },
     "packages/spor-icon-react": {
       "name": "@vygruppen/spor-icon-react",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-layout-react": "*"
@@ -40405,7 +40405,7 @@
     },
     "packages/spor-icon-react-native": {
       "name": "@vygruppen/spor-icon-react-native",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "@svgr/core": "^6.2.0",
@@ -41858,7 +41858,7 @@
     },
     "packages/spor-image-react": {
       "name": "@vygruppen/spor-image-react",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^1.7.3",
@@ -41880,7 +41880,7 @@
     },
     "packages/spor-input-react": {
       "name": "@vygruppen/spor-input-react",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
@@ -41906,7 +41906,7 @@
     },
     "packages/spor-layout-react": {
       "name": "@vygruppen/spor-layout-react",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "react": ">17.0.0",
@@ -41924,7 +41924,7 @@
     },
     "packages/spor-layout-react-native": {
       "name": "@vygruppen/spor-layout-react-native",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "devDependencies": {
         "@shopify/restyle": "^2.1.0",
@@ -41941,7 +41941,7 @@
     },
     "packages/spor-linjetag-react-native": {
       "name": "@vygruppen/spor-linjetag-react-native",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
@@ -43326,7 +43326,7 @@
     },
     "packages/spor-link-react": {
       "name": "@vygruppen/spor-link-react",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-icon-react": "*"
@@ -43351,7 +43351,7 @@
     },
     "packages/spor-loader": {
       "name": "@vygruppen/spor-loader",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^6.2.2"
@@ -43359,7 +43359,7 @@
     },
     "packages/spor-loader-react": {
       "name": "@vygruppen/spor-loader-react",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-loader": "*",
@@ -43385,7 +43385,7 @@
     },
     "packages/spor-loader-react-native": {
       "name": "@vygruppen/spor-loader-react-native",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-loader": "*"
@@ -44772,7 +44772,7 @@
     },
     "packages/spor-logo-react": {
       "name": "@vygruppen/spor-logo-react",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "react": ">17.0.0",
@@ -44790,7 +44790,7 @@
     },
     "packages/spor-message-box-react-native": {
       "name": "@vygruppen/spor-message-box-react-native",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-button-react-native": "*",
@@ -46176,7 +46176,7 @@
     },
     "packages/spor-modal-react": {
       "name": "@vygruppen/spor-modal-react",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "react-swipeable": "^7.0.0"
@@ -46201,7 +46201,7 @@
     },
     "packages/spor-modal-react-native": {
       "name": "@vygruppen/spor-modal-react-native",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
@@ -47589,7 +47589,7 @@
     },
     "packages/spor-popover-react": {
       "name": "@vygruppen/spor-popover-react",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-button-react": "*",
@@ -47617,11 +47617,11 @@
     },
     "packages/spor-provider-react": {
       "name": "@vygruppen/spor-provider-react",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
-        "@vygruppen/spor-i18n-react": "^0.0.5",
-        "@vygruppen/spor-theme-react": "^0.5.0"
+        "@vygruppen/spor-i18n-react": "^0.0.6",
+        "@vygruppen/spor-theme-react": "^0.5.6"
       },
       "devDependencies": {
         "@chakra-ui/react": "^1.7.3",
@@ -47643,7 +47643,7 @@
     },
     "packages/spor-provider-react-native": {
       "name": "@vygruppen/spor-provider-react-native",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
@@ -47663,7 +47663,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "0.13.20",
+      "version": "0.13.21",
       "license": "MIT",
       "dependencies": {
         "@leile/lobo-t": "^1.0.5",
@@ -47709,7 +47709,7 @@
     },
     "packages/spor-react-native": {
       "name": "@vygruppen/spor-react-native",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "license": "MIT",
       "dependencies": {
         "@shopify/restyle": "^2.1.0",
@@ -47740,7 +47740,7 @@
     },
     "packages/spor-stepper-react": {
       "name": "@vygruppen/spor-stepper-react",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
@@ -47768,7 +47768,7 @@
     },
     "packages/spor-tab-react": {
       "name": "@vygruppen/spor-tab-react",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^1.7.3",
@@ -47790,7 +47790,7 @@
     },
     "packages/spor-table-react": {
       "name": "@vygruppen/spor-table-react",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^1.7.3",
@@ -47812,7 +47812,7 @@
     },
     "packages/spor-theme-react": {
       "name": "@vygruppen/spor-theme-react",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/theme-tools": "^1.3.1",
@@ -47830,7 +47830,7 @@
     },
     "packages/spor-theme-react-native": {
       "name": "@vygruppen/spor-theme-react-native",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-design-tokens": "*"
@@ -47849,7 +47849,7 @@
     },
     "packages/spor-typography-react": {
       "name": "@vygruppen/spor-typography-react",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-design-tokens": "*"
@@ -47874,7 +47874,7 @@
     },
     "packages/spor-typography-react-native": {
       "name": "@vygruppen/spor-typography-react-native",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@shopify/restyle": "^2.1.0",
@@ -54289,7 +54289,7 @@
         "@vygruppen/spor-design-tokens": "*",
         "@vygruppen/spor-icon": "*",
         "@vygruppen/spor-icon-react": "*",
-        "@vygruppen/spor-react": "^0.13.20",
+        "@vygruppen/spor-react": "^0.13.21",
         "config": "*",
         "eslint": "7.32.0",
         "framer-motion": "^6.2.8",
@@ -64701,8 +64701,8 @@
         "@chakra-ui/react": "^1.7.3",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
-        "@vygruppen/spor-i18n-react": "^0.0.5",
-        "@vygruppen/spor-theme-react": "^0.5.0",
+        "@vygruppen/spor-i18n-react": "^0.0.6",
+        "@vygruppen/spor-theme-react": "^0.5.6",
         "framer-motion": "^6.0.0",
         "react": ">17.0.0",
         "react-dom": ">17.0.0",
@@ -64873,7 +64873,7 @@
         "@sanity/desk-tool": "^2.27.1",
         "@sanity/eslint-config-studio": "^2.0.0",
         "@sanity/vision": "^2.27.1",
-        "@vygruppen/spor-design-tokens": "^2.4.3",
+        "@vygruppen/spor-design-tokens": "^2.4.4",
         "eslint": "^8.6.0",
         "framer-motion": "^6.2.8",
         "prop-types": "^15.7",

--- a/packages/spor-card-react-native/src/Card.tsx
+++ b/packages/spor-card-react-native/src/Card.tsx
@@ -164,8 +164,8 @@ export const Card = ({
   const selectedIconIfEnabled = isSelected && (
     <Box
       marginRight="sm"
-      alignSelf="center"
-      style={size == "sm" ? { marginVertical: -2 } : { marginVertical: -5 }}
+      alignSelf={isCenterSuccessIcon ? "center" : "auto"}
+      marginVertical={0.5}
     >
       {size === "lg" ? <SuccessFill30Icon /> : <SuccessFill24Icon />}
     </Box>

--- a/packages/spor-card-react-native/src/Card.tsx
+++ b/packages/spor-card-react-native/src/Card.tsx
@@ -72,6 +72,7 @@ type CardProps = Exclude<RestyleProps, "elevationLevel"> & {
   onClose?: () => void;
   isSelected?: boolean;
   isDisabled?: boolean;
+  isSuccessIconCenter?: boolean;
 };
 
 /**
@@ -125,6 +126,7 @@ export const Card = ({
   size = "lg",
   isSelected = false,
   isDisabled = false,
+  isSuccessIconCenter = false,
   ...props
 }: CardProps) => {
   const restyleProps: Record<string, any> = { ...props, size };
@@ -164,7 +166,7 @@ export const Card = ({
   const selectedIconIfEnabled = isSelected && (
     <Box
       marginRight="sm"
-      alignSelf={isCenterSuccessIcon ? "center" : "auto"}
+      alignSelf={isSuccessIconCenter ? "center" : "auto"}
       marginVertical={0.5}
     >
       {size === "lg" ? <SuccessFill30Icon /> : <SuccessFill24Icon />}


### PR DESCRIPTION

**Bakgrunn** 
Success ikonet skal ikke havne i mitten i salgsappen


![Screen Shot 2022-08-18 at 1 28 08 PM](https://user-images.githubusercontent.com/24417944/185408755-7a23258c-1175-4c0f-a2db-86ea7a7f9a0e.png)

**Løsning**
- fjerne at ikonet skal være sentrert 
- sende med en props som sier at iconet skal være sentrert

![Screen Shot 2022-08-18 at 3 35 49 PM](https://user-images.githubusercontent.com/24417944/185409075-7a4e51b5-4ebe-43da-9208-c3efa8138574.png)

