### PR TITLE
Rmove popover on disabled datepicker

### DIFF
--- a/.changeset/quiet-fans-peel.md
+++ b/.changeset/quiet-fans-peel.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Rmove popover on disabled datepicker

--- a/packages/spor-datepicker-react/src/DatePicker.tsx
+++ b/packages/spor-datepicker-react/src/DatePicker.tsx
@@ -107,7 +107,7 @@ export function DatePicker({ variant, ...props }: DatePickerProps) {
             </PopoverAnchor>
             {hasTrigger && <CalendarTriggerButton {...buttonProps} />}
           </InputGroup>
-          {state.isOpen && (
+          {state.isOpen && !props.isDisabled && (
             <PopoverContent
               backgroundColor="white"
               color="darkGrey"


### PR DESCRIPTION
Når du trykker på datepicker-ikonet på en disabled datepicker dukker ikke kalenderen opp. 