### PR TITLE
Deprecate size og fiks padding på ikoner på badges

### DIFF
--- a/.changeset/thin-pillows-wink.md
+++ b/.changeset/thin-pillows-wink.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-typography-react": patch
+"@vygruppen/spor-theme-react": patch
+---
+
+Deprecate size prop for Badge, and fix an issue with excessive padding when badges have icons

--- a/packages/spor-theme-react/src/components/badge.ts
+++ b/packages/spor-theme-react/src/components/badge.ts
@@ -8,6 +8,9 @@ const config = defineStyleConfig({
     fontSize: ["mobile.xs", "desktop.xs"],
     borderRadius: "xl",
     fontWeight: "bold",
+    paddingLeft: [2, 3],
+    paddingRight: [2, 3],
+    minHeight: [4, 5],
   },
   variants: {
     solid: ({ colorScheme }) => ({
@@ -19,20 +22,9 @@ const config = defineStyleConfig({
       ...getColorScheme(colorScheme as ColorScheme),
     }),
   },
-  sizes: {
-    sm: {
-      px: 2,
-      height: 4,
-    },
-    md: {
-      px: 3,
-      height: 5,
-    },
-  },
   defaultProps: {
     variant: "solid",
     colorScheme: "grey",
-    size: "sm",
   },
 });
 

--- a/packages/spor-theme-react/src/components/badge.ts
+++ b/packages/spor-theme-react/src/components/badge.ts
@@ -1,7 +1,8 @@
 import { defineStyleConfig } from "@chakra-ui/react";
 
 const config = defineStyleConfig({
-  baseStyle: {
+  baseStyle: ({ colorScheme }) => ({
+    borderStyle: "solid",
     display: "inline-flex",
     alignItems: "center",
     justifyContent: "center",
@@ -11,16 +12,15 @@ const config = defineStyleConfig({
     paddingLeft: [2, 3],
     paddingRight: [2, 3],
     minHeight: [4, 5],
-  },
+    ...getColorScheme(colorScheme as ColorScheme),
+  }),
   variants: {
-    solid: ({ colorScheme }) => ({
-      border: "none",
-      ...getColorScheme(colorScheme as ColorScheme),
-    }),
-    outline: ({ colorScheme }) => ({
-      border: "1px solid",
-      ...getColorScheme(colorScheme as ColorScheme),
-    }),
+    solid: {
+      borderWidth: 0,
+    },
+    outline: {
+      borderWidth: 1,
+    },
   },
   defaultProps: {
     variant: "solid",

--- a/packages/spor-typography-react/src/Badge.tsx
+++ b/packages/spor-typography-react/src/Badge.tsx
@@ -29,9 +29,8 @@ export type BadgeProps = Omit<ChakraBadgeProps, "variant" | "colorScheme"> & {
    *
    * Can be specified as `outline` to render a border around the badge. */
   variant?: "solid" | "outline";
-  /** The badge size – "sm" by default.
-   *
-   * Can be specified as `md` to render a larger badge.
+  /**
+   * @deprecated Size is automatically set based on screen size.
    */
   size?: "sm" | "md";
   /** Optional badge icon. Will be rendered to the left of the text.
@@ -47,13 +46,6 @@ export type BadgeProps = Omit<ChakraBadgeProps, "variant" | "colorScheme"> & {
  *
  * ```tsx
  * <Badge colorScheme="green">Hello</Badge>
- * ```
- *
- * You can specify the `size` (`sm` by default) and the `variant` (`solid` by default) props if required.
- *
- *
- * ```tsx
- * <Badge colorScheme="red" size="md" variant="outline">Special</Badge>
  * ```
  *
  * If you want an icon, pass it in through the `icon` prop:
@@ -75,8 +67,13 @@ export const Badge = forwardRef<BadgeProps, As<any>>(
       colorScheme = `light-${colorScheme}`;
     }
     return (
-      <ChakraBadge colorScheme={colorScheme} {...props} ref={ref}>
-        {icon && React.cloneElement(icon, { mr: 1 })}
+      <ChakraBadge
+        colorScheme={colorScheme}
+        {...props}
+        paddingLeft={icon ? 1 : undefined}
+        ref={ref}
+      >
+        {icon && React.cloneElement(icon, { marginRight: 1 })}
         {children}
       </ChakraBadge>
     );


### PR DESCRIPTION
Denne endringen deprekerer `size` propen på Badge-komponenten. Badges skal ikke ha forskjellige størrelser, men skal ha litt forskjellig størrelse basert på skjermstørrelser.

Denne endringen fikser også et issue der Badges fikk feil padding når man sender inn et ikon