### PR TITLE
Fiks en fargebug med deviation icons på travel tags

### DIFF
--- a/.changeset/gold-eggs-cheat.md
+++ b/.changeset/gold-eggs-cheat.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-theme-react": patch
+"@vygruppen/spor-linjetag-react": patch
+---
+
+Fix some broken colors

--- a/packages/spor-theme-react/src/components/travel-tag.ts
+++ b/packages/spor-theme-react/src/components/travel-tag.ts
@@ -250,6 +250,16 @@ const getDeviationIconStyle = (props: StyleFunctionProps) => {
     top: "-7px",
     right: "-7px",
     stroke: "white",
-    color: props.deviationLevel === "info" ? "ocean" : "inherit",
+    color:
+      deviationIconColor[
+        props.deviationLevel as keyof typeof deviationIconColor
+      ] || "inherit",
   };
 };
+
+const deviationIconColor = {
+  critical: "brightRed",
+  major: "golden",
+  minor: "golden",
+  info: "ocean",
+} as const;


### PR DESCRIPTION
Denne PRen fikser en bug der fargene hadde forsvunnet fra noen travel tag devlation icons.