### PR TITLE
La datepickere fungere som native inputs.

### DIFF
--- a/.changeset/unlucky-walls-wonder.md
+++ b/.changeset/unlucky-walls-wonder.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Fix bug where datepicker didn't work with native form tags

--- a/packages/spor-datepicker-react/src/DateField.tsx
+++ b/packages/spor-datepicker-react/src/DateField.tsx
@@ -29,6 +29,7 @@ function createCalendar(identifier: string) {
 type DateFieldProps = AriaDateFieldProps<DateValue> & {
   label?: React.ReactNode;
   labelProps?: DOMAttributes<FocusableElement>;
+  name?: string;
 };
 export function DateField(props: DateFieldProps) {
   const locale = useCurrentLocale();
@@ -54,6 +55,7 @@ export function DateField(props: DateFieldProps) {
           <DateSegment key={i} segment={segment} state={state} />
         ))}
       </Flex>
+      <input type="hidden" value={state.value?.toString()} name={props.name} />
     </Box>
   );
 }

--- a/packages/spor-datepicker-react/src/DatePicker.tsx
+++ b/packages/spor-datepicker-react/src/DatePicker.tsx
@@ -22,6 +22,7 @@ import { useCurrentLocale } from "./utils";
 
 type DatePickerProps = AriaDatePickerProps<DateValue> & {
   variant: ResponsiveValue<"simple" | "with-trigger">;
+  name?: string;
 };
 /**
  * A date picker component.
@@ -99,6 +100,7 @@ export function DatePicker({ variant, ...props }: DatePickerProps) {
                 <DateField
                   label={props.label}
                   labelProps={labelProps}
+                  name={props.name}
                   {...fieldProps}
                 />
               </StyledField>


### PR DESCRIPTION
Denne endringen gjør det mulig å bruke datepickers som en del av native forms.

Du kan også spesifisere navnet på input-elementet ved å sende inn en `name` prop.

Fixes #415 