### PR TITLE
Forbedre illustrasjonssiden

### DIFF
--- a/apps/docs/app/routes/__base/ressurser/illustrasjoner/alle.tsx
+++ b/apps/docs/app/routes/__base/ressurser/illustrasjoner/alle.tsx
@@ -1,0 +1,57 @@
+import { LoaderFunction, Response } from "@remix-run/node";
+import { SanityAsset } from "@sanity/image-url/lib/types/types";
+import Archiver from "archiver";
+import { PassThrough } from "stream";
+import { getClient } from "~/utils/sanity/client";
+import { urlBuilder } from "~/utils/sanity/utils";
+import { slugify } from "~/utils/stringUtils";
+
+type Illustration = {
+  title: string;
+  imageLightBackground: SanityAsset;
+  imageDarkBackground: SanityAsset;
+};
+
+/**
+ * Fetches all illustrations from Sanity and returns them as a zip file.
+ */
+export const loader: LoaderFunction = async () => {
+  console.info("Fetching list of illustrations from Sanity");
+  const allIllustrations = await getClient().fetch<Illustration[]>(
+    `*[_type == "illustration"] { title, imageLightBackground, imageDarkBackground }`
+  );
+  console.info(
+    `Found ${allIllustrations.length} illustrations. Downloading them in parallel…`
+  );
+  const zip = Archiver("zip");
+  const stream = new PassThrough();
+
+  zip.pipe(stream);
+
+  const promises = allIllustrations
+    .flatMap((illustration) => [
+      {
+        title: slugify(`${illustration.title} light`),
+        url: urlBuilder.image(illustration.imageLightBackground).url(),
+      },
+      {
+        title: slugify(`${illustration.title} dark`),
+        url: urlBuilder.image(illustration.imageDarkBackground).url(),
+      },
+    ])
+    .map(async (illustration) => {
+      const response = await fetch(illustration.url);
+      zip.append(await response.text(), { name: `${illustration.title}.svg` });
+    });
+  await Promise.all(promises);
+  zip.finalize();
+
+  const headers = new Headers();
+  headers.set("Content-Type", "application/zip");
+  headers.set("Content-Disposition", "attachment; filename=illustrasjoner.zip");
+  headers.set("Cache-Control", "max-age=60");
+  return new Response(stream, {
+    status: 200,
+    headers,
+  });
+};

--- a/apps/docs/app/routes/__base/ressurser/illustrasjoner/index.tsx
+++ b/apps/docs/app/routes/__base/ressurser/illustrasjoner/index.tsx
@@ -78,7 +78,9 @@ export default function IllustrasjonerPage() {
       <Button
         variant="primary"
         size="lg"
-        onClick={() => alert("Det kommer snart")}
+        as="a"
+        download="illustrasjoner.zip"
+        href="/ressurser/illustrasjoner/alle"
         leftIcon={<DownloadOutline24Icon />}
       >
         Last ned alle illustrasjoner
@@ -118,7 +120,11 @@ export default function IllustrasjonerPage() {
             <Flex flexDirection="column" height="100%">
               <Flex gap={1} alignItems="center">
                 <Text variant="sm">{illustration.title}</Text>
-                <SimplePopover triggerElement={<InformationOutline18Icon />}>
+                <SimplePopover
+                  placement="top"
+                  arrowPadding={2}
+                  triggerElement={<InformationOutline18Icon />}
+                >
                   {illustration.description}
                 </SimplePopover>
               </Flex>
@@ -134,6 +140,7 @@ export default function IllustrasjonerPage() {
                 }
                 alt={illustration.description}
                 width="100%"
+                maxHeight="10rem"
                 objectFit="contain"
                 objectPosition="center"
                 flex={1}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,6 +24,7 @@
     "@vygruppen/spor-icon": "*",
     "@vygruppen/spor-icon-react": "*",
     "@vygruppen/spor-react": "*",
+    "archiver": "^5.3.1",
     "framer-motion": "^7.5.2",
     "match-sorter": "^6.3.1",
     "picosanity": "^4.0.0",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@remix-run/dev": "1.7.2",
+    "@types/archiver": "^5.3.1",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
     "config": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@vygruppen/spor-icon": "*",
         "@vygruppen/spor-icon-react": "*",
         "@vygruppen/spor-react": "*",
+        "archiver": "^5.3.1",
         "framer-motion": "^7.5.2",
         "match-sorter": "^6.3.1",
         "picosanity": "^4.0.0",
@@ -57,6 +58,7 @@
       },
       "devDependencies": {
         "@remix-run/dev": "1.7.2",
+        "@types/archiver": "^5.3.1",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.6",
         "config": "*",
@@ -9871,6 +9873,15 @@
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/archiver": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.3.1.tgz",
+      "integrity": "sha512-wKYZaSXaDvTZuInAWjCeGG7BEAgTWG2zZW0/f7IYFcoHB2X2d9lkVFnrOlXl3W6NrvO6Ml3FLLu8Uksyymcpnw==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "*"
       }
     },
     "node_modules/@types/cacheable-request": {
@@ -30221,7 +30232,7 @@
     },
     "packages/spor-accordion-react": {
       "name": "@vygruppen/spor-accordion-react",
-      "version": "0.1.4",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^2.3.5",
@@ -30243,7 +30254,7 @@
     },
     "packages/spor-button-react": {
       "name": "@vygruppen/spor-button-react",
-      "version": "0.2.11",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
@@ -30269,7 +30280,7 @@
     },
     "packages/spor-card-react": {
       "name": "@vygruppen/spor-card-react",
-      "version": "0.3.2",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-layout-react": "*"
@@ -30294,7 +30305,7 @@
     },
     "packages/spor-datepicker-react": {
       "name": "@vygruppen/spor-datepicker-react",
-      "version": "0.1.9",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@internationalized/date": "^3.0.1",
@@ -30340,7 +30351,7 @@
     },
     "packages/spor-i18n-react": {
       "name": "@vygruppen/spor-i18n-react",
-      "version": "0.0.6",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@leile/lobo-t": "^1.0.5"
@@ -30385,7 +30396,7 @@
     },
     "packages/spor-icon-react": {
       "name": "@vygruppen/spor-icon-react",
-      "version": "0.6.4",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-layout-react": "*"
@@ -31167,7 +31178,7 @@
     },
     "packages/spor-image-react": {
       "name": "@vygruppen/spor-image-react",
-      "version": "0.1.2",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^2.3.5",
@@ -31189,7 +31200,7 @@
     },
     "packages/spor-input-react": {
       "name": "@vygruppen/spor-input-react",
-      "version": "0.5.5",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
@@ -31215,7 +31226,7 @@
     },
     "packages/spor-layout-react": {
       "name": "@vygruppen/spor-layout-react",
-      "version": "0.3.3",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^2.3.5",
@@ -31234,7 +31245,7 @@
     },
     "packages/spor-linjetag-react": {
       "name": "@vygruppen/spor-linjetag-react",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-icon-react": "*"
@@ -31259,7 +31270,7 @@
     },
     "packages/spor-link-react": {
       "name": "@vygruppen/spor-link-react",
-      "version": "0.1.13",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-icon-react": "*"
@@ -31292,7 +31303,7 @@
     },
     "packages/spor-loader-react": {
       "name": "@vygruppen/spor-loader-react",
-      "version": "0.2.4",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-loader": "*",
@@ -31318,7 +31329,7 @@
     },
     "packages/spor-logo-react": {
       "name": "@vygruppen/spor-logo-react",
-      "version": "0.1.4",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "react": "^18.2.0",
@@ -31336,7 +31347,7 @@
     },
     "packages/spor-modal-react": {
       "name": "@vygruppen/spor-modal-react",
-      "version": "0.1.4",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "react-swipeable": "^7.0.0"
@@ -31361,7 +31372,7 @@
     },
     "packages/spor-popover-react": {
       "name": "@vygruppen/spor-popover-react",
-      "version": "0.1.19",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-button-react": "*",
@@ -31389,11 +31400,11 @@
     },
     "packages/spor-provider-react": {
       "name": "@vygruppen/spor-provider-react",
-      "version": "0.0.9",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@vygruppen/spor-i18n-react": "^0.0.6",
-        "@vygruppen/spor-theme-react": "^0.6.5"
+        "@vygruppen/spor-i18n-react": "^1.0.0",
+        "@vygruppen/spor-theme-react": "^1.0.0"
       },
       "devDependencies": {
         "@chakra-ui/react": "^2.3.5",
@@ -31415,7 +31426,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "0.14.6",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.3.5",
@@ -31458,7 +31469,7 @@
     },
     "packages/spor-stepper-react": {
       "name": "@vygruppen/spor-stepper-react",
-      "version": "0.1.19",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
@@ -31486,7 +31497,7 @@
     },
     "packages/spor-tab-react": {
       "name": "@vygruppen/spor-tab-react",
-      "version": "0.1.3",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^2.3.5",
@@ -31508,7 +31519,7 @@
     },
     "packages/spor-table-react": {
       "name": "@vygruppen/spor-table-react",
-      "version": "0.0.7",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^2.3.5",
@@ -31530,7 +31541,7 @@
     },
     "packages/spor-theme-react": {
       "name": "@vygruppen/spor-theme-react",
-      "version": "0.6.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/theme-tools": "^2.0.12",
@@ -31548,7 +31559,7 @@
     },
     "packages/spor-typography-react": {
       "name": "@vygruppen/spor-typography-react",
-      "version": "0.4.9",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-design-tokens": "*"
@@ -38551,6 +38562,15 @@
         "@types/estree": "*"
       }
     },
+    "@types/archiver": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.3.1.tgz",
+      "integrity": "sha512-wKYZaSXaDvTZuInAWjCeGG7BEAgTWG2zZW0/f7IYFcoHB2X2d9lkVFnrOlXl3W6NrvO6Ml3FLLu8Uksyymcpnw==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*"
+      }
+    },
     "@types/cacheable-request": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
@@ -39095,12 +39115,14 @@
         "@remix-run/serve": "1.7.2",
         "@sanity/groq-store": "^0.4.1",
         "@sanity/image-url": "^1.0.1",
+        "@types/archiver": "*",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.6",
         "@vygruppen/spor-design-tokens": "*",
         "@vygruppen/spor-icon": "*",
         "@vygruppen/spor-icon-react": "*",
         "@vygruppen/spor-react": "*",
+        "archiver": "^5.3.1",
         "config": "*",
         "eslint": "7.32.0",
         "framer-motion": "^7.5.2",
@@ -40124,8 +40146,8 @@
         "@chakra-ui/react": "^2.3.5",
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
-        "@vygruppen/spor-i18n-react": "^0.0.6",
-        "@vygruppen/spor-theme-react": "^0.6.5",
+        "@vygruppen/spor-i18n-react": "^1.0.0",
+        "@vygruppen/spor-theme-react": "^1.0.0",
         "framer-motion": ">6.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",


### PR DESCRIPTION
Denne endringen forbedrer måten illustrasjonsbiblioteket er implementert på, samt lager en resource route for å laste ned alle illustrasjoner som en zip-fil.

Ta gjerne en titt på `/routes/ressurser/illustrasjoner/alle.tsx` filen – den er nemlig ganske kul! Den er nok ikke helt 100 % enda. Det jeg prøver å få til er å streame resultatet fra Sanity direkte inn i zip-streamen som så sendes direkte ned til brukeren. 

Slik det er i dag blir nok ikke responsen sendt før alt er i minnet på serveren, som sikkert kommer til å smelle en vakker dag. Om du er ram på streams, så ta gjerne en ekstra titt for å se om det kan forbedres!