### PR TITLE
Legg til automatisk title-tag for IconButton

### DIFF
--- a/.changeset/pink-mayflies-remember.md
+++ b/.changeset/pink-mayflies-remember.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-button-react": patch
+---
+
+Set the default title attribute of icon buttons to the aria-label if not specified

--- a/packages/spor-button-react/src/IconButton.tsx
+++ b/packages/spor-button-react/src/IconButton.tsx
@@ -53,6 +53,11 @@ export type IconButtonProps = Omit<ChakraIconButtonProps, "variant"> & {
  */
 export const IconButton = forwardRef<IconButtonProps, As<any>>(
   ({ ...props }, ref) => (
-    <ChakraIconButton {...props} spinner={<ColorSpinner m={1} />} ref={ref} />
+    <ChakraIconButton
+      title={props["aria-label"]}
+      {...props}
+      spinner={<ColorSpinner m={1} />}
+      ref={ref}
+    />
   )
 );

--- a/packages/spor-button-react/src/IconButton.tsx
+++ b/packages/spor-button-react/src/IconButton.tsx
@@ -4,7 +4,7 @@ import {
   IconButton as ChakraIconButton,
   IconButtonProps as ChakraIconButtonProps,
 } from "@chakra-ui/react";
-import { Spinner } from "@vygruppen/spor-loader-react";
+import { ColorSpinner } from "@vygruppen/spor-loader-react";
 import React from "react";
 
 export type IconButtonProps = Omit<ChakraIconButtonProps, "variant"> & {
@@ -53,6 +53,6 @@ export type IconButtonProps = Omit<ChakraIconButtonProps, "variant"> & {
  */
 export const IconButton = forwardRef<IconButtonProps, As<any>>(
   ({ ...props }, ref) => (
-    <ChakraIconButton {...props} spinner={<Spinner m={1} />} ref={ref} />
+    <ChakraIconButton {...props} spinner={<ColorSpinner m={1} />} ref={ref} />
   )
 );


### PR DESCRIPTION
Denne endringen gjør at alle `IconButton` komponenter automatisk får en title-attributt lagt på seg. 
- Om man ikke spesifiserer `title` spesifikt, vil den defaulte til hva enn du sender inn som `aria-label` (som er påkrevd)
- Om du spesifiserer `title` som en tom streng, vil man ikke sette noen title.
- Om du spesifiserer `title` som en ikke-tom streng, vil den overstyre `aria-label`.

```tsx
<IconButton icon={<SomeIcon />} aria-label="Something" /> // title === "Something"
<IconButton icon={<SomeIcon />} aria-label="Something" title="" /> // title === ""
<IconButton icon={<SomeIcon />} aria-label="Something" title="Something else" /> // title === "Something else"
```