### PR TITLE
🐛Fikse feil for sirkulære ikoner.

### DIFF
--- a/.changeset/honest-pillows-cross.md
+++ b/.changeset/honest-pillows-cross.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react-native": patch
+---
+
+Fikser feil ved generering av sirkulærere ikoner.

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -135,7 +135,8 @@ async function generateComponent(iconData: IconData) {
       "<Svg",
       "{ \n\tconst theme = useTheme(); \n\treturn <Box {...props}><Svg"
     )
-    .replace("</Svg>", "</Svg></Box>}");
+    .replace("</Svg>", "</Svg></Box>}")
+    .replace(`strokeWidth: "none"`, `"strokeWidth: 0`);
 
   return createComponentFile(iconData, jsCode);
 }


### PR DESCRIPTION
Appen kræsjer når ikoner med sirkel har strokeWidth: "none" på Android enheter. 


Løsning Erstatter strokeWidth: "none"  med strokeWidth:0. 
![image](https://user-images.githubusercontent.com/24417944/192514544-342d4a69-047e-4f40-9c48-4f64f1755c65.png)
![Screen Shot 2022-09-27 at 1 29 54 PM](https://user-images.githubusercontent.com/24417944/192514560-306aea6d-37d2-4196-ad3a-07a539219602.png)
