### PR TITLE
Add role img to all icons

### DIFF
--- a/.changeset/rich-timers-carry.md
+++ b/.changeset/rich-timers-carry.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react": patch
+---
+
+Add role="img" to all icons

--- a/packages/spor-icon-react/bin/generate.ts
+++ b/packages/spor-icon-react/bin/generate.ts
@@ -108,6 +108,9 @@ async function generateComponent(iconData: IconData) {
       expandProps: "end",
       ref: true,
       titleProp: false,
+      svgProps: {
+        role: "img",
+      },
       svgo: true,
       svgoConfig: {
         removeViewBox: false,


### PR DESCRIPTION
Denne endringen setter `role="img"` på alle ikon-komponenter. Det gjøres for å forbedre brukeropplevelsen for skjermleser-brukere, og for å holde oss til [anbefalingene fra MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#svg_and_roleimg).

Fixes #507 