### PR TITLE
Legg til floating button, close button

### DIFF
--- a/.changeset/perfect-dodos-wave.md
+++ b/.changeset/perfect-dodos-wave.md
@@ -1,0 +1,8 @@
+---
+"@vygruppen/spor-button-react": minor
+"@vygruppen/spor-theme-react": patch
+---
+
+Add new variant "floating"
+Add new componnet "CloseButton"
+Add better support for ButtonGroup

--- a/.changeset/perfect-dodos-wave.md
+++ b/.changeset/perfect-dodos-wave.md
@@ -4,5 +4,5 @@
 ---
 
 Add new variant "floating"
-Add new componnet "CloseButton"
+Add new component "CloseButton"
 Add better support for ButtonGroup

--- a/package-lock.json
+++ b/package-lock.json
@@ -30812,6 +30812,7 @@
       "license": "MIT",
       "dependencies": {
         "@vygruppen/spor-i18n-react": "*",
+        "@vygruppen/spor-icon-react": "*",
         "@vygruppen/spor-loader-react": "*"
       },
       "devDependencies": {
@@ -40315,6 +40316,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@vygruppen/spor-i18n-react": "*",
+        "@vygruppen/spor-icon-react": "*",
         "@vygruppen/spor-loader-react": "*",
         "framer-motion": ">6.0.0",
         "react": "^18.2.0",

--- a/packages/spor-button-react/package.json
+++ b/packages/spor-button-react/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@vygruppen/spor-i18n-react": "*",
+    "@vygruppen/spor-icon-react": "*",
     "@vygruppen/spor-loader-react": "*"
   },
   "devDependencies": {

--- a/packages/spor-button-react/src/Button.tsx
+++ b/packages/spor-button-react/src/Button.tsx
@@ -4,6 +4,7 @@ import {
   ButtonProps as ChakraButtonProps,
   Center,
   forwardRef,
+  useButtonGroup,
 } from "@chakra-ui/react";
 import { createTexts, useTranslation } from "@vygruppen/spor-i18n-react";
 import { ColorInlineLoader } from "@vygruppen/spor-loader-react";
@@ -13,16 +14,24 @@ export type ButtonProps = Exclude<
   ChakraButtonProps,
   "colorScheme" | "loadingText" | "size" | "variant"
 > & {
-  /** The size of the button. Try not to use the xs size a lot */
+  /**
+   * The size of the button.
+   *
+   * Defaults to "md"
+   * */
   size?: "xs" | "sm" | "md" | "lg";
-  /** The different variants of a button */
+  /** The different variants of a button
+   *
+   * Defaults to "primary"
+   */
   variant?:
     | "control"
     | "primary"
     | "secondary"
     | "tertiary"
     | "additional"
-    | "ghost";
+    | "ghost"
+    | "floating";
 };
 /**
  * Buttons are used to trigger actions.
@@ -35,6 +44,7 @@ export type ButtonProps = Exclude<
  * - `tertiary`: Used for non-essential actions, as well as in combination with the primary button.
  * - `additional`: Used for additional choices, like a less important tertiary action.
  * - `ghost`: Used inside other interactive elements, like date pickers and input fields.
+ * - `floating`: Used for floating actions, like a menu button in a menu.
  *
  * ```tsx
  * <Button variant="primary" onClick={confirmOrder}>
@@ -49,12 +59,14 @@ export type ButtonProps = Exclude<
  *   Cancel trip
  * </Button>
  * ```
+ *
+ * @see https://spor.cloud.vy.no/komponenter/button
  */
 export const Button = forwardRef<ButtonProps, "button">(
   (
     {
-      size = "md",
-      variant = "primary",
+      size,
+      variant,
       children,
       isLoading,
       isDisabled,
@@ -65,11 +77,18 @@ export const Button = forwardRef<ButtonProps, "button">(
     ref
   ) => {
     const ariaLabel = useCorrectAriaLabel(props);
+    const buttonGroup = useButtonGroup();
+    const finalVariant = (variant ??
+      buttonGroup?.variant ??
+      "primary") as Required<ButtonProps["variant"]>;
+    const finalSize = (size ?? buttonGroup?.size ?? "md") as Required<
+      ButtonProps["size"]
+    >;
 
     return (
       <ChakraButton
-        size={size}
-        variant={variant}
+        size={finalSize}
+        variant={finalVariant}
         {...props}
         ref={ref}
         aria-label={ariaLabel}
@@ -77,14 +96,24 @@ export const Button = forwardRef<ButtonProps, "button">(
         isDisabled={isDisabled || isLoading}
         leftIcon={
           isLoading && leftIcon ? (
-            <Box visibility={isLoading ? "hidden" : "visible"}>{leftIcon}</Box>
+            <Box
+              visibility={isLoading ? "hidden" : "visible"}
+              aria-hidden="true"
+            >
+              {leftIcon}
+            </Box>
           ) : (
             leftIcon
           )
         }
         rightIcon={
           isLoading && rightIcon ? (
-            <Box visibility={isLoading ? "hidden" : "visible"}>{rightIcon}</Box>
+            <Box
+              visibility={isLoading ? "hidden" : "visible"}
+              aria-hidden="true"
+            >
+              {rightIcon}
+            </Box>
           ) : (
             rightIcon
           )
@@ -100,7 +129,7 @@ export const Button = forwardRef<ButtonProps, "button">(
             paddingTop={2}
           >
             <ColorInlineLoader
-              maxWidth={sizeToWidthMap[size] || "4rem"}
+              maxWidth={getLoaderWidth(finalSize)}
               width="100%"
               mx={2}
             />
@@ -112,12 +141,19 @@ export const Button = forwardRef<ButtonProps, "button">(
   }
 );
 
-const sizeToWidthMap: Record<string, string> = {
-  xs: "4rem",
-  sm: "4rem",
-  md: "5rem",
-  lg: "6rem",
-};
+function getLoaderWidth(size: any) {
+  switch (size) {
+    case "xs":
+      return "4rem";
+    case "sm":
+      return "4rem";
+    case "md":
+      return "5rem";
+    case "lg":
+    default:
+      return "6rem";
+  }
+}
 
 function useCorrectAriaLabel(props: ButtonProps) {
   const { t } = useTranslation();

--- a/packages/spor-button-react/src/CloseButton.tsx
+++ b/packages/spor-button-react/src/CloseButton.tsx
@@ -1,0 +1,62 @@
+import { forwardRef } from "@chakra-ui/react";
+import { createTexts, useTranslation } from "@vygruppen/spor-i18n-react";
+import {
+  CloseFill18Icon,
+  CloseFill24Icon,
+  CloseFill30Icon,
+} from "@vygruppen/spor-icon-react";
+import React from "react";
+import { IconButton, IconButtonProps } from "./IconButton";
+
+export type CloseButtonProps = Omit<
+  IconButtonProps,
+  "variant" | "aria-label"
+> & {
+  /** Defaults to a localized version of "close" */
+  "aria-label"?: string;
+};
+
+/**
+ * A close button component.
+ *
+ * This button closes stuff, like modals and dialogs.
+ *
+ * ```tsx
+ * <CloseButton onClick={closeModal} />
+ * ```
+ */
+export const CloseButton = forwardRef<CloseButtonProps, "button">(
+  (props, ref) => {
+    const { t } = useTranslation();
+    return (
+      <IconButton
+        ref={ref}
+        variant="ghost"
+        icon={getIcon(props.size)}
+        aria-label={props["aria-label"] || t(texts.close)}
+        {...props}
+      />
+    );
+  }
+);
+
+const getIcon = (size: CloseButtonProps["size"]) => {
+  switch (size) {
+    case "xs":
+    case "sm":
+      return <CloseFill18Icon />;
+    case "md":
+      return <CloseFill24Icon />;
+    case "lg":
+      return <CloseFill30Icon />;
+  }
+};
+
+const texts = createTexts({
+  close: {
+    en: "Close",
+    nb: "Lukk",
+    nn: "Lukk",
+    sv: "Stäng",
+  },
+});

--- a/packages/spor-button-react/src/index.tsx
+++ b/packages/spor-button-react/src/index.tsx
@@ -1,4 +1,5 @@
 export * from "./Button";
 export * from "./ButtonGroup";
-export * from "./IconButton";
+export * from "./CloseButton";
 export * from "./FloatingActionButton";
+export * from "./IconButton";

--- a/packages/spor-input-react/src/SearchInput.tsx
+++ b/packages/spor-input-react/src/SearchInput.tsx
@@ -28,7 +28,7 @@ export type SearchInputProps = Exclude<
 export const SearchInput = forwardRef<SearchInputProps, "input">(
   ({ label, onReset, ...props }, ref) => {
     const { t } = useTranslation();
-    const showCloseButton = onReset && Boolean(props.value);
+    const showClearButton = onReset && Boolean(props.value);
     return (
       <InputGroup position="relative">
         <InputLeftElement>
@@ -50,7 +50,7 @@ export const SearchInput = forwardRef<SearchInputProps, "input">(
         <FormLabel htmlFor={props.id} pointerEvents="none">
           {label ?? t(texts.label)}
         </FormLabel>
-        {showCloseButton && (
+        {showClearButton && (
           <InputRightElement width="fit-content">
             <IconButton
               variant="ghost"

--- a/packages/spor-theme-react/src/components/button.ts
+++ b/packages/spor-theme-react/src/components/button.ts
@@ -154,6 +154,36 @@ const config = defineStyleConfig({
         backgroundColor: "mint",
       },
     }),
+    floating: {
+      backgroundColor: "white",
+      boxShadow: "sm",
+      _active: {
+        backgroundColor: "mint",
+      },
+      _hover: {
+        boxShadow: "md",
+      },
+      ...focusVisible({
+        focus: {
+          boxShadow: getBoxShadowString({
+            borderColor: "greenHaze",
+            borderWidth: 2,
+            baseShadow: "sm",
+          }),
+          _hover: {
+            boxShadow: getBoxShadowString({
+              borderColor: "greenHaze",
+              borderWidth: 2,
+              baseShadow: "md",
+            }),
+          },
+        },
+        notFocus: {
+          outline: "none",
+          boxShadow: "sm",
+        },
+      }),
+    },
   },
   sizes: {
     lg: {


### PR DESCRIPTION
Denne endringen legger til et par endringer:

- Ny variant: `<Button variant="floating" />`. som finnes for React Native
- Ny komponent `<CloseButton />`
- Bedret støtte for `<ButtonGroup />` props