### PR TITLE
Gjør ikoner resizable

### DIFF
--- a/.changeset/light-rocks-sin.md
+++ b/.changeset/light-rocks-sin.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react-native": patch
+---
+
+Fix a bug where resizing the icons directly through height or width didn't work as expected

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -126,7 +126,9 @@ async function generateComponent(iconData: IconData) {
   jsCode = "import { Box, useTheme } from 'app/spor';\n" + jsCode;
   jsCode = jsCode
     .replace("{...props}", "")
-    .replace("props", '{ color = "darkGrey", ...props }')
+    .replace("props", '{ color = "darkGrey", width, height, ...props }')
+    .replace(/width={(\d+)}/, "width={width ?? $1}")
+    .replace(/height={(\d+)}/, "height={height ?? $1}")
     .replace(
       "<Svg",
       "{ \n\tconst theme = useTheme(); \n\treturn <Box {...props}><Svg"

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -129,17 +129,11 @@ async function generateComponent(iconData: IconData) {
     .replace("props", '{ color = "darkGrey", width, height, ...props }')
     // Weird regex alert!
     // Replaces `width={18}` with
-    // `width={props.style?.width ?? theme.spacing[width] ?? 18}`
-    .replace(
-      /width={(\d+)}/,
-      "width={props.style?.width ?? theme.spacing[width] ?? $1}"
-    )
+    // `width={props.style?.width ?? width ?? 18}`
+    .replace(/width={(\d+)}/, "width={props.style?.width ?? width ?? $1}")
     // Replaces `height={18}` with
-    // `height=props.style?.height ?? theme.spacing[height] ?? 18}`
-    .replace(
-      /height={(\d+)}/,
-      "height={props.style?.height ?? theme.spacing[height] ?? $1}"
-    )
+    // `height=props.style?.height ?? height ?? 18}`
+    .replace(/height={(\d+)}/, "height={props.style?.height ?? height ?? $1}")
     .replace(
       "<Svg",
       "{ \n\tconst theme = useTheme(); \n\treturn <Box {...props}><Svg"

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -127,7 +127,10 @@ async function generateComponent(iconData: IconData) {
   jsCode = jsCode
     .replace("{...props}", "")
     .replace("props", '{ color = "darkGrey", width, height, ...props }')
+    // Weird regex alert!
+    // Replaces `width={18}` with `width={width ?? 18}`
     .replace(/width={(\d+)}/, "width={width ?? $1}")
+    // Replaces `height={18}` with `height={width ?? 18}`
     .replace(/height={(\d+)}/, "height={height ?? $1}")
     .replace(
       "<Svg",

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -128,10 +128,18 @@ async function generateComponent(iconData: IconData) {
     .replace("{...props}", "")
     .replace("props", '{ color = "darkGrey", width, height, ...props }')
     // Weird regex alert!
-    // Replaces `width={18}` with `width={width ?? 18}`
-    .replace(/width={(\d+)}/, "width={width ?? $1}")
-    // Replaces `height={18}` with `height={width ?? 18}`
-    .replace(/height={(\d+)}/, "height={height ?? $1}")
+    // Replaces `width={18}` with
+    // `width={props.style?.width ?? theme.spacing[width] ?? 18}`
+    .replace(
+      /width={(\d+)}/,
+      "width={props.style?.width ?? theme.spacing[width] ?? $1}"
+    )
+    // Replaces `height={18}` with
+    // `height=props.style?.height ?? theme.spacing[height] ?? 18}`
+    .replace(
+      /height={(\d+)}/,
+      "height={props.style?.height ?? theme.spacing[height] ?? $1}"
+    )
     .replace(
       "<Svg",
       "{ \n\tconst theme = useTheme(); \n\treturn <Box {...props}><Svg"


### PR DESCRIPTION
Denne endringen fikser en bug som gjorde at ikoner ikke kunne være hvilken som helst størrelse på React Native.

Grunnen var at `width` og `height` ble satt direkte på den omkringliggende boksen, og ikke SVGen i seg selv.

Denne løsningen gjør det slik at man kan sette størrelser slik:

```tsx
<SomeFill18Icon /> // 99 % av tilfeller
<SomeFill30Icon width={64} height={64} /> // via props
<SomeFill30Icon style={{ width: 64, height: 64 }} /> // via style-prop
```