### PR TITLE
Hide decorative element for screen reader

### DIFF
--- a/.changeset/great-walls-play.md
+++ b/.changeset/great-walls-play.md
@@ -1,0 +1,8 @@
+---
+"@vygruppen/spor-input-react": patch
+"@vygruppen/spor-linjetag-react": patch
+"@vygruppen/spor-link-react": patch
+"@vygruppen/spor-logo-react": patch
+---
+
+Improve accessibility of related icons

--- a/packages/spor-input-react/src/SearchInput.tsx
+++ b/packages/spor-input-react/src/SearchInput.tsx
@@ -31,8 +31,8 @@ export const SearchInput = forwardRef<SearchInputProps, "input">(
     const showCloseButton = onReset && Boolean(props.value);
     return (
       <InputGroup position="relative">
-        <InputLeftElement aria-hidden="true">
-          <SearchOutline24Icon />
+        <InputLeftElement>
+          <SearchOutline24Icon aria-hidden="true" />
         </InputLeftElement>
         <ChakraInput
           pl={7}

--- a/packages/spor-input-react/src/SearchInput.tsx
+++ b/packages/spor-input-react/src/SearchInput.tsx
@@ -31,7 +31,7 @@ export const SearchInput = forwardRef<SearchInputProps, "input">(
     const showCloseButton = onReset && Boolean(props.value);
     return (
       <InputGroup position="relative">
-        <InputLeftElement>
+        <InputLeftElement aria-hidden="true">
           <SearchOutline24Icon />
         </InputLeftElement>
         <ChakraInput

--- a/packages/spor-linjetag-react/src/InfoTag.tsx
+++ b/packages/spor-linjetag-react/src/InfoTag.tsx
@@ -33,7 +33,11 @@ export const InfoTag = ({
   const styles = useMultiStyleConfig("InfoTag", { variant, size });
   return (
     <Box sx={styles.container}>
-      <LineIcon variant={variant} size={size} sx={styles.iconContainer} />
+      <LineIcon
+        variant={variant}
+        size={size}
+        sx={styles.iconContainer}
+      />
       <Box sx={styles.textContainer}>
         {title && (
           <Box as="span" sx={styles.title}>

--- a/packages/spor-link-react/package.json
+++ b/packages/spor-link-react/package.json
@@ -20,7 +20,8 @@
     "dev": "tsup src/index.tsx --watch --format esm"
   },
   "dependencies": {
-    "@vygruppen/spor-icon-react": "*"
+    "@vygruppen/spor-icon-react": "*",
+    "@vygruppen/spor-i18n-react": "*"
   },
   "devDependencies": {
     "react": "^18.2.0",

--- a/packages/spor-link-react/src/TextLink.tsx
+++ b/packages/spor-link-react/src/TextLink.tsx
@@ -3,6 +3,7 @@ import {
   Link as ChakraLink,
   LinkProps as ChakraLinkProps,
 } from "@chakra-ui/react";
+import { useTranslation } from "@vygruppen/spor-i18n-react";
 import { LinkOutOutline24Icon } from "@vygruppen/spor-icon-react";
 import React from "react";
 
@@ -15,6 +16,7 @@ type LinkProps = Omit<ChakraLinkProps, "variant"> & {
  */
 export const TextLink = forwardRef<LinkProps, "a">(
   ({ children, ...props }, ref) => {
+    const { t } = useTranslation();
     const isExternal =
       props.isExternal !== undefined
         ? props.isExternal
@@ -22,11 +24,24 @@ export const TextLink = forwardRef<LinkProps, "a">(
     return (
       <ChakraLink {...props} ref={ref} isExternal={isExternal}>
         {children}
-        {isExternal && <LinkOutOutline24Icon ml={0.5} />}
+        {isExternal && (
+          <LinkOutOutline24Icon
+            marginLeft={0.5}
+            aria-label={t(texts.externalLink)}
+          />
+        )}
       </ChakraLink>
     );
   }
 );
+
+const texts = {
+  externalLink: {
+    nb: "Ekstern lenke",
+    sv: "Extern länk",
+    en: "External link",
+  },
+};
 
 /** Link to different sites or parts of sites.
  *

--- a/packages/spor-logo-react/src/VyLogo.tsx
+++ b/packages/spor-logo-react/src/VyLogo.tsx
@@ -16,6 +16,7 @@ export const VyLogo = ({ colorScheme, ...boxProps }: VyLogoProps) => {
 
   return (
     <Box as="svg" viewBox="0 0 107 54" {...boxProps}>
+      <title>Vy logo</title>
       <path
         fillRule="evenodd"
         clipRule="evenodd"


### PR DESCRIPTION
1.1.1 Ikke-tekstlig innhold (Nivå A)

Hvis det ikke-tekstlige innholdet er ren dekorasjon, skal det implementeres på en slik måte at det kan ignoreres av kompenserende teknologi.


Er det flere steder i Spor-komponentene vi kun bruker dekorative elementer som bør skjules?