### PR TITLE
Fiks en følgefeil i Datepicker

### DIFF
--- a/.changeset/sour-impalas-juggle.md
+++ b/.changeset/sour-impalas-juggle.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Fix a bug where the datepicker would crash

--- a/apps/docs/app/features/root-providers/RootProviders.tsx
+++ b/apps/docs/app/features/root-providers/RootProviders.tsx
@@ -1,4 +1,5 @@
 import { Language, SporProvider } from "@vygruppen/spor-react";
+import { SSRProvider } from "react-aria";
 import { PortableTextProvider } from "../portable-text/PortableText";
 
 type RootProvidersProps = { children: React.ReactNode };
@@ -9,8 +10,11 @@ type RootProvidersProps = { children: React.ReactNode };
  */
 export const RootProviders = ({ children }: RootProvidersProps) => {
   return (
-    <SporProvider language={Language.NorwegianBokmal}>
-      <PortableTextProvider>{children}</PortableTextProvider>
-    </SporProvider>
+    <SSRProvider>
+      <SporProvider language={Language.NorwegianBokmal}>
+        <PortableTextProvider>
+        {children}</PortableTextProvider>
+      </SporProvider>
+    </SSRProvider>
   );
 };

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,6 +31,7 @@
     "prism-react-renderer": "^1.3.5",
     "prismjs": "^1.29.0",
     "react": "^18.2.0",
+    "react-aria": "^3.22.0",
     "react-dom": "^18.2.0",
     "react-live": "^3.1.1",
     "remix-utils": "^5.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30873,8 +30873,8 @@
         "@vygruppen/spor-icon-react": "*",
         "@vygruppen/spor-input-react": "*",
         "@vygruppen/spor-typography-react": "*",
-        "react-aria": "^3.18.0",
-        "react-stately": "^3.16.0"
+        "react-aria": "^3.22.0",
+        "react-stately": "^3.20.0"
       },
       "devDependencies": {
         "@chakra-ui/react": "^2.3.5",
@@ -40352,9 +40352,9 @@
         "@vygruppen/spor-typography-react": "*",
         "framer-motion": "^6.0.0",
         "react": "^18.2.0",
-        "react-aria": "^3.18.0",
+        "react-aria": "^3.22.0",
         "react-dom": "^18.2.0",
-        "react-stately": "^3.16.0",
+        "react-stately": "^3.20.0",
         "tsup": "^6.2.2",
         "vitest": "^0.26.3",
         "vitest-axe": "^0.1.0"

--- a/packages/spor-datepicker-react/package.json
+++ b/packages/spor-datepicker-react/package.json
@@ -49,7 +49,7 @@
     "@vygruppen/spor-icon-react": "*",
     "@vygruppen/spor-input-react": "*",
     "@vygruppen/spor-typography-react": "*",
-    "react-aria": "^3.18.0",
-    "react-stately": "^3.16.0"
+    "react-aria": "^3.22.0",
+    "react-stately": "^3.20.0"
   }
 }

--- a/packages/spor-datepicker-react/src/DateTimeSegment.tsx
+++ b/packages/spor-datepicker-react/src/DateTimeSegment.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@chakra-ui/react";
+import { useDateSegment } from "@react-aria/datepicker";
 import React, { useRef } from "react";
-import { useDateSegment } from "react-aria";
 import { DateFieldState, DateSegment } from "react-stately";
 
 type DateTimeSegmentProps = {
@@ -16,6 +16,7 @@ type DateTimeSegmentProps = {
  * */
 export const DateTimeSegment = ({ segment, state }: DateTimeSegmentProps) => {
   const ref = useRef(null);
+
   const { segmentProps } = useDateSegment(segment, state, ref);
   return (
     <Box
@@ -26,7 +27,6 @@ export const DateTimeSegment = ({ segment, state }: DateTimeSegmentProps) => {
         fontVariantNumeric: "tabular-nums",
         boxSizing: "content-box",
       }}
-      boxSizing="content-box"
       px="1px"
       textAlign="end"
       outline="none"

--- a/packages/spor-datepicker-react/src/TimeField.tsx
+++ b/packages/spor-datepicker-react/src/TimeField.tsx
@@ -1,8 +1,8 @@
 import { Box, Flex } from "@chakra-ui/react";
 import { CalendarDateTime, Time } from "@internationalized/date";
+import { AriaTimeFieldProps, useTimeField } from "@react-aria/datepicker";
 import { FormLabel } from "@vygruppen/spor-input-react";
 import React, { useRef } from "react";
-import { AriaTimeFieldProps, useTimeField } from "react-aria";
 import { DateFieldState } from "react-stately";
 import { DateTimeSegment } from "./DateTimeSegment";
 import { getTimestampFromTime } from "./utils";


### PR DESCRIPTION
Denne fikser en bug der Datepicker ikke fungerte lenger fordi, wait for it, jeg hadde importert to hooks fra to forskjellige pakker.

TIL at `useDateSegment` må være importert fra samme pakke i både `TimeField` og `DateField`. Og ikke `react-aria` det ene stedet, og `@react-aria/datepicker` det andre. Utrolig irriterende at det overhodet går an.

Det var den arbeidsdagen 😅