### PR TITLE
Add deviation variants for Elm line tags

### DIFF
--- a/packages/spor-elm/src/Spor/LineTag/LineIcon.elm
+++ b/packages/spor-elm/src/Spor/LineTag/LineIcon.elm
@@ -159,114 +159,115 @@ iconColor variant =
 
 icon : Variant -> Size -> Svg msg
 icon variant size =
-    case ( variant, size ) of
-        ( LocalTrain, Sm ) ->
-            Svg.fromUnstyled <| Transportation.trainFill18X18 []
+    Svg.fromUnstyled <|
+        case ( variant, size ) of
+            ( LocalTrain, Sm ) ->
+                Transportation.trainFill18X18 []
 
-        ( LocalTrain, Md ) ->
-            Svg.fromUnstyled <| Transportation.trainFill24X24 []
+            ( LocalTrain, Md ) ->
+                Transportation.trainFill24X24 []
 
-        ( LocalTrain, Lg ) ->
-            Svg.fromUnstyled <| Transportation.trainFill30X30 []
+            ( LocalTrain, Lg ) ->
+                Transportation.trainFill30X30 []
 
-        ( RegionTrain, Sm ) ->
-            Svg.fromUnstyled <| Transportation.trainFill18X18 []
+            ( RegionTrain, Sm ) ->
+                Transportation.trainFill18X18 []
 
-        ( RegionTrain, Md ) ->
-            Svg.fromUnstyled <| Transportation.trainFill24X24 []
+            ( RegionTrain, Md ) ->
+                Transportation.trainFill24X24 []
 
-        ( RegionTrain, Lg ) ->
-            Svg.fromUnstyled <| Transportation.trainFill30X30 []
+            ( RegionTrain, Lg ) ->
+                Transportation.trainFill30X30 []
 
-        ( RegionExpressTrain, Sm ) ->
-            Svg.fromUnstyled <| Transportation.trainFill18X18 []
+            ( RegionExpressTrain, Sm ) ->
+                Transportation.trainFill18X18 []
 
-        ( RegionExpressTrain, Md ) ->
-            Svg.fromUnstyled <| Transportation.trainFill24X24 []
+            ( RegionExpressTrain, Md ) ->
+                Transportation.trainFill24X24 []
 
-        ( RegionExpressTrain, Lg ) ->
-            Svg.fromUnstyled <| Transportation.trainFill30X30 []
+            ( RegionExpressTrain, Lg ) ->
+                Transportation.trainFill30X30 []
 
-        ( LongDistanceTrain, Sm ) ->
-            Svg.fromUnstyled <| Transportation.trainFill18X18 []
+            ( LongDistanceTrain, Sm ) ->
+                Transportation.trainFill18X18 []
 
-        ( LongDistanceTrain, Md ) ->
-            Svg.fromUnstyled <| Transportation.trainFill24X24 []
+            ( LongDistanceTrain, Md ) ->
+                Transportation.trainFill24X24 []
 
-        ( LongDistanceTrain, Lg ) ->
-            Svg.fromUnstyled <| Transportation.trainFill30X30 []
+            ( LongDistanceTrain, Lg ) ->
+                Transportation.trainFill30X30 []
 
-        ( AirportExpressTrain, Sm ) ->
-            Svg.fromUnstyled <| Transportation.trainFill18X18 []
+            ( AirportExpressTrain, Sm ) ->
+                Transportation.trainFill18X18 []
 
-        ( AirportExpressTrain, Md ) ->
-            Svg.fromUnstyled <| Transportation.trainFill24X24 []
+            ( AirportExpressTrain, Md ) ->
+                Transportation.trainFill24X24 []
 
-        ( AirportExpressTrain, Lg ) ->
-            Svg.fromUnstyled <| Transportation.trainFill30X30 []
+            ( AirportExpressTrain, Lg ) ->
+                Transportation.trainFill30X30 []
 
-        ( VyBus, Sm ) ->
-            Svg.fromUnstyled <| Transportation.expressBusFill18X18 []
+            ( VyBus, Sm ) ->
+                Transportation.expressBusFill18X18 []
 
-        ( VyBus, Md ) ->
-            Svg.fromUnstyled <| Transportation.expressBusFill24X24 []
+            ( VyBus, Md ) ->
+                Transportation.expressBusFill24X24 []
 
-        ( VyBus, Lg ) ->
-            Svg.fromUnstyled <| Transportation.expressBusFill30X30 []
+            ( VyBus, Lg ) ->
+                Transportation.expressBusFill30X30 []
 
-        ( LocalBus, Sm ) ->
-            Svg.fromUnstyled <| Transportation.busFill18X18 []
+            ( LocalBus, Sm ) ->
+                Transportation.busFill18X18 []
 
-        ( LocalBus, Md ) ->
-            Svg.fromUnstyled <| Transportation.busFill24X24 []
+            ( LocalBus, Md ) ->
+                Transportation.busFill24X24 []
 
-        ( LocalBus, Lg ) ->
-            Svg.fromUnstyled <| Transportation.busFill30X30 []
+            ( LocalBus, Lg ) ->
+                Transportation.busFill30X30 []
 
-        ( Ferry, Sm ) ->
-            Svg.fromUnstyled <| Transportation.ferryFill18X18 []
+            ( Ferry, Sm ) ->
+                Transportation.ferryFill18X18 []
 
-        ( Ferry, Md ) ->
-            Svg.fromUnstyled <| Transportation.ferryFill24X24 []
+            ( Ferry, Md ) ->
+                Transportation.ferryFill24X24 []
 
-        ( Ferry, Lg ) ->
-            Svg.fromUnstyled <| Transportation.ferryFill30X30 []
+            ( Ferry, Lg ) ->
+                Transportation.ferryFill30X30 []
 
-        ( Subway, Sm ) ->
-            Svg.fromUnstyled <| Transportation.subwayFill18X18 []
+            ( Subway, Sm ) ->
+                Transportation.subwayFill18X18 []
 
-        ( Subway, Md ) ->
-            Svg.fromUnstyled <| Transportation.subwayFill24X24 []
+            ( Subway, Md ) ->
+                Transportation.subwayFill24X24 []
 
-        ( Subway, Lg ) ->
-            Svg.fromUnstyled <| Transportation.subwayFill30X30 []
+            ( Subway, Lg ) ->
+                Transportation.subwayFill30X30 []
 
-        ( Tram, Sm ) ->
-            Svg.fromUnstyled <| Transportation.trainFill18X18 []
+            ( Tram, Sm ) ->
+                Transportation.trainFill18X18 []
 
-        ( Tram, Md ) ->
-            Svg.fromUnstyled <| Transportation.tramFill24X24 []
+            ( Tram, Md ) ->
+                Transportation.tramFill24X24 []
 
-        ( Tram, Lg ) ->
-            Svg.fromUnstyled <| Transportation.trainFill30X30 []
+            ( Tram, Lg ) ->
+                Transportation.trainFill30X30 []
 
-        ( AlternativeTransport, Sm ) ->
-            Svg.fromUnstyled <| Transportation.altTransportFill18X18 []
+            ( AlternativeTransport, Sm ) ->
+                Transportation.altTransportFill18X18 []
 
-        ( AlternativeTransport, Md ) ->
-            Svg.fromUnstyled <| Transportation.altTransportFill24X24 []
+            ( AlternativeTransport, Md ) ->
+                Transportation.altTransportFill24X24 []
 
-        ( AlternativeTransport, Lg ) ->
-            Svg.fromUnstyled <| Transportation.altTransportFill30X30 []
+            ( AlternativeTransport, Lg ) ->
+                Transportation.altTransportFill30X30 []
 
-        ( Walk, Sm ) ->
-            Svg.fromUnstyled <| Transportation.walkFill18X18 []
+            ( Walk, Sm ) ->
+                Transportation.walkFill18X18 []
 
-        ( Walk, Md ) ->
-            Svg.fromUnstyled <| Transportation.walkFill24X24 []
+            ( Walk, Md ) ->
+                Transportation.walkFill24X24 []
 
-        ( Walk, Lg ) ->
-            Svg.fromUnstyled <| Transportation.walkFill30X30 []
+            ( Walk, Lg ) ->
+                Transportation.walkFill30X30 []
 
 
 backgroundColor : Variant -> Color

--- a/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
+++ b/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
@@ -304,7 +304,7 @@ deviationIcon maybeDeviationLevel =
 deviationStyle : DeviationLevel -> Style
 deviationStyle deviationLevel =
     let
-        fillColor =
+        iconFillColor =
             if deviationLevel == Info then
                 [ Css.fill <| Alias.toCss Alias.ocean ]
 
@@ -320,7 +320,7 @@ deviationStyle deviationLevel =
         , Css.property "stroke" "white"
         , Css.property "stroke-width" "2"
         , Css.Global.descendants
-            [ Css.Global.path fillColor
+            [ Css.Global.path iconFillColor
             , Css.Global.typeSelector "path:first-child" [ Css.fill <| Alias.toCss Alias.white ]
             ]
         ]

--- a/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
+++ b/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
@@ -293,7 +293,7 @@ deviationIcon maybeDeviationLevel =
                     [ Css.position Css.absolute
                     , Css.top <| Css.px -7
                     , Css.right <| Css.px -8
-                    , Css.zIndex <| Css.int 2
+                    , Css.zIndex <| Css.int 1
                     , Css.property "paint-order" "stroke"
                     , Css.property "stroke" "white"
                     , Css.property "stroke-width" "2"

--- a/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
+++ b/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
@@ -280,29 +280,8 @@ deviationIcon : Maybe DeviationLevel -> Html msg
 deviationIcon maybeDeviationLevel =
     case maybeDeviationLevel of
         Just deviationLevel ->
-            let
-                fillColor =
-                    if deviationLevel == Info then
-                        [ Css.fill <| Alias.toCss Alias.ocean ]
-
-                    else
-                        []
-            in
             Html.span
-                [ Attributes.css
-                    [ Css.position Css.absolute
-                    , Css.top <| Css.px -7
-                    , Css.right <| Css.px -8
-                    , Css.zIndex <| Css.int 1
-                    , Css.property "paint-order" "stroke"
-                    , Css.property "stroke" "white"
-                    , Css.property "stroke-width" "2"
-                    , Css.Global.descendants
-                        [ Css.Global.path fillColor
-                        , Css.Global.typeSelector "path:first-child" [ Css.fill <| Alias.toCss Alias.white ]
-                        ]
-                    ]
-                ]
+                [ Attributes.css [ deviationStyle deviationLevel ] ]
                 [ Svg.fromUnstyled <|
                     case deviationLevel of
                         Critical ->
@@ -320,6 +299,31 @@ deviationIcon maybeDeviationLevel =
 
         Nothing ->
             Html.text ""
+
+
+deviationStyle : DeviationLevel -> Style
+deviationStyle deviationLevel =
+    let
+        fillColor =
+            if deviationLevel == Info then
+                [ Css.fill <| Alias.toCss Alias.ocean ]
+
+            else
+                []
+    in
+    Css.batch
+        [ Css.position Css.absolute
+        , Css.top <| Css.px -7
+        , Css.right <| Css.px -8
+        , Css.zIndex <| Css.int 1
+        , Css.property "paint-order" "stroke"
+        , Css.property "stroke" "white"
+        , Css.property "stroke-width" "2"
+        , Css.Global.descendants
+            [ Css.Global.path fillColor
+            , Css.Global.typeSelector "path:first-child" [ Css.fill <| Alias.toCss Alias.white ]
+            ]
+        ]
 
 
 deviationBorderStyle : Maybe DeviationLevel -> Style

--- a/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
+++ b/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
@@ -328,9 +328,7 @@ deviationBorderStyle maybeDeviationLevel =
         Just deviationLevel ->
             deviationBorderColor deviationLevel
                 |> Maybe.map
-                    (\color ->
-                        Css.boxShadow6 Css.inset Css.zero Css.zero Css.zero (Css.px 1) color
-                    )
+                    (Css.boxShadow6 Css.inset Css.zero Css.zero Css.zero <| Css.px 1)
                 |> Maybe.withDefault (Css.batch [])
 
         Nothing ->

--- a/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
+++ b/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
@@ -310,6 +310,13 @@ deviationStyle deviationLevel =
 
             else
                 []
+
+        iconSymbolColor =
+            if deviationLevel == Major || deviationLevel == Minor then
+                Alias.toCss Alias.darkGrey
+
+            else
+                Alias.toCss Alias.white
     in
     Css.batch
         [ Css.position Css.absolute
@@ -321,7 +328,7 @@ deviationStyle deviationLevel =
         , Css.property "stroke-width" "2"
         , Css.Global.descendants
             [ Css.Global.path iconFillColor
-            , Css.Global.typeSelector "path:first-child" [ Css.fill <| Alias.toCss Alias.white ]
+            , Css.Global.typeSelector "path:first-child" [ Css.fill iconSymbolColor ]
             ]
         ]
 

--- a/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
+++ b/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
@@ -331,8 +331,7 @@ deviationBorderStyle maybeDeviationLevel =
     case maybeDeviationLevel of
         Just deviationLevel ->
             deviationBorderColor deviationLevel
-                |> Maybe.map
-                    (Css.boxShadow6 Css.inset Css.zero Css.zero Css.zero <| Css.px 1)
+                |> Maybe.map (Css.boxShadow6 Css.inset Css.zero Css.zero Css.zero <| Css.px 1)
                 |> Maybe.withDefault (Css.batch [])
 
         Nothing ->

--- a/packages/spor-elm/src/Spor/LineTag/Types.elm
+++ b/packages/spor-elm/src/Spor/LineTag/Types.elm
@@ -7,7 +7,7 @@ module Spor.LineTag.Types exposing (Variant(..), Size(..), DeviationLevel(..))
 -}
 
 
-{-| Used to configure the variant of the line tag (LocalTrain is default).
+{-| Used to configure the variant of the line tag.
 -}
 type Variant
     = LocalTrain
@@ -24,7 +24,7 @@ type Variant
     | Walk
 
 
-{-| Used to configure the size of the line tag (Md is default).
+{-| Used to configure the size of the line tag.
 -}
 type Size
     = Sm
@@ -32,7 +32,7 @@ type Size
     | Lg
 
 
-{-| Used to configure what deviation (if any) exists for a line (Nothing is default).
+{-| Used to configure what deviation (if any) exists for a line.
 -}
 type DeviationLevel
     = Critical

--- a/packages/spor-elm/src/Spor/LineTag/Types.elm
+++ b/packages/spor-elm/src/Spor/LineTag/Types.elm
@@ -1,14 +1,14 @@
-module Spor.LineTag.Types exposing (Variant(..), Size(..))
+module Spor.LineTag.Types exposing (Variant(..), Size(..), DeviationLevel(..))
 
-{-| The `Variant` type is used for configuring the variant of the line tag component (LocalTrain is default).
-The size is used to configure the size of the line tag (Md is default).
+{-|
 
-@docs Variant, Size
+@docs Variant, Size, DeviationLevel
 
 -}
 
 
-{-| -}
+{-| Used to configure the variant of the line tag (LocalTrain is default).
+-}
 type Variant
     = LocalTrain
     | RegionTrain
@@ -24,8 +24,18 @@ type Variant
     | Walk
 
 
-{-| -}
+{-| Used to configure the size of the line tag (Md is default).
+-}
 type Size
     = Sm
     | Md
     | Lg
+
+
+{-| Used to configure what deviation (if any) exists for a line (Nothing is default).
+-}
+type DeviationLevel
+    = Critical
+    | Major
+    | Minor
+    | Info


### PR DESCRIPTION
## Background

We want to indicate in the travel tags if there are any deviations on the line. There are four types of them: `info`, `minor`, `major` and `critical`.

## Solution

Implement the styling of the different deviation levels for the travel tag.

## Illustrations 
| Info      | Minor | Major |  Critical |
| ----------- | ----------- |  ----------- |----------- |
|  ![Skjermbilde 2022-09-16 kl  15 29 41](https://user-images.githubusercontent.com/15145686/190658058-4a831cc9-433b-4660-a541-7975bcd6ddd3.png)      | ![Skjermbilde 2022-09-16 kl  15 38 20](https://user-images.githubusercontent.com/15145686/190658073-ad3a5f6f-b942-4d02-8afa-034f918a9d30.png)        |   ![Skjermbilde 2022-09-16 kl  15 34 09](https://user-images.githubusercontent.com/15145686/190658071-c7075d04-21b1-4f6d-9d6f-e814c4e1bb0d.png)   |  ![Skjermbilde 2022-09-16 kl  15 33 37](https://user-images.githubusercontent.com/15145686/190658067-bdeaf93f-a9ae-4754-901b-654126cc8184.png) |