### PR TITLE
Legg til støtte for å kunne aligne bilder

### DIFF
--- a/apps/docs/app/features/Images-with-caption/ImageWithCaption.tsx
+++ b/apps/docs/app/features/Images-with-caption/ImageWithCaption.tsx
@@ -1,20 +1,67 @@
-import { Stack, Image, Text } from "@vygruppen/spor-react";
+import { PortableText } from "@portabletext/react";
+import { Flex, Image, Stack } from "@vygruppen/spor-react";
 
 type ImageWithCaptionProps = {
   src: string;
   alt: string;
-  caption?: React.ReactNode;
+  aspectRatio?: string;
+  alignment?: "left" | "center" | "right" | "none";
+  caption?: any;
 };
 
 export const ImageWithCaption = ({
   src,
   alt,
   caption,
+  aspectRatio,
+  alignment,
 }: ImageWithCaptionProps) => {
   return (
-    <Stack spacing={1.5}>
-      <Image src={src} alt={alt} borderRadius="sm" boxShadow="sm" />
-      <Text textStyle="xs">{caption}</Text>
-    </Stack>
+    <Flex
+      as="figure"
+      marginTop={[3, 6]}
+      flexDirection="column"
+      alignItems={mapAlignmentToAlignItems(alignment)}
+    >
+      {src && <Image src={src} alt={alt || ""} sx={{ aspectRatio }} />}
+      {caption && (
+        <Stack
+          as="figcaption"
+          textStyle="xs"
+          color="dimGrey"
+          marginTop={1.5}
+          textAlign={mapAlignmentToTextAlign(alignment)}
+        >
+          <PortableText value={caption} />
+        </Stack>
+      )}
+    </Flex>
   );
+};
+
+const mapAlignmentToAlignItems = (
+  alignment: ImageWithCaptionProps["alignment"]
+) => {
+  switch (alignment) {
+    case "left":
+      return "flex-start";
+    case "right":
+      return "flex-end";
+    case "center":
+    default:
+      return "center";
+  }
+};
+const mapAlignmentToTextAlign = (
+  alignment: ImageWithCaptionProps["alignment"]
+) => {
+  switch (alignment) {
+    case "left":
+      return "left";
+    case "right":
+      return "right";
+    case "center":
+    default:
+      ["left", "center"];
+  }
 };

--- a/apps/docs/app/features/portable-text/PortableText.tsx
+++ b/apps/docs/app/features/portable-text/PortableText.tsx
@@ -29,6 +29,7 @@ import {
 import React from "react";
 import { urlBuilder } from "~/utils/sanity/utils";
 import { CodeBlock } from "../code-block/CodeBlock";
+import { ImageWithCaption } from "../Images-with-caption/ImageWithCaption";
 import { InteractiveCode } from "../interactive-code/InteractiveCode";
 import { LinkableHeading } from "../linkable-heading/LinkableHeading";
 import { useUserPreferences } from "../user-preferences/UserPreferencesContext";
@@ -187,33 +188,20 @@ const components: Partial<PortableTextReactComponents> = {
     imageWithCaption: ({ value }) => {
       const [, , dimensions] = value.image.asset?._ref.split("-");
       const aspectRatio = dimensions.split("x").join(" / ");
+
       return (
-        <Box as="figure" marginTop={[3, 6]}>
-          {value.image && (
-            <Image
-              src={urlBuilder
-                .image(value.image)
-                .width(924)
-                .fit("max")
-                .auto("format")
-                .url()}
-              alt={value.alt || ""}
-              mx="auto"
-              __css={{ aspectRatio }}
-            />
-          )}
-          {value.caption && (
-            <Stack
-              as="figcaption"
-              textStyle="xs"
-              color="dimGrey"
-              marginTop={1.5}
-              textAlign={["left", "center"]}
-            >
-              <PortableText value={value.caption} />
-            </Stack>
-          )}
-        </Box>
+        <ImageWithCaption
+          src={urlBuilder
+            .image(value.image)
+            .width(924)
+            .fit("max")
+            .auto("format")
+            .url()}
+          alt={value.alt}
+          alignment={value.alignment}
+          caption={value.caption}
+          aspectRatio={aspectRatio}
+        />
       );
     },
     image: ({ value }) => {

--- a/apps/studio/schemas/objects/imageWithCaption.tsx
+++ b/apps/studio/schemas/objects/imageWithCaption.tsx
@@ -34,9 +34,10 @@ export const imageWithCaption = defineType({
       description:
         "This is only a suggestion, the image may be aligned differently depending on the context",
       type: "string",
-      initialValue: 'center',
+      initialValue: "none",
       options: {
         list: [
+          { title: "No preference", value: "none" },
           { title: "Left-aligned", value: "left" },
           { title: "Center-aligned", value: "center" },
           { title: "Right-aligned", value: "right" },

--- a/apps/studio/schemas/objects/imageWithCaption.tsx
+++ b/apps/studio/schemas/objects/imageWithCaption.tsx
@@ -28,6 +28,21 @@ export const imageWithCaption = defineType({
       type: "array",
       of: [{ type: "block", styles: [{ title: "Text", value: "normal" }] }],
     }),
+    defineField({
+      name: "alignment",
+      title: "Preferred alignment",
+      description:
+        "This is only a suggestion, the image may be aligned differently depending on the context",
+      type: "string",
+      options: {
+        list: [
+          { title: "Left-aligned", value: "left" },
+          { title: "Center-aligned", value: "center" },
+          { title: "Right-aligned", value: "right" },
+        ],
+        layout: "radio",
+      },
+    }),
   ],
   preview: {
     select: {

--- a/apps/studio/schemas/objects/imageWithCaption.tsx
+++ b/apps/studio/schemas/objects/imageWithCaption.tsx
@@ -34,6 +34,7 @@ export const imageWithCaption = defineType({
       description:
         "This is only a suggestion, the image may be aligned differently depending on the context",
       type: "string",
+      initialValue: 'center',
       options: {
         list: [
           { title: "Left-aligned", value: "left" },


### PR DESCRIPTION
Denne endringen legger til støtte for å velge en alignment på bilder.

Det er ikke alltid bilder kan, eller skal, bli alignet, så dette kan kun ses på som en anbefaling

![screenshot of the new UI](https://user-images.githubusercontent.com/1307267/199223571-d26bfac6-d594-46f0-89b3-c81d61d9a6b5.png)
