### PR TITLE
Ny komponent: CardSelect

### DIFF
--- a/.changeset/good-coins-marry.md
+++ b/.changeset/good-coins-marry.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-input-react": minor
+"@vygruppen/spor-theme-react": patch
+---
+
+New component: Card Select

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "prism-react-renderer": "^1.3.5",
         "prismjs": "^1.29.0",
         "react": "^18.2.0",
+        "react-aria": "^3.22.0",
         "react-dom": "^18.2.0",
         "react-live": "^3.1.1",
         "remix-utils": "^5.1.0",
@@ -30863,7 +30864,7 @@
     },
     "packages/spor-datepicker-react": {
       "name": "@vygruppen/spor-datepicker-react",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@internationalized/date": "^3.0.1",
@@ -31919,6 +31920,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
+        "@vygruppen/spor-card-react": "*",
         "@vygruppen/spor-i18n-react": "*",
         "@vygruppen/spor-icon-react": "*",
         "react-aria": "^3.21.0",
@@ -40144,6 +40146,7 @@
         "prism-react-renderer": "^1.3.5",
         "prismjs": "^1.29.0",
         "react": "^18.2.0",
+        "react-aria": "^3.22.0",
         "react-dom": "^18.2.0",
         "react-live": "^3.1.1",
         "remix-utils": "^5.1.0",
@@ -41155,6 +41158,7 @@
         "@chakra-ui/react": "^2.3.5",
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
+        "@vygruppen/spor-card-react": "*",
         "@vygruppen/spor-i18n-react": "*",
         "@vygruppen/spor-icon-react": "*",
         "framer-motion": ">6.0.0",

--- a/packages/spor-input-react/package.json
+++ b/packages/spor-input-react/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@vygruppen/spor-i18n-react": "*",
     "@vygruppen/spor-icon-react": "*",
+    "@vygruppen/spor-card-react": "*",
     "react-aria": "^3.21.0",
     "react-stately": "^3.19.0"
   },

--- a/packages/spor-input-react/src/CardSelect.tsx
+++ b/packages/spor-input-react/src/CardSelect.tsx
@@ -1,0 +1,158 @@
+import {
+  Box,
+  BoxProps,
+  chakra,
+  Flex,
+  forwardRef,
+  useMultiStyleConfig,
+} from "@chakra-ui/react";
+import { Card } from "@vygruppen/spor-card-react";
+import {
+  DropdownDownFill24Icon,
+  DropdownUpFill24Icon,
+} from "@vygruppen/spor-icon-react";
+import React, { useEffect, useRef, useState } from "react";
+import { AriaPositionProps, useButton, useOverlayTrigger } from "react-aria";
+import { useOverlayTriggerState } from "react-stately";
+import { Popover } from "./Popover";
+
+type CardSelectProps = BoxProps & {
+  /** The design of the trigger button.
+   *
+   * - `ghost` is a transparent button with text
+   * - `outline` is a button with a border and text
+   * - `card` is a button with a drop shadow (like a card) and text
+   */
+  variant: "ghost" | "outline" | "card";
+  /** The size of the trigger button */
+  size: "sm" | "md" | "lg";
+  /** Whether the card select is open / active, if controlled */
+  isOpen?: boolean;
+  /** The default state of the card select. Defaults to false (closed) */
+  defaultOpen?: boolean;
+  /** Callback for when the card select opens or closes. */
+  onToggle?: (isOpen: boolean) => void;
+  /** The text of the trigger button */
+  label: string;
+  /** An optional trigger button icon, rendered to the left of the label */
+  icon?: React.ReactNode;
+  /** The content of the card select */
+  children: React.ReactNode;
+  /** The horizontalOffset of the popover card */
+  crossOffset?: number;
+  /** The position of the popover card */
+  placement?: AriaPositionProps["placement"];
+};
+
+/**
+ * A card select component.
+ *
+ * This component consists of a trigger button and a card select popover. The trigger button has several different variants and sizes, and can have an optional icon.
+ *
+ * ```tsx
+ * <CardSelect label="Languages" variant="card" size="md">
+ *   <LanguageSettings />
+ * </CardSelect>
+ * ```
+ *
+ * @see https://spor.cloud.vy.no/komponenter/card-select
+ */
+export const CardSelect = forwardRef<CardSelectProps, "button">(
+  (
+    {
+      variant,
+      size,
+      isOpen: externalIsOpen,
+      defaultOpen = false,
+      onToggle,
+      label,
+      icon,
+      children,
+      width = "fit-content",
+      crossOffset = 0,
+      placement = "bottom",
+      ...props
+    },
+    externalRef
+  ) => {
+    const internalRef = useRef<HTMLButtonElement>(null);
+    const triggerRef = (externalRef ??
+      internalRef) as React.RefObject<HTMLButtonElement>;
+
+    const state = useOverlayTriggerState({
+      isOpen: externalIsOpen,
+      onOpenChange: onToggle,
+      defaultOpen,
+    });
+    const { triggerProps, overlayProps } = useOverlayTrigger(
+      { type: "dialog" },
+      state,
+      triggerRef
+    );
+
+    const { buttonProps } = useButton(triggerProps, triggerRef);
+
+    const styles = useMultiStyleConfig("CardSelect", { variant, size });
+    useForceRerender(state.isOpen);
+
+    return (
+      <Box {...props}>
+        <chakra.button
+          type="button"
+          ref={triggerRef}
+          sx={styles.trigger}
+          {...buttonProps}
+          width={width}
+        >
+          <Flex gap={1.5} alignItems="center">
+            {icon}
+            <Box as="span">{label}</Box>
+            {state.isOpen ? (
+              <DropdownUpFill24Icon aria-hidden="true" />
+            ) : (
+              <DropdownDownFill24Icon aria-hidden="true" />
+            )}
+          </Flex>
+        </chakra.button>
+        {state.isOpen && (
+          <Popover
+            state={state}
+            triggerRef={triggerRef}
+            offset={size === "sm" ? 6 : 12}
+            crossOffset={crossOffset}
+            placement={placement}
+          >
+            <Card
+              colorScheme="white"
+              size="lg"
+              sx={styles.card}
+              {...overlayProps}
+            >
+              {children}
+            </Card>
+          </Popover>
+        )}
+      </Box>
+    );
+  }
+);
+
+/**
+ * Hold my beer.
+ *
+ * This is a workaround for a "bug" in react-aria where the overlay doesn't
+ * calculate the placement correctly for some reason.
+ *
+ * This is a hack, which forces React to rerender the component one extra time
+ * after the state changes from closed to open.
+ *
+ * There is probably a better way to do this, but I could not come up with one.
+ */
+function useForceRerender(shouldRerender: boolean) {
+  const [_, update] = useState(false);
+  useEffect(() => {
+    if (shouldRerender) {
+      update((x) => !x);
+    }
+  }, [shouldRerender]);
+}

--- a/packages/spor-input-react/src/InfoSelect.tsx
+++ b/packages/spor-input-react/src/InfoSelect.tsx
@@ -46,11 +46,11 @@ type InfoSelectProps = {
   children: any;
   /**
    * The items to render
-   * 
+   *
    * If you have a dynamic list of items you want to display, you should use this prop instead of mapping them out. This is a performance optimization.
-   * 
+   *
    * You can render each item in a render function, passed in as `children`:
-   * 
+   *
    * ```tsx
    * <Select items={items}>
    *   {(item) => <div>{item.someProp}</div>}

--- a/packages/spor-input-react/src/ListBox.tsx
+++ b/packages/spor-input-react/src/ListBox.tsx
@@ -33,7 +33,7 @@ export const ListBox = forwardRef<HTMLUListElement, ListBoxProps>(
     const styles = useMultiStyleConfig("ListBox", {});
     const internalRef = useRef<HTMLUListElement>(null);
     const listBoxRef = (ref ?? internalRef) as RefObject<HTMLUListElement>;
-    let { listBoxProps } = useListBox(props, state, listBoxRef);
+    const { listBoxProps } = useListBox(props, state, listBoxRef);
 
     return (
       <Box

--- a/packages/spor-input-react/src/Popover.tsx
+++ b/packages/spor-input-react/src/Popover.tsx
@@ -1,38 +1,70 @@
 import { Box } from "@chakra-ui/react";
-import React, { forwardRef, RefObject, useRef } from "react";
-import { DismissButton, Overlay, usePopover } from "react-aria";
-import { SelectState } from "react-stately";
+import React, { useRef } from "react";
+import {
+  AriaPopoverProps,
+  DismissButton,
+  Overlay,
+  usePopover,
+} from "react-aria";
+import { OverlayTriggerState } from "react-stately";
 
 type PopoverProps = {
+  /** The content to be shown as a popover */
   children: React.ReactNode;
-  state: SelectState<unknown>;
+  /** The internal state of the overlay trigger element.
+   *
+   * Get this from the useOverlayTriggerState hook or similar.
+   */
+  state: OverlayTriggerState;
+  /** The reference to the trigger button for this overlay */
   triggerRef: React.RefObject<HTMLButtonElement>;
+  /** The offset in pixels between the bottom of the trigger and the top of the popover */
+  offset?: number;
+  /** The cross-axis offset (left or right) of the popover, compared to the center of the trigger element  */
+  crossOffset?: number;
+  /** The position of the popover, relative to the popover.
+   *
+   * Defaults to "bottom"
+   */
+  placement?: AriaPopoverProps["placement"];
 };
-export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
-  ({ children, state, ...props }, ref) => {
-    const internalRef = useRef<HTMLDivElement>();
-    const popoverRef = (ref ?? internalRef) as RefObject<HTMLDivElement>;
-    const { popoverProps, underlayProps } = usePopover(
-      {
-        ...props,
-        popoverRef,
-      },
-      state
-    );
+/**
+ * Internal popover component.
+ *
+ * Used to render accessible popover content, like a  dropdown menu or a card select. Should not be used directly, but as a part of Spor components.
+ */
+export const Popover = ({
+  children,
+  state,
+  triggerRef,
+  offset = 0,
+  crossOffset = 0,
+  placement = "bottom",
+}: PopoverProps) => {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const { popoverProps, underlayProps } = usePopover(
+    {
+      triggerRef,
+      popoverRef,
+      offset,
+      crossOffset,
+      placement,
+    },
+    state
+  );
 
-    return (
-      <Overlay>
-        <Box {...underlayProps} position="fixed" inset="0" />
-        <Box
-          {...popoverProps}
-          ref={popoverRef}
-          minWidth={props.triggerRef.current?.clientWidth ?? "auto"}
-        >
-          <DismissButton onDismiss={state.close} />
-          {children}
-          <DismissButton onDismiss={state.close} />
-        </Box>
-      </Overlay>
-    );
-  }
-);
+  return (
+    <Overlay>
+      <Box {...underlayProps} position="fixed" inset="0" />
+      <Box
+        {...popoverProps}
+        ref={popoverRef}
+        minWidth={triggerRef.current?.clientWidth ?? "auto"}
+      >
+        <DismissButton onDismiss={state.close} />
+        {children}
+        <DismissButton onDismiss={state.close} />
+      </Box>
+    </Overlay>
+  );
+};

--- a/packages/spor-input-react/src/index.tsx
+++ b/packages/spor-input-react/src/index.tsx
@@ -1,5 +1,6 @@
 export { FormHelperText, InputGroup } from "@chakra-ui/react";
 export type { InputGroupProps } from "@chakra-ui/react";
+export * from "./CardSelect";
 export * from "./Checkbox";
 export * from "./CheckboxGroup";
 export * from "./ChoiceChip";
@@ -10,10 +11,10 @@ export * from "./InfoSelect";
 export * from "./Input";
 export * from "./InputElement";
 export * from "./ListBox";
+export * from "./NativeSelect";
 export * from "./PasswordInput";
 export * from "./Radio";
 export * from "./RadioGroup";
 export * from "./SearchInput";
-export * from "./NativeSelect";
 export * from "./Switch";
 export * from "./Textarea";

--- a/packages/spor-theme-react/src/components/card-select.ts
+++ b/packages/spor-theme-react/src/components/card-select.ts
@@ -1,0 +1,79 @@
+import { anatomy } from "@chakra-ui/anatomy";
+import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
+import { mode } from "@chakra-ui/theme-tools";
+import { getBoxShadowString } from "../utils/box-shadow-utils";
+import { focusVisible } from "../utils/focus-utils";
+
+const parts = anatomy("card-select").parts("trigger", "card");
+
+const helpers = createMultiStyleConfigHelpers(parts.keys);
+const config = helpers.defineMultiStyleConfig({
+  baseStyle: (props) => ({
+    trigger: {
+      appearance: "none",
+      display: "flex",
+      alignItems: "center",
+      borderRadius: "sm",
+      _expanded: {
+        backgroundColor: mode("mint", "night")(props),
+      },
+      ...focusVisible({
+        notFocus: {},
+        focus: {
+          boxShadow: getBoxShadowString({
+            borderColor: "greenHaze",
+            borderWidth: 3,
+          }),
+          outline: "none",
+        },
+      }),
+    },
+    card: {
+      borderRadius: "sm",
+      boxShadow: "md",
+      padding: 3,
+    },
+  }),
+  variants: {
+    ghost: {
+      trigger: {},
+    },
+    outline: (props) => ({
+      trigger: {
+        boxShadow: getBoxShadowString({
+          borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
+        }),
+      },
+    }),
+    card: {
+      trigger: {
+        boxShadow: "sm",
+      },
+    },
+  },
+  sizes: {
+    sm: {
+      trigger: {
+        paddingX: 1.5,
+        paddingY: 1,
+        minHeight: "1.25rem",
+      },
+    },
+    md: {
+      trigger: {
+        paddingX: 2,
+        paddingY: 1.5,
+        minHeight: "2.625rem",
+      },
+    },
+    lg: {
+      trigger: {
+        paddingX: 3,
+        paddingY: 2,
+        minHeight: "3.375rem",
+      },
+    },
+  },
+});
+
+export default config;

--- a/packages/spor-theme-react/src/components/index.ts
+++ b/packages/spor-theme-react/src/components/index.ts
@@ -3,6 +3,7 @@ export { default as Alert } from "./alert";
 export { default as Badge } from "./badge";
 export { default as Button } from "./button";
 export { default as Card } from "./card";
+export { default as CardSelect } from "./card-select";
 export { default as Checkbox } from "./checkbox";
 export { default as ChoiceChip } from "./choice-chip";
 export { default as CloseButton } from "./close-button";

--- a/packages/spor-theme-react/src/utils/box-shadow-utils.ts
+++ b/packages/spor-theme-react/src/utils/box-shadow-utils.ts
@@ -1,4 +1,4 @@
-import { colors } from "../foundations/colors";
+import { colors, ColorsType } from "../foundations/colors";
 import { shadows } from "../foundations/shadows";
 
 type GetBoxShadowStringArgs = {
@@ -24,6 +24,14 @@ export const getBoxShadowString = (
     let color = borderColor;
     if (borderColor in colors) {
       color = colors[borderColor as keyof typeof colors] as string;
+    } else {
+      const [subgroup, value] = borderColor.split(".");
+      const subgroupValue = (colors[subgroup as keyof ColorsType] as any)?.[
+        value
+      ];
+      if (subgroupValue) {
+        color = subgroupValue;
+      }
     }
     allShadows.push(
       `${isInset ? "inset " : ""}0 0 0 ${borderWidth}px ${color}`


### PR DESCRIPTION
Denne pull requesten legger til støtte for en ny type "select" - nemlig en "Card Select"!

Card Selects er i bunn og grunn bare en spesialdesignet trigger-knapp, som viser frem et flytende popover-kort når man trykker på den.

Slik ser det ut:

![2023-01-18 12 36 32](https://user-images.githubusercontent.com/1307267/213161704-b8c0978e-ed93-4a18-a90d-3169ed013ba9.gif)

Det er basert på React Aria, så det burde funke godt med skjermleser også