### PR TITLE
Legg til ny dokumenttype for illustrasjoner

### DIFF
--- a/apps/studio/config/deskStructure.ts
+++ b/apps/studio/config/deskStructure.ts
@@ -35,4 +35,5 @@ export default () =>
       S.documentTypeListItem("category").title("Categories"),
       S.documentTypeListItem("component").title("Components"),
       S.documentTypeListItem("menu").title("Menus"),
+      S.documentTypeListItem("illustration").title("Illustrations"),
     ]);

--- a/apps/studio/schemas/documents/illustration.tsx
+++ b/apps/studio/schemas/documents/illustration.tsx
@@ -1,0 +1,46 @@
+import { MdBrush } from "react-icons/md";
+import { ArrayField, Document, ImageField, StringField } from "../schemaTypes";
+
+export type Illustration = {
+  title: StringField;
+  tags: ArrayField;
+  image: ImageField;
+};
+export const illustration: Document<Illustration> = {
+  name: "illustration",
+  title: "Illustration",
+  type: "document",
+  icon: MdBrush,
+  fields: [
+    {
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "tags",
+      title: "Tags",
+      description:
+        "Searchable words for this illustration. The more the better!",
+      type: "array",
+      of: [{ type: "string" }],
+      options: {
+        layout: "tags",
+      },
+    },
+    {
+      name: "image",
+      title: "Illustration",
+      description: "Upload the SVG version of your illustration",
+      type: "image",
+      validation: (Rule) => Rule.required(),
+    },
+  ],
+  preview: {
+    select: {
+      title: "title",
+      media: "image",
+    },
+  },
+};

--- a/apps/studio/schemas/documents/index.tsx
+++ b/apps/studio/schemas/documents/index.tsx
@@ -1,5 +1,6 @@
 export * from "./article";
 export * from "./category";
 export * from "./component";
+export * from "./illustration";
 export * from "./menu";
 export * from "./siteSettings";


### PR DESCRIPTION
Denne endringen legger til en ny dokumenttype for illustrasjoner i Sanity. Den ser slik ut:

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/1307267/191944882-9b2e93bf-202d-4cc5-abe1-1b99d976aa30.png">

Er det noe mer vi trenger?