### PR TITLE
Legg til nye farger på badges

### DIFF
--- a/.changeset/dull-phones-kiss.md
+++ b/.changeset/dull-phones-kiss.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-typography-react": minor
+"@vygruppen/spor-theme-react": patch
+---
+
+Add new colors dark-green, light-green, dark-blue and light-blue. Also deprecate green and blue in favor of their light versions.

--- a/packages/spor-theme-react/src/components/badge.ts
+++ b/packages/spor-theme-react/src/components/badge.ts
@@ -51,9 +51,11 @@ type ColorScheme =
   | "yellow"
   | "light-yellow"
   | "red"
-  | "green"
+  | "light-green"
+  | "dark-green"
   | "orange"
-  | "blue"
+  | "light-blue"
+  | "dark-blue"
   | "grey"
   | "white";
 type ColorSpec = {
@@ -77,20 +79,30 @@ const colorCombinations: Record<ColorScheme, ColorSpec> = {
     borderColor: "brightRed",
     color: "darkGrey",
   },
-  green: {
+  "light-green": {
     backgroundColor: "seaMist",
     borderColor: "darkTeal",
     color: "darkTeal",
+  },
+  "dark-green": {
+    backgroundColor: "celadon",
+    borderColor: "blueGreen",
+    color: "white",
   },
   orange: {
     backgroundColor: "champagne",
     borderColor: "pumpkin",
     color: "darkGrey",
   },
-  blue: {
+  "light-blue": {
     backgroundColor: "lightBlue",
     borderColor: "ocean",
     color: "darkGrey",
+  },
+  "dark-blue": {
+    backgroundColor: "darkBlue",
+    borderColor: "sky",
+    color: "white",
   },
   grey: {
     backgroundColor: "platinum",

--- a/packages/spor-typography-react/src/Badge.tsx
+++ b/packages/spor-typography-react/src/Badge.tsx
@@ -14,9 +14,15 @@ export type BadgeProps = Omit<ChakraBadgeProps, "variant" | "colorScheme"> & {
     | "yellow"
     | "light-yellow"
     | "red"
+    | "light-green"
+    /** @deprecated Use "light-green" instead */
     | "green"
+    | "dark-green"
     | "orange"
+    | "light-blue"
+    /** @deprecated Use "light-blue" instead */
     | "blue"
+    | "dark-blue"
     | "grey"
     | "white";
   /** The design variant – "solid" by default.
@@ -53,16 +59,28 @@ export type BadgeProps = Omit<ChakraBadgeProps, "variant" | "colorScheme"> & {
  * If you want an icon, pass it in through the `icon` prop:
  *
  * ```tsx
- * <Badge colorScheme="blue" icon={<InformationOutline18Icon />}>
+ * <Badge colorScheme="light-blue" icon={<InformationOutline18Icon />}>
  *   Information
  * </Badge>
  * ```
  */
 export const Badge = forwardRef<BadgeProps, As<any>>(
-  ({ icon, children, ...props }, ref) => (
-    <ChakraBadge {...props} ref={ref}>
-      {icon && React.cloneElement(icon, { mr: 1 })}
-      {children}
-    </ChakraBadge>
-  )
+  ({ icon, colorScheme = "grey", children, ...props }, ref) => {
+    if (colorScheme === "blue" || colorScheme === "green") {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          `⚠️ You're using a deprecated Badge colorScheme – ${colorScheme}. Please use "light-${colorScheme}" instead.`
+        );
+      }
+      colorScheme = `light-${colorScheme}`;
+    }
+    return (
+      <ChakraBadge colorScheme={colorScheme} {...props} ref={ref}>
+        {icon && React.cloneElement(icon, { mr: 1 })}
+        {children}
+      </ChakraBadge>
+    );
+  }
 );
+
+<Badge colorScheme="blue" />;


### PR DESCRIPTION
Denne endringen legger til to nye farger "dark-green" og "dark-blue" til Badge-komponenten sin `colorScheme` prop.

Den renamer også `green` til `light-green` og `blue` til `dark-blue`, for å gjøre det litt enklere å forstå. De gamle navnene `blue` og `green` er nå deprecated, og du vil få en advarsel under utvikling om du bruker dem. De vil bli fjernet til neste major-release.