### PR TITLE
use loader args instead of loader function

### DIFF
--- a/apps/docs/app/features/table-of-contents/useHeadings.ts
+++ b/apps/docs/app/features/table-of-contents/useHeadings.ts
@@ -1,5 +1,5 @@
 import { useLocation } from "@remix-run/react";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { HeadingLevelType, HeadingType } from "./TableOfContents";
 
 /**
@@ -9,7 +9,7 @@ export const useHeadings = () => {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const location = useLocation();
   const [headings, setHeadings] = useState<HeadingType[]>([]);
-  useLayoutEffect(() => {
+  useEffect(() => {
     const id = setTimeout(() => {
       const headingList: HeadingType[] = [];
       contentRef.current?.querySelectorAll("h2, h3, h4").forEach((el) => {

--- a/apps/docs/app/routes/__base.tsx
+++ b/apps/docs/app/routes/__base.tsx
@@ -7,7 +7,7 @@ import { useHeadings } from "~/features/table-of-contents/useHeadings";
 import { getClient } from "~/utils/sanity/client";
 
 /* This loader isn't use here directly, but from within the left sidebar component tree. Don't remove it, even if it isn't used here.  */
-export const loader: LoaderFunction = async () => {
+export const loader = async () => {
   const menu = await getClient().fetch(
     `*[_type == "menu" && slug.current == "side-menu"][0] { menuItems }`
   );

--- a/apps/docs/app/routes/__base/$category/$slug/index.tsx
+++ b/apps/docs/app/routes/__base/$category/$slug/index.tsx
@@ -1,5 +1,5 @@
 import { PortableText } from "@portabletext/react";
-import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import type { LoaderArgs, MetaFunction } from "@remix-run/node";
 import {
   Badge,
   Box,
@@ -65,10 +65,7 @@ type Data = {
 };
 type LoaderData = PreviewableLoaderData<Data>;
 
-export const loader: LoaderFunction = async ({
-  params,
-  request,
-}): Promise<LoaderData> => {
+export const loader = async ({ params, request }: LoaderArgs) => {
   invariant(params.category, "Expected params.category");
   invariant(params.slug, "Expected params.slug");
 
@@ -125,7 +122,7 @@ export const loader: LoaderFunction = async ({
   };
 };
 
-export const meta: MetaFunction = ({ data }: { data: LoaderData }) => {
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (!data) {
     return {};
   }

--- a/apps/docs/app/routes/__base/komponenter/oversikt.tsx
+++ b/apps/docs/app/routes/__base/komponenter/oversikt.tsx
@@ -1,5 +1,5 @@
 import { PortableText } from "@portabletext/react";
-import { LoaderFunction } from "@remix-run/node";
+import { LoaderArgs } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import { Box, Card, Heading, Image, SimpleGrid } from "@vygruppen/spor-react";
 import { getClient } from "~/utils/sanity/client";
@@ -58,12 +58,7 @@ const articleQuery = async () => {
   return article;
 };
 
-type LoaderData = {
-  components: ComponentData[];
-  article: ArticleData;
-};
-
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader = async ({ request }: LoaderArgs) => {
   const session = await getUserPreferencesSession(request);
   const userPreferences = session.getUserPreferences();
   const technologyPreference =
@@ -80,7 +75,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 };
 
 export default function ComponentsPage() {
-  const { components, article } = useLoaderData<LoaderData>();
+  const { components, article } = useLoaderData<typeof loader>();
   return (
     <Box>
       <Heading as="h1" textStyle="xl-display" mb={2}>

--- a/apps/docs/app/routes/__base/ressurser/ikoner/index.tsx
+++ b/apps/docs/app/routes/__base/ressurser/ikoner/index.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   ButtonGroup,
   Divider,
-  DownloadOutline24Icon,
   Heading,
   Stack,
   Text,
@@ -11,6 +10,7 @@ import { Link } from "@remix-run/react";
 import { SearchBar } from "~/features/routes/ressurser/ikoner/SearchBar";
 import { SearchFilterProvider } from "~/features/routes/ressurser/ikoner/SearchFilterContext";
 import { SearchResults } from "~/features/routes/ressurser/ikoner/SearchResults";
+import { DownloadOutline24Icon } from "@vygruppen/spor-icon-react";
 
 export default function IconsPage() {
   return (

--- a/apps/docs/app/routes/__base/ressurser/illustrasjonsbibliotek/alle.tsx
+++ b/apps/docs/app/routes/__base/ressurser/illustrasjonsbibliotek/alle.tsx
@@ -15,7 +15,7 @@ type Illustration = {
 /**
  * Fetches all illustrations from Sanity and returns them as a zip file.
  */
-export const loader: LoaderFunction = async () => {
+export const loader = async () => {
   console.info("Fetching list of illustrations from Sanity");
   const allIllustrations = await getClient().fetch<Illustration[]>(
     `*[_type == "illustration"] { title, imageLightBackground, imageDarkBackground }`

--- a/apps/docs/app/routes/__base/ressurser/illustrasjonsbibliotek/index.tsx
+++ b/apps/docs/app/routes/__base/ressurser/illustrasjonsbibliotek/index.tsx
@@ -1,20 +1,22 @@
 import { PortableText } from "@portabletext/react";
-import { json, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { SanityAsset } from "@sanity/image-url/lib/types/types";
+import {
+  DownloadOutline18Icon,
+  DownloadOutline24Icon,
+  InformationOutline18Icon,
+} from "@vygruppen/spor-icon-react";
 import {
   Badge,
   Box,
   Button,
   Card,
   Divider,
-  DownloadOutline18Icon,
-  DownloadOutline24Icon,
   Flex,
   Heading,
   IconButton,
   Image,
-  InformationOutline18Icon,
   SearchInput,
   Select,
   SimpleGrid,
@@ -50,7 +52,7 @@ type LoaderData = {
   };
 };
 
-export const loader: LoaderFunction = async () => {
+export const loader = async () => {
   const client = getClient();
   const query = `
   {
@@ -78,11 +80,11 @@ export const loader: LoaderFunction = async () => {
   }
 }`;
   const { illustrations, article } = await client.fetch(query);
-  return json<LoaderData>({ illustrations, article });
+  return json({ illustrations, article } as LoaderData);
 };
 
 export default function IllustrasjonerPage() {
-  const { illustrations, article } = useLoaderData<LoaderData>();
+  const { illustrations, article } = useLoaderData<typeof loader>();
   const [searchValue, setSearchValue] = useState("");
   const [background, setBackground] = useState("light");
 

--- a/apps/docs/app/routes/lekegrind.tsx
+++ b/apps/docs/app/routes/lekegrind.tsx
@@ -1,4 +1,4 @@
-import { ActionFunction, json, LoaderFunction } from "@remix-run/node";
+import { ActionArgs, json, LoaderArgs } from "@remix-run/node";
 import { useFetcher, useLoaderData } from "@remix-run/react";
 import { Stack } from "@vygruppen/spor-react";
 import { useState } from "react";
@@ -9,7 +9,7 @@ import { LiveProvider } from "~/features/interactive-code/LiveProvider";
 import { debounce } from "~/utils/debounce";
 import { getPlaygroundDataSession } from "~/utils/playgroundData.server";
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const { setPlaygroundData, commit } = await getPlaygroundDataSession(request);
   const formData = await request.formData();
   const playgroundData = formData.get("playgroundData");
@@ -35,7 +35,7 @@ export const action: ActionFunction = async ({ request }) => {
   );
 };
 
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader = async ({ request }: LoaderArgs) => {
   const session = await getPlaygroundDataSession(request);
   const playgroundData = session.getPlaygroundData();
 
@@ -47,10 +47,6 @@ export const loader: LoaderFunction = async ({ request }) => {
       },
     }
   );
-};
-
-type LoaderData = {
-  playgroundData: string;
 };
 
 const defaultCode = `<Stack textAlign="center">
@@ -70,7 +66,7 @@ const saveToCookie = debounce((newCode: string, fetcher: any) => {
 
 export default function PlaygroundPage() {
   const { playgroundData: initialPlaygroundDataFromCookie } =
-    useLoaderData<LoaderData>();
+    useLoaderData<typeof loader>();
   const [playgroundData, setPlaygroundData] = useState(
     initialPlaygroundDataFromCookie || defaultCode
   );

--- a/apps/docs/app/routes/studio.tsx
+++ b/apps/docs/app/routes/studio.tsx
@@ -1,7 +1,7 @@
 import { LoaderFunction, redirect } from "@remix-run/node";
 
 // Redirect users to the Studio app.
-export const loader: LoaderFunction = async () => {
+export const loader = async () => {
   if (process.env.NODE_ENV === "development") {
     return redirect("http://localhost:3333");
   }


### PR DESCRIPTION
Denne endringen er en teknisk oppgradering, som gjør det litt kulere å skrive Remix-kode

- Rewrite all loaders and actions to use LoaderArgs
- Use regular useEffect instead of useLayoutEffect
