### PR TITLE
Add bold VySans for Elm

### DIFF
--- a/packages/spor-elm/src/Spor/Internal/TextStyle.elm
+++ b/packages/spor-elm/src/Spor/Internal/TextStyle.elm
@@ -65,6 +65,46 @@ toCss textStyle =
                 [ Css.fontSize (Css.rem 0.875) ]
             ]
 
+        TextStyle.ExtraLargeSansBold ->
+            [ Css.fontFamilies [ "VySans bold" ]
+            , Css.lineHeight (Css.num 1.333)
+            , Css.fontSize (Css.rem 2.5)
+            , mediaQuery Breakpoint.sm
+                [ Css.fontSize (Css.rem 1.875) ]
+            ]
+
+        TextStyle.LargeBold ->
+            [ Css.fontFamilies [ "VySans bold" ]
+            , Css.lineHeight (Css.num 1.333)
+            , Css.fontSize (Css.rem 1.875)
+            , mediaQuery Breakpoint.sm
+                [ Css.fontSize (Css.rem 1.5) ]
+            ]
+
+        TextStyle.MediumBold ->
+            [ Css.fontFamilies [ "VySans bold" ]
+            , Css.lineHeight (Css.num 1.333)
+            , Css.fontSize (Css.rem 1.5)
+            , mediaQuery Breakpoint.sm
+                [ Css.fontSize (Css.rem 1.125) ]
+            ]
+
+        TextStyle.SmallBold ->
+            [ Css.fontFamilies [ "VySans bold" ]
+            , Css.lineHeight (Css.num 1.333)
+            , Css.fontSize (Css.rem 1.125)
+            , mediaQuery Breakpoint.sm
+                [ Css.fontSize (Css.rem 1) ]
+            ]
+
+        TextStyle.ExtraSmallBold ->
+            [ Css.fontFamilies [ "VySans bold" ]
+            , Css.lineHeight (Css.num 1.333)
+            , Css.fontSize (Css.rem 1)
+            , mediaQuery Breakpoint.sm
+                [ Css.fontSize (Css.rem 0.875) ]
+            ]
+
 
 mediaQuery : Breakpoint -> List Css.Style -> Css.Style
 mediaQuery breakpoint styles =

--- a/packages/spor-elm/src/Spor/LineTag/LineText.elm
+++ b/packages/spor-elm/src/Spor/LineTag/LineText.elm
@@ -81,10 +81,8 @@ toHtml (LineText options) =
         ]
         [ Html.span
             [ Attributes.css <|
-                [ Css.color <| Alias.toCss Alias.darkGrey
-                , Css.fontWeight Css.bold
-                ]
-                    ++ TextStyle.toCss TextStyle.ExtraSmall
+                (Css.color <| Alias.toCss Alias.darkGrey)
+                    :: TextStyle.toCss TextStyle.ExtraSmall
             ]
             [ Html.text options.title ]
         , description options

--- a/packages/spor-elm/src/Spor/TextStyle.elm
+++ b/packages/spor-elm/src/Spor/TextStyle.elm
@@ -19,3 +19,8 @@ type TextStyle
     | Medium
     | Small
     | ExtraSmall
+    | ExtraLargeSansBold
+    | LargeBold
+    | MediumBold
+    | SmallBold
+    | ExtraSmallBold


### PR DESCRIPTION
We are launching new line tags. The font is a bit fuzzy on web, due to using `VySans` with `fontWeight` `bold`. 

We should rather use `VySans bold` for this (which did not exist here yet).


| Before | After |
| --- | ----------- |
| ![Skjermbilde 2022-12-07 kl  15 16 39](https://user-images.githubusercontent.com/15145686/206203557-d334b0fa-c268-42b6-baec-1edb85283a92.png) | ![Skjermbilde 2022-12-07 kl  15 16 50](https://user-images.githubusercontent.com/15145686/206203560-5e5d183b-91a6-44b9-8043-3e26d1f4b7c4.png) |




