### PR TITLE
Legg til beskrivelsesfelter for illustrasjoner i Sanity

### DIFF
--- a/apps/studio/schemas/documents/illustration.tsx
+++ b/apps/studio/schemas/documents/illustration.tsx
@@ -1,10 +1,19 @@
 import { MdBrush } from "react-icons/md";
-import { ArrayField, Document, ImageField, StringField } from "../schemaTypes";
+import {
+  ArrayField,
+  Document,
+  ImageField,
+  StringField,
+  TextField,
+} from "../schemaTypes";
 
 export type Illustration = {
   title: StringField;
   tags: ArrayField;
   image: ImageField;
+  descriptionNb: TextField;
+  descriptionSv: TextField;
+  descriptionEn: TextField;
 };
 export const illustration: Document<Illustration> = {
   name: "illustration",
@@ -19,10 +28,17 @@ export const illustration: Document<Illustration> = {
       validation: (Rule) => Rule.required(),
     },
     {
+      name: "image",
+      title: "Illustration",
+      description: "Upload the SVG version of your illustration",
+      type: "image",
+      validation: (Rule) => Rule.required(),
+    },
+    {
       name: "tags",
       title: "Tags",
       description:
-        "Searchable words for this illustration. The more the better!",
+        "Searchable words for this illustration (in Norwegian). The more the better!",
       type: "array",
       of: [{ type: "string" }],
       options: {
@@ -30,11 +46,24 @@ export const illustration: Document<Illustration> = {
       },
     },
     {
-      name: "image",
-      title: "Illustration",
-      description: "Upload the SVG version of your illustration",
-      type: "image",
+      name: "descriptionNb",
+      title: "Description (Norwegian Bokmål)",
+      description:
+        "Describe the illustration in Norwegian Bokmål, for screen readers",
+      type: "text",
       validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "descriptionSv",
+      title: "Description (Swedish)",
+      description: "Describe the illustration in Swedish, for screen readers",
+      type: "text",
+    },
+    {
+      name: "descriptionEn",
+      title: "Description (English)",
+      description: "Describe the illustration in English, for screen readers",
+      type: "text",
     },
   ],
   preview: {


### PR DESCRIPTION
Denne endringer legger til tre nye felter i Sanity-modellen for illustrasjoner - nemlig beskrivelse av bildet på norsk (bokmål), svensk og engelsk.

Disse tekstene skal brukes som default alt-tekster, om man ikke kan skrive en mer beskrivende en selv gitt utifra konteksten de brukes i.