### PR TITLE
Alignment og actionTypes

### DIFF
--- a/.changeset/lucky-roses-design.md
+++ b/.changeset/lucky-roses-design.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-message-box-react-native": patch
+---
+
+Align message box icons and buttons to the top of message boxes

--- a/.changeset/lucky-roses-design.md
+++ b/.changeset/lucky-roses-design.md
@@ -3,3 +3,4 @@
 ---
 
 Align message box icons and buttons to the top of message boxes
+Make actionType="none" optional

--- a/packages/spor-message-box-react-native/src/MessageBox.tsx
+++ b/packages/spor-message-box-react-native/src/MessageBox.tsx
@@ -102,6 +102,8 @@ const getIconVariant = (variant: MessageBoxVariant) => {
  *  Insufficient funds
  * </MessageBox>
  * ```
+ *
+ * Note that message boxes should have a short text - never more than two lines of text. If you have more, use a different component.
  */
 export const MessageBox = (props: MessageBoxProps) => {
   const { variant, children, actionType, ...rest } = props;
@@ -113,10 +115,10 @@ export const MessageBox = (props: MessageBoxProps) => {
   const icon = getIconVariant(variant);
 
   return (
-    <Box flexDirection="row" style={style as any} {...rest}>
-      <Box flex={1} flexDirection="row">
-        <Box marginRight={1}>{icon}</Box>
-        <Box flex={1} alignSelf="center">
+    <Box flexDirection="row" style={style as any} {...rest} alignItems="center">
+      <Box flex={1} flexDirection="row" alignItems="center">
+        <Box marginRight={2}>{icon}</Box>
+        <Box flex={1}>
           <Text variant="md">{children}</Text>
         </Box>
       </Box>
@@ -127,6 +129,7 @@ export const MessageBox = (props: MessageBoxProps) => {
           variant="ghost"
           onPress={props.onPress}
           leftIcon={<CloseOutline18Icon />}
+          marginLeft={2}
         />
       )}
       {isButtonProps(props) && (
@@ -134,7 +137,7 @@ export const MessageBox = (props: MessageBoxProps) => {
           size="xs"
           variant="additional"
           onPress={props.onPress}
-          marginLeft={1}
+          marginLeft={2}
         >
           {props.buttonText}
         </Button>

--- a/packages/spor-message-box-react-native/src/MessageBox.tsx
+++ b/packages/spor-message-box-react-native/src/MessageBox.tsx
@@ -67,7 +67,18 @@ const getIconVariant = (variant: MessageBoxVariant) => {
       return null;
   }
 };
-
+/**
+ * A message box component.
+ *
+ * Message boxes can either be closable,
+ *
+ * Message boxes comes in three different variants, with different icons and colors – success, info and error.
+ *
+ * ```tsx
+ * <MessageBox variant="success">That went well</MessageBox>
+ * <MessageBox variant="info">Just FYI</MessageBox>
+ * <MessageBox variant="error">Insufficient funds</MessageBox>
+ */
 export const MessageBox = (props: MessageBoxProps) => {
   const { variant, children, actionType, ...rest } = props;
   const { style } = useRestyle(restyleFunctions, {
@@ -79,11 +90,9 @@ export const MessageBox = (props: MessageBoxProps) => {
 
   return (
     <Box flexDirection="row" style={style as any} {...rest}>
-      <Box flex={1} flexDirection="row" alignItems="center">
-        <Box mr={1} alignContent="center">
-          {icon}
-        </Box>
-        <Box flex={1}>
+      <Box flex={1} flexDirection="row">
+        <Box marginRight={1}>{icon}</Box>
+        <Box flex={1} alignSelf="center">
           <Text variant="md">{children}</Text>
         </Box>
       </Box>
@@ -97,16 +106,14 @@ export const MessageBox = (props: MessageBoxProps) => {
         />
       )}
       {isButtonProps(props) && (
-        <Box alignSelf="center">
-          <Button
-            size="xs"
-            variant="additional"
-            onPress={props.onPress}
-            marginLeft={1}
-          >
-            {props.buttonText}
-          </Button>
-        </Box>
+        <Button
+          size="xs"
+          variant="additional"
+          onPress={props.onPress}
+          marginLeft={1}
+        >
+          {props.buttonText}
+        </Button>
       )}
     </Box>
   );

--- a/packages/spor-message-box-react-native/src/MessageBox.tsx
+++ b/packages/spor-message-box-react-native/src/MessageBox.tsx
@@ -50,7 +50,7 @@ type WithButtonProps = {
 };
 
 type WithoutButtonProps = {
-  actionType: "none";
+  actionType?: "none";
 };
 
 type ActionProps = WithCloseButtonProps | WithButtonProps | WithoutButtonProps;
@@ -70,14 +70,38 @@ const getIconVariant = (variant: MessageBoxVariant) => {
 /**
  * A message box component.
  *
- * Message boxes can either be closable,
+ * Message boxes can have a close button, a text button or neither. For the button variants, you need to pass an `onPress` function, and specify the action type and optional text:
+ *
+ * ```tsx
+ * <MessageBox variant="success">
+ *   Great job!
+ * </MessageBox>
+ * <MessageBox variant="info" actionType="close" onPress={handleClose}>
+ *   The train leaves from platform 2.
+ * </MessageBox>
+ * <MessageBox
+ *  variant="error"
+ *  actionType="button"
+ *  buttonText="Lukk"
+ *  onPress={handleClose}
+ * >
+ *   Something went wrong
+ * </MessageBox>
+ * ```
  *
  * Message boxes comes in three different variants, with different icons and colors – success, info and error.
  *
  * ```tsx
- * <MessageBox variant="success">That went well</MessageBox>
- * <MessageBox variant="info">Just FYI</MessageBox>
- * <MessageBox variant="error">Insufficient funds</MessageBox>
+ * <MessageBox variant="success">
+ *  That went well
+ * </MessageBox>
+ * <MessageBox variant="info">
+ *  Just FYI
+ * </MessageBox>
+ * <MessageBox variant="error">
+ *  Insufficient funds
+ * </MessageBox>
+ * ```
  */
 export const MessageBox = (props: MessageBoxProps) => {
   const { variant, children, actionType, ...rest } = props;


### PR DESCRIPTION
Denne endringen aligner ikoner og knapper til toppen i MessageBox, og gjør `actionType`-propen optional om man ikke skal ha noen knapp til høyre.

Venter fortsatt på en beslutning på om knapper skal være venstre- eller center aligned, så ikke merge før dette er bekreftet av @perweum :) 