### PR TITLE
Fiks en lenkebug

### DIFF
--- a/.changeset/warm-buckets-walk.md
+++ b/.changeset/warm-buckets-walk.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-theme-react": patch
+"@vygruppen/spor-link-react": patch
+---
+
+Fix a bug where the box shadows were misplaced on some links

--- a/package-lock.json
+++ b/package-lock.json
@@ -31903,7 +31903,7 @@
     },
     "packages/spor-icon-react-native": {
       "name": "@vygruppen/spor-icon-react-native",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "devDependencies": {
         "@shopify/restyle": "^2.1.0",
@@ -32707,7 +32707,7 @@
     },
     "packages/spor-layout-react": {
       "name": "@vygruppen/spor-layout-react",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@chakra-ui/react": "^2.3.5",

--- a/packages/spor-theme-react/src/components/link.ts
+++ b/packages/spor-theme-react/src/components/link.ts
@@ -43,6 +43,7 @@ const config = defineStyleConfig({
           boxShadow: getBoxShadowString({
             borderColor: "pine",
             borderWidth: 3,
+            isInset: false,
           }),
         },
         notFocus: {
@@ -57,11 +58,16 @@ const config = defineStyleConfig({
         boxShadow: getBoxShadowString({
           borderColor: "coralGreen",
           borderWidth: 3,
+          isInset: false,
         }),
       },
       _active: {
         backgroundColor: "mint",
-        boxShadow: getBoxShadowString({ borderColor: "mint", borderWidth: 3 }),
+        boxShadow: getBoxShadowString({
+          borderColor: "mint",
+          borderWidth: 3,
+          isInset: false,
+        }),
         color: "pine",
       },
     },
@@ -74,6 +80,7 @@ const config = defineStyleConfig({
           boxShadow: getBoxShadowString({
             borderColor: "darkGrey",
             borderWidth: 3,
+            isInset: false,
           }),
         },
         notFocus: {
@@ -88,6 +95,7 @@ const config = defineStyleConfig({
         boxShadow: getBoxShadowString({
           borderColor: props.theme.colors.blackAlpha[100],
           borderWidth: 3,
+          isInset: false,
         }),
       },
       _active: {
@@ -96,6 +104,7 @@ const config = defineStyleConfig({
         boxShadow: getBoxShadowString({
           borderColor: "mint",
           borderWidth: 3,
+          isInset: false,
         }),
       },
     }),
@@ -108,6 +117,7 @@ const config = defineStyleConfig({
           boxShadow: getBoxShadowString({
             borderColor: "white",
             borderWidth: 3,
+            isInset: false,
           }),
         },
         notFocus: {
@@ -122,6 +132,7 @@ const config = defineStyleConfig({
         boxShadow: getBoxShadowString({
           borderColor: props.theme.colors.whiteAlpha[200],
           borderWidth: 3,
+          isInset: false,
         }),
       },
       _active: {
@@ -130,6 +141,7 @@ const config = defineStyleConfig({
         boxShadow: getBoxShadowString({
           borderColor: props.theme.colors.whiteAlpha[400],
           borderWidth: 3,
+          isInset: false,
         }),
       },
     }),

--- a/packages/spor-theme-react/src/utils/box-shadow-utils.ts
+++ b/packages/spor-theme-react/src/utils/box-shadow-utils.ts
@@ -5,6 +5,7 @@ type GetBoxShadowStringArgs = {
   baseShadow?: keyof typeof shadows;
   borderColor?: keyof typeof colors | string;
   borderWidth?: number;
+  isInset?: boolean;
 };
 /**
  * A utility for creating box shadow strings
@@ -13,6 +14,7 @@ export const getBoxShadowString = ({
   baseShadow,
   borderColor,
   borderWidth = 1,
+  isInset = true,
 }: GetBoxShadowStringArgs) => {
   const allShadows: string[] = [];
 
@@ -21,7 +23,9 @@ export const getBoxShadowString = ({
     if (borderColor in colors) {
       color = colors[borderColor as keyof typeof colors] as string;
     }
-    allShadows.push(`inset 0 0 0 ${borderWidth}px ${color}`);
+    allShadows.push(
+      `${isInset ? "inset " : ""}0 0 0 ${borderWidth}px ${color}`
+    );
   }
   if (baseShadow) {
     allShadows.push(shadows[baseShadow]);


### PR DESCRIPTION
Denne endringen fikser en bug der lenker så litt feil ut i noen tilstander.

Buggen dukket nok opp da jeg skrev om alle box shadows til å bruke denne nye funksjonen vår "getBoxShadowString" – denne skulle nok i utgangspunktet ikke brukt denne 😅 Men med et nytt flagg som lar oss overstyre om en box shadow skal være inset eller ei, gikk det greit.