### PR TITLE
Fiks bug for tom timepicker input

### DIFF
--- a/.changeset/hot-gifts-mate.md
+++ b/.changeset/hot-gifts-mate.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Fix a bug where wiping the value would crash the time picker component

--- a/packages/spor-datepicker-react/src/TimeField.tsx
+++ b/packages/spor-datepicker-react/src/TimeField.tsx
@@ -38,7 +38,7 @@ export const TimeField = ({ state, label, ...props }: TimeFieldProps) => {
       </Flex>
       <input
         type="hidden"
-        value={getTimestampFromTime(state.value as CalendarDateTime)}
+        value={getTimestampFromTime(state.value as CalendarDateTime | null)}
         name={props.name}
       />
     </Box>

--- a/packages/spor-datepicker-react/src/TimePicker.tsx
+++ b/packages/spor-datepicker-react/src/TimePicker.tsx
@@ -80,9 +80,12 @@ export const TimePicker = ({
     isDisabled,
   });
 
-  const dateTime = state.value as CalendarDateTime;
+  const dateTime = state.value as CalendarDateTime | null;
 
   const handleBackwardsClick = () => {
+    if (!dateTime) {
+      return;
+    }
     const minutesToSubtract =
       dateTime.minute % minuteInterval || minuteInterval;
     state.setValue(
@@ -92,6 +95,9 @@ export const TimePicker = ({
     );
   };
   const handleForwardClick = () => {
+    if (!dateTime) {
+      return;
+    }
     const minutesToAdd =
       minuteInterval - (dateTime.minute % minuteInterval) || minuteInterval;
     state.setValue(
@@ -108,7 +114,7 @@ export const TimePicker = ({
   )}`;
   const inputLabel = label ?? t(texts.time);
   const ariaLabel = `${inputLabel} – ${t(
-    texts.selectedTimeIs(`${dateTime.hour} ${dateTime.minute}`)
+    texts.selectedTimeIs(`${dateTime?.hour ?? 0} ${dateTime?.minute ?? 0}`)
   )}`;
   return (
     <StyledField

--- a/packages/spor-datepicker-react/src/utils.ts
+++ b/packages/spor-datepicker-react/src/utils.ts
@@ -28,6 +28,6 @@ export const getCurrentTime = () => {
 };
 
 /** Gets a readable timestamp from a given time object */
-export const getTimestampFromTime = (time: CalendarDateTime) => {
-  return `${time.hour}:${time.minute}`;
+export const getTimestampFromTime = (time: CalendarDateTime | null) => {
+  return `${time?.hour ?? 0}:${time?.minute ?? 0}`;
 };


### PR DESCRIPTION
Dette fikser en bug for når man fjerner alle verdiene i en timepicker (backspacer vekk alle tallene, for eksempel). 

Takk til @FluidSense for å ha oppdaget buggen!