### PR TITLE
Add pine as text color token

### DIFF
--- a/apps/docs/app/features/routes/ressurser/design-tokens/ColorTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/ColorTokens.tsx
@@ -61,6 +61,7 @@ export function ColorTokens(props: BoxProps) {
             tokens.color.alias.darkGrey,
             tokens.color.alias.white,
             tokens.color.alias.darkTeal,
+            tokens.color.alias.pine,
           ]}
         />
 


### PR DESCRIPTION
Denne fiksen legger til pine som godkjent farge for tekst.

Fixes #586 