### PR TITLE
Legg til støtte for å spesifisere retningen av en Stack med flexDirection

### DIFF
--- a/.changeset/heavy-spies-roll.md
+++ b/.changeset/heavy-spies-roll.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-layout-react": minor
+---
+
+Nå kan man spesifisere retningen på en Stack med flexDirection istedenfor direction.

--- a/packages/spor-layout-react/src/Stack.tsx
+++ b/packages/spor-layout-react/src/Stack.tsx
@@ -1,0 +1,37 @@
+import type { StackProps as ChakraStackProps } from "@chakra-ui/react";
+import { Stack as ChakraStack } from "@chakra-ui/react";
+import React from "react";
+
+export type StackProps = ChakraStackProps & {
+  flexDirection: ChakraStackProps["direction"];
+};
+/**
+ * Adds consistent spacing between elements
+ *
+ * ```tsx
+ * <Stack>
+ *   <Text>Here's a paragraph</Text>
+ *   <Text>Here's another perfectly spaced paragraph</Text>
+ * </Stack>
+ * ```
+ *
+ * By default, the stack will be a column. You can change this by setting the `flexDirection` prop to any valid flex direction:
+ * ```tsx
+ * <Stack flexDirection="row">
+ *   <Checkbox>Here's a checkbox</Checkbox>
+ *   <Checkbox>Here's another checkbox, almost right next to the first one</Checkbox>
+ * </Stack>
+ * ```
+ *
+ * You can specify the spacing between elements with the `spacing` prop:
+ *
+ * ```tsx
+ * <Stack spacing={4}>
+ *   <Card>Here's one card</Card>
+ *   <Card>Here's another card, with a lot of space between it</Card>
+ * </Stack>
+ * ```
+ */
+export const Stack = ({ flexDirection, ...props }: StackProps) => {
+  return <ChakraStack {...props} direction={flexDirection} />;
+};

--- a/packages/spor-layout-react/src/index.tsx
+++ b/packages/spor-layout-react/src/index.tsx
@@ -8,7 +8,6 @@ export {
   HStack,
   SimpleGrid,
   Spacer,
-  Stack,
   VStack,
   Wrap,
   WrapItem,
@@ -22,8 +21,8 @@ export type {
   GridProps,
   SimpleGridProps,
   SpacerProps,
-  StackProps,
   WrapItemProps,
   WrapProps,
 } from "@chakra-ui/react";
 export * from "./Divider";
+export * from "./Stack";


### PR DESCRIPTION
Før måtte man bruke direction til å spesifisere retningen. Det kan man fortsatt gjøre, men det anbefales nå å heller bruke flexDirection, for å bruke samme APIet som React Native.
