### PR TITLE
Dark mode støtte for switches, pluss fjerning av variants

### DIFF
--- a/.changeset/clean-bags-remain.md
+++ b/.changeset/clean-bags-remain.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-input-react": patch
+"@vygruppen/spor-theme-react": patch
+---
+
+Add support for dark mode on switches

--- a/apps/docs/app/features/interactive-code/LivePreview.tsx
+++ b/apps/docs/app/features/interactive-code/LivePreview.tsx
@@ -1,11 +1,44 @@
-import { Box, BoxProps } from "@vygruppen/spor-react";
+import { ColorModeProvider, Flex } from "@chakra-ui/react";
+import {
+  Box,
+  BoxProps,
+  FormControl,
+  IconButton,
+  NightFill24Icon,
+  SummerFill24Icon,
+} from "@vygruppen/spor-react";
+import { useState } from "react";
 import { LivePreview as ReactLivePreview } from "react-live";
 
 export const LivePreview = (props: BoxProps) => {
+  const [isDarkMode, setDarkMode] = useState(false);
   return (
-    <Box borderRadius="sm" border="sm" borderColor="osloGrey" p={4} {...props}>
-      {/** @ts-ignore Bad typing in React Live */}
-      <ReactLivePreview Component={Box} width="100%" />
-    </Box>
+    <ColorModeProvider value={isDarkMode ? "dark" : "light"}>
+      <Box
+        borderRadius="sm"
+        border="sm"
+        borderColor="osloGrey"
+        backgroundColor={isDarkMode ? "darkGrey" : "white"}
+        color={isDarkMode ? "white" : "darkGrey"}
+        transition="all .1s ease-out"
+        p={4}
+        position="relative"
+        {...props}
+      >
+        <FormControl position="absolute" top={2} right={2}>
+          <Flex justifyContent="flex-end">
+            <IconButton
+              size="sm"
+              variant="additional"
+              onClick={() => setDarkMode((d) => !d)}
+              icon={isDarkMode ? <SummerFill24Icon /> : <NightFill24Icon />}
+              aria-label={isDarkMode ? "Dark mode" : "Light mode"}
+            />
+          </Flex>
+        </FormControl>
+        {/** @ts-ignore Bad typing in React Live */}
+        <ReactLivePreview Component={Box} width="100%" />
+      </Box>
+    </ColorModeProvider>
   );
 };

--- a/apps/docs/app/features/portable-text/PortableText.tsx
+++ b/apps/docs/app/features/portable-text/PortableText.tsx
@@ -234,17 +234,18 @@ const components: Partial<PortableTextReactComponents> = {
     codeExample: ({ value }) => {
       const code = value.reactCode.code;
 
-      const showCodeBlock = value.layout === "code-only";
+      if (value.layout === "code-only") {
+        return <CodeBlock marginY={3} language="tsx" code={code} />;
+      }
 
-      return showCodeBlock ? (
-        <CodeBlock my={3} language="tsx" code={code} />
-      ) : (
-        <InteractiveCode
-          layout={value.layout}
-          my={3}
-          maxWidth={`calc(100vw - var(--spor-space-6))`}
-          code={code}
-        />
+      return (
+        <Box paddingBottom={3}>
+          <InteractiveCode
+            layout={value.layout}
+            maxWidth={`calc(100vw - var(--spor-space-6))`}
+            code={code}
+          />
+        </Box>
       );
     },
     component: ({ value }) => {

--- a/apps/docs/app/root.tsx
+++ b/apps/docs/app/root.tsx
@@ -1,3 +1,4 @@
+import { ColorModeScript } from "@chakra-ui/react";
 import { withEmotionCache } from "@emotion/react";
 import { json, LinksFunction, MetaFunction } from "@remix-run/node";
 import {
@@ -160,6 +161,7 @@ const Document = withEmotionCache(
           ))}
         </head>
         <body>
+          <ColorModeScript />
           <RootProviders>{children}</RootProviders>
           <ScrollRestoration />
           <Scripts />

--- a/packages/spor-input-react/src/Switch.tsx
+++ b/packages/spor-input-react/src/Switch.tsx
@@ -6,6 +6,7 @@ import {
 import React from "react";
 
 export type SwitchProps = Exclude<ChakraSwitchProps, "colorScheme"> & {
+  /** @deprecated The outline variant is deprecated. Stop using the variant prop, as it will no longer apply */
   variant?: "solid" | "outline";
   size?: "sm" | "md" | "lg";
 };
@@ -32,7 +33,7 @@ export type SwitchProps = Exclude<ChakraSwitchProps, "colorScheme"> & {
  * ```
  */
 export const Switch = forwardRef<SwitchProps, "input">(
-  ({ variant = "solid", size = "md", ...props }: SwitchProps, ref) => {
-    return <ChakraSwitch variant={variant} size={size} {...props} ref={ref} />;
+  ({ size = "md", ...props }: SwitchProps, ref) => {
+    return <ChakraSwitch variant="solid" size={size} {...props} ref={ref} />;
   }
 );

--- a/packages/spor-theme-react/src/components/switch.ts
+++ b/packages/spor-theme-react/src/components/switch.ts
@@ -1,7 +1,9 @@
 import { switchAnatomy as parts } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import { calc, cssVar } from "@chakra-ui/theme-tools";
+import { calc, cssVar, mode } from "@chakra-ui/theme-tools";
 import { colors } from "../foundations";
+import { getBoxShadowString } from "../utils/box-shadow-utils";
+import { focusVisible } from "../utils/focus-utils";
 
 const $width = cssVar("switch-track-width");
 const $height = cssVar("switch-track-height");
@@ -27,8 +29,7 @@ const config = helpers.defineMultiStyleConfig({
       transitionDuration: "fast",
 
       _disabled: {
-        opacity: 0.4,
-        cursor: "not-allowed",
+        pointerEvents: "none",
       },
     },
     thumb: {
@@ -43,31 +44,117 @@ const config = helpers.defineMultiStyleConfig({
     },
   },
   variants: {
-    solid: {
+    solid: ({ colorMode }) => ({
       track: {
         backgroundColor: "osloGrey",
+        boxShadow: mode(
+          "none",
+          getBoxShadowString({
+            borderColor: colors.whiteAlpha[400],
+          })
+        )({ colorMode }),
 
-        _focus: {
-          boxShadow: "outline",
-        },
+        ...focusVisible({
+          focus: {
+            boxShadow: mode(
+              getBoxShadowString([
+                {
+                  borderColor: "white",
+                  borderWidth: 2,
+                  isInset: false,
+                },
+                {
+                  borderColor: "primaryGreen",
+                  borderWidth: 4,
+                  isInset: false,
+                },
+              ]),
+              getBoxShadowString({
+                borderColor: "coralGreen",
+                borderWidth: 2,
+                isInset: false,
+              })
+            )({ colorMode }),
+          },
+          notFocus: {
+            boxShadow: mode(
+              "none",
+              getBoxShadowString({
+                borderColor: colors.whiteAlpha[400],
+              })
+            )({ colorMode }),
+          },
+        }),
         _hover: {
           backgroundColor: "steel",
+          boxShadow: mode(
+            "none",
+            getBoxShadowString({ borderColor: colors.white })
+          )({ colorMode }),
         },
         _checked: {
-          backgroundColor: "darkTeal",
+          backgroundColor: mode("darkTeal", "celadon")({ colorMode }),
+          ...focusVisible({
+            focus: {
+              boxShadow: mode(
+                getBoxShadowString([
+                  {
+                    borderColor: "white",
+                    borderWidth: 2,
+                    isInset: false,
+                  },
+                  {
+                    borderColor: "primaryGreen",
+                    borderWidth: 4,
+                    isInset: false,
+                  },
+                ]),
+                getBoxShadowString({
+                  borderWidth: 2,
+                  borderColor: "coralGreen",
+                  isInset: false,
+                })
+              )({ colorMode }),
+            },
+            notFocus: {
+              boxShadow: mode(
+                "none",
+                getBoxShadowString({ borderColor: colors.white })
+              )({ colorMode }),
+            },
+          }),
+
           _hover: {
-            backgroundColor: "pine",
+            backgroundColor: mode("pine", "river")({ colorMode }),
+            boxShadow: mode(
+              "none",
+              getBoxShadowString({ borderColor: colors.white })
+            )({ colorMode }),
           },
-          _focus: {
-            boxShadow: `0 0 0 4px ${colors.greenHaze}, 0 0 0 2px ${colors.white}`,
+        },
+        _disabled: {
+          backgroundColor: mode("platinum", "dimGrey")({ colorMode }),
+          boxShadow: mode(
+            "none",
+            getBoxShadowString({ borderColor: colors.whiteAlpha[400] })
+          )({ colorMode }),
+          _checked: {
+            backgroundColor: mode("platinum", "dimGrey")({ colorMode }),
+            boxShadow: mode(
+              "none",
+              getBoxShadowString({ borderColor: colors.whiteAlpha[400] })
+            )({ colorMode }),
           },
         },
       },
 
       thumb: {
         backgroundColor: "white",
+        "[data-disabled] &": {
+          backgroundColor: "steel",
+        },
       },
-    },
+    }),
     outline: {
       track: {
         backgroundColor: "platinum",

--- a/packages/spor-theme-react/src/utils/box-shadow-utils.ts
+++ b/packages/spor-theme-react/src/utils/box-shadow-utils.ts
@@ -10,12 +10,14 @@ type GetBoxShadowStringArgs = {
 /**
  * A utility for creating box shadow strings
  */
-export const getBoxShadowString = ({
-  baseShadow,
-  borderColor,
-  borderWidth = 1,
-  isInset = true,
-}: GetBoxShadowStringArgs) => {
+export const getBoxShadowString = (
+  args: GetBoxShadowStringArgs | GetBoxShadowStringArgs[]
+): string => {
+  if (Array.isArray(args)) {
+    return args.map((arg) => getBoxShadowString(arg)).join(", ");
+  }
+
+  const { baseShadow, borderColor, borderWidth = 1, isInset = true } = args;
   const allShadows: string[] = [];
 
   if (borderColor) {

--- a/packages/spor-theme-react/src/utils/focus-utils.ts
+++ b/packages/spor-theme-react/src/utils/focus-utils.ts
@@ -12,5 +12,5 @@ type FocusArgs = {
 export const focusVisible = ({ notFocus, focus }: FocusArgs) => ({
   _focus: focus,
   _focusVisible: focus,
-  "&:focus:not(:focus-visible)": notFocus,
+  "&[data-focus]:not([data-focus-visible])": notFocus,
 });


### PR DESCRIPTION
Denne endringen introduserer tre ting:
- Dark mode støtte for switches
- Deprekering av outline-varianten for switches
- Støtte for å toggle dark mode i kode-eksemplene.

![2022-11-18 15 14 02](https://user-images.githubusercontent.com/1307267/202724603-8f1818f6-a499-47ec-ba41-455f3e5e08ab.gif)

I tillegg fikset jeg et par bugs som har gjort at focus states har vært litt buggy.