### PR TITLE
Replace invalid character in Elm function name

### DIFF
--- a/packages/spor-design-tokens/scripts/formatters/elm/module.ts
+++ b/packages/spor-design-tokens/scripts/formatters/elm/module.ts
@@ -12,7 +12,7 @@ export const elmFormatter: Named<Format> = {
         const exposing = moduleType.exposings().concat(
             dictionary
                 .allProperties
-                .map((prop) => prop.name)
+                .map((prop) => prop.name.replace(".", "_"))
         )
         .join(', ');
 
@@ -110,7 +110,7 @@ class ModuleType {
             '-}',
             `${token.name} : ${this.name}`,
             `${token.name} =`,
-                `${defaultIndentation}${this.name} <| ${this.wrappedType.construct(token.value)}`,
+                `${defaultIndentation}${this.name.replace(".", "_")} <| ${this.wrappedType.construct(token.value)}`,
             '',
             ''
         ];

--- a/packages/spor-design-tokens/scripts/formatters/elm/module.ts
+++ b/packages/spor-design-tokens/scripts/formatters/elm/module.ts
@@ -12,7 +12,7 @@ export const elmFormatter: Named<Format> = {
         const exposing = moduleType.exposings().concat(
             dictionary
                 .allProperties
-                .map((prop) => prop.name.replace(".", "_"))
+                .map((prop) => prop.name.replace('.', '_'))
         )
         .join(', ');
 
@@ -108,8 +108,8 @@ class ModuleType {
         return [
             `{-| ${token.comment || ''}`,
             '-}',
-            `${token.name.replace(".", "_")} : ${this.name}`,
-            `${token.name.replace(".", "_")} =`,
+            `${token.name.replace('.', '_')} : ${this.name}`,
+            `${token.name.replace('.', '_')} =`,
                 `${defaultIndentation}${this.name} <| ${this.wrappedType.construct(token.value)}`,
             '',
             ''

--- a/packages/spor-design-tokens/scripts/formatters/elm/module.ts
+++ b/packages/spor-design-tokens/scripts/formatters/elm/module.ts
@@ -108,9 +108,9 @@ class ModuleType {
         return [
             `{-| ${token.comment || ''}`,
             '-}',
-            `${token.name} : ${this.name}`,
-            `${token.name} =`,
-                `${defaultIndentation}${this.name.replace(".", "_")} <| ${this.wrappedType.construct(token.value)}`,
+            `${token.name.replace(".", "_")} : ${this.name}`,
+            `${token.name.replace(".", "_")} =`,
+                `${defaultIndentation}${this.name} <| ${this.wrappedType.construct(token.value)}`,
             '',
             ''
         ];


### PR DESCRIPTION
When we generate Elm code, we can end up with punctiation in the function names. This is not valid in Elm.

We can instead replace the punctuation with underscore (the closest thing that could resemble a punctuation?), which is valid. If there are any other suggestions, they are welcome.

![Skjermbilde 2022-09-01 kl  09 51 26](https://user-images.githubusercontent.com/15145686/188072033-03099874-94d8-451d-aa06-629b35fee4ed.png)
