### PR TITLE
Legg til støtte for flere linjer med tekst i knapper

### DIFF
--- a/.changeset/swift-hairs-enjoy.md
+++ b/.changeset/swift-hairs-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-theme-react": patch
+"@vygruppen/spor-button-react": patch
+---
+
+Let buttons span several lines

--- a/packages/spor-theme-react/src/components/button.ts
+++ b/packages/spor-theme-react/src/components/button.ts
@@ -9,7 +9,6 @@ const config = defineStyleConfig({
     border: 0,
     borderRadius: "xl",
     fontWeight: "bold",
-    whiteSpace: "nowrap",
     transitionProperty: "common",
     transitionDuration: "normal",
     px: 3,
@@ -158,22 +157,22 @@ const config = defineStyleConfig({
   },
   sizes: {
     lg: {
-      height: 8,
+      minHeight: 8,
       minWidth: 8,
       fontSize: "18px",
     },
     md: {
-      height: 7,
+      minHeight: 7,
       minWidth: 7,
       fontSize: "18px",
     },
     sm: {
-      height: 6,
+      minHeight: 6,
       minWidth: 6,
       fontSize: "16px",
     },
     xs: {
-      height: 5,
+      minHeight: 5,
       minWidth: 5,
       fontSize: "16px",
       px: 2,


### PR DESCRIPTION
Denne endringen tillater flere linjer med tekst i en knapp. Det vil gjøre opplevelsen for folk som bruker mye zoom (spesielt på mobil) mye bedre.