### PR TITLE
Fiks React Native release-bug

### DIFF
--- a/.changeset/flat-books-warn.md
+++ b/.changeset/flat-books-warn.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react-native": patch
+---
+
+Fix build bug for react-native

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "add-package": "plop --plopfile internal/plopfile.mjs",
     "prebuild": "rimraf packages/*/dist",
-    "build": "turbo run build --filter=@vygruppen/spor*-react",
+    "build": "turbo run build --filter=@vygruppen/spor*-react --filter=@vygruppen/spor*-react-native",
     "test": "turbo run test --parallel",
     "dev": "turbo run dev --no-cache --parallel --filter=@vygruppen/spor*-react --filter=@vygruppen/docs --filter=@vygruppen/studio",
     "postinstall": "patch-package",


### PR DESCRIPTION
Denne fiksen endrer slik at react-native pakker nå blir bygd! Det har visst ikke fungert på en stund - men siden vi bare har én pakke som er react native spesifikk så merket vi det ikke før nå.