### PR TITLE
Legg til støtte for å bruke fargenavn, marginer etc på ikoner i React Native

### DIFF
--- a/.changeset/cold-gorillas-reply.md
+++ b/.changeset/cold-gorillas-reply.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react-native": minor
+---
+
+Add support for using color names

--- a/package-lock.json
+++ b/package-lock.json
@@ -10132,6 +10132,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/@shopify/restyle": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/restyle/-/restyle-2.1.0.tgz",
+      "integrity": "sha512-CE4DDf5ZvDI438n5iQrdqw628Sa0F4C6CwTGxJEAKQLvC+4orWtr2TFPskoxl9hrMfk+TOzNTDZ3tcR88qKvrw==",
+      "dev": true,
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-native": ">=0.59.0"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "dev": true,
@@ -34393,6 +34403,7 @@
       "version": "0.1.5",
       "license": "MIT",
       "devDependencies": {
+        "@shopify/restyle": "^2.1.0",
         "@svgr/core": "^6.2.0",
         "@svgr/plugin-jsx": "^6.2.0",
         "@svgr/plugin-svgo": "^6.2.0",
@@ -42519,6 +42530,13 @@
         }
       }
     },
+    "@shopify/restyle": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/restyle/-/restyle-2.1.0.tgz",
+      "integrity": "sha512-CE4DDf5ZvDI438n5iQrdqw628Sa0F4C6CwTGxJEAKQLvC+4orWtr2TFPskoxl9hrMfk+TOzNTDZ3tcR88qKvrw==",
+      "dev": true,
+      "requires": {}
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "dev": true,
@@ -43699,6 +43717,7 @@
     "@vygruppen/spor-icon-react-native": {
       "version": "file:packages/spor-icon-react-native",
       "requires": {
+        "@shopify/restyle": "*",
         "@svgr/core": "^6.2.0",
         "@svgr/plugin-jsx": "^6.2.0",
         "@svgr/plugin-svgo": "^6.2.0",

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -124,11 +124,17 @@ async function generateComponent(iconData: IconData) {
   // to make it work as we want.
   // The most straight-forward way to do this is by using string replacement.
   // It looks hacky, it is hacky, but it works.
-  jsCode = "import { Box, useTheme } from '@shopify/restyle';\n" + jsCode;
+  jsCode =
+    "import { createBox, useTheme } from '@shopify/restyle';\n" +
+    "const Box = createBox();\n" +
+    jsCode;
   jsCode = jsCode
     .replace("{...props}", "")
     .replace("props", '{ color = "darkGrey", ...props }')
-    .replace("<Svg", "{ \n\tconst theme = useTheme(); \n\treturn <Box {...props}><Svg")
+    .replace(
+      "<Svg",
+      "{ \n\tconst theme = useTheme(); \n\treturn <Box {...props}><Svg"
+    )
     .replace("</Svg>", "</Svg></Box>}");
 
   return createComponentFile(iconData, jsCode);

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -99,7 +99,7 @@ async function generateComponents(icons: IconData[]) {
 }
 
 async function generateComponent(iconData: IconData) {
-  const jsCode = await transform(
+  let jsCode = await transform(
     iconData.icon,
     {
       icon: false,
@@ -112,13 +112,25 @@ async function generateComponent(iconData: IconData) {
       },
       native: true,
       replaceAttrValues: {
-        '#2B2B2C': `{props.color ?? "#2B2B2C"}`,
+        "#2B2B2C": `{theme.colors[color] ?? "#2B2B2C"}`,
       },
     },
     {
       componentName: iconData.componentName,
     }
   );
+
+  // Since we don't own the template, we need to change the generated code
+  // to make it work as we want.
+  // The most straight-forward way to do this is by using string replacement.
+  // It looks hacky, it is hacky, but it works.
+  jsCode = "import { Box, useTheme } from '@shopify/restyle';\n" + jsCode;
+  jsCode = jsCode
+    .replace("{...props}", "")
+    .replace("props", '{ color = "darkGrey", ...props }')
+    .replace("<Svg", "{ \n\tconst theme = useTheme(); \n\treturn <Box {...props}><Svg")
+    .replace("</Svg>", "</Svg></Box>}");
+
   return createComponentFile(iconData, jsCode);
 }
 

--- a/packages/spor-icon-react-native/bin/typeDefinitionTemplate.ts
+++ b/packages/spor-icon-react-native/bin/typeDefinitionTemplate.ts
@@ -4,11 +4,11 @@ export const typeDefinitionTemplate = (iconsData: IconData[]) => {
   return `
 // This file was auto-generated.
 // Please do not change this file directly.
-import type { BoxProps } from "@vygruppen/spor-layout-react-native";
+import type { BoxProps } from "app/spor";
 import type { ForwardRefExoticComponent } from "react";
 
 declare module "@vygruppen/spor-icon-react-native" {
-  type IconProps = BoxProps & { color?: string };
+  type IconProps = BoxProps & { color?: BoxProps["backgroundColor"] };
   export type IconComponent = ForwardRefExoticComponent<IconProps>;
 
   ${iconsData

--- a/packages/spor-icon-react-native/package.json
+++ b/packages/spor-icon-react-native/package.json
@@ -24,21 +24,23 @@
     "build:step-3": "rimraf tmp"
   },
   "devDependencies": {
-    "@vygruppen/spor-icon": "*",
-    "react-native-svg": "^12.3.0",
+    "@shopify/restyle": "^2.1.0",
     "@svgr/core": "^6.2.0",
     "@svgr/plugin-jsx": "^6.2.0",
     "@svgr/plugin-svgo": "^6.2.0",
     "@types/fs-extra": "^9.0.13",
+    "@vygruppen/spor-icon": "*",
     "case": "^1.6.3",
     "fs-extra": "^10.0.0",
     "react": ">17.0.0",
     "react-native": "^0.66.0",
+    "react-native-svg": "^12.3.0",
     "rimraf": "^3.0.2",
     "ts-node": "^10.4.0",
     "tsup": "^6.2.2"
   },
   "peerDependencies": {
+    "@shopify/restyle": "^2.1.0",
     "react": ">17.0.0",
     "react-native": "^0.66.0",
     "react-native-svg": "^12.3.0"

--- a/packages/spor-icon-react-native/tsconfig.json
+++ b/packages/spor-icon-react-native/tsconfig.json
@@ -7,7 +7,7 @@
   },
   "ts-node": {
     "compilerOptions": {
-      "module": "CommonJS"
+      "module": "CommonJS",
     }
   }
 }


### PR DESCRIPTION
Denne endringen gjør at man nå kan spesifisere såkalte `Box`-props på React Native-ikoner – akkurat som i React. Det vil si at man kan gjøre følgende:

```tsx
<AddFill18Icon color="brightRed" marginRight={2} />
```

Implementasjonen er litt hacky, men når man skal bruke svgr til å generere React Native-komponenter, har man ikke kontroll over templaten på samme måte som i React. Resultatet blir at man må bruke `String.prototype.replace` for å endre den genererte koden.