### PR TITLE
Bruk store avviksikoner på store travel tags

### DIFF
--- a/.changeset/olive-roses-repair.md
+++ b/.changeset/olive-roses-repair.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-linjetag-react": patch
+"@vygruppen/spor-theme-react": patch
+---
+
+Use large deviation icons on large travel tags

--- a/packages/spor-linjetag-react/src/TravelTag.tsx
+++ b/packages/spor-linjetag-react/src/TravelTag.tsx
@@ -7,8 +7,11 @@ import {
 } from "@chakra-ui/react";
 import {
   ErrorFill18Icon,
+  ErrorFill24Icon,
   InformationFill18Icon,
+  InformationFill24Icon,
   WarningFill18Icon,
+  WarningFill24Icon,
 } from "@vygruppen/spor-icon-react";
 import React from "react";
 import { LineIcon } from "./LineIcon";
@@ -76,7 +79,7 @@ export const TravelTag = forwardRef<TravelTagProps, As<any>>(
       deviationLevel,
     });
 
-    const DeviationLevelIcon = getDeviationLevelIcon(deviationLevel);
+    const DeviationLevelIcon = getDeviationLevelIcon({ deviationLevel, size });
 
     return (
       <Box sx={styles.container} aria-disabled={isDisabled} ref={ref} {...rest}>
@@ -100,17 +103,18 @@ export const TravelTag = forwardRef<TravelTagProps, As<any>>(
   }
 );
 
-const getDeviationLevelIcon = (
-  deviationLevel: TravelTagProps["deviationLevel"]
-) => {
+const getDeviationLevelIcon = ({
+  deviationLevel,
+  size,
+}: Pick<TravelTagProps, "deviationLevel" | "size">) => {
   switch (deviationLevel) {
     case "critical":
-      return ErrorFill18Icon;
+      return size === "lg" ? ErrorFill24Icon : ErrorFill18Icon;
     case "major":
     case "minor":
-      return WarningFill18Icon;
+      return size === "lg" ? WarningFill24Icon : WarningFill18Icon;
     case "info":
-      return InformationFill18Icon;
+      return size === "lg" ? InformationFill24Icon : InformationFill18Icon;
     default:
       return null;
   }

--- a/packages/spor-theme-react/src/components/travel-tag.ts
+++ b/packages/spor-theme-react/src/components/travel-tag.ts
@@ -247,8 +247,10 @@ const getDeviationBorderColor = (props: StyleFunctionProps) => {
 const getDeviationIconStyle = (props: StyleFunctionProps) => {
   return {
     position: "absolute",
-    top: "-7px",
-    right: "-7px",
+    top: "0",
+    right: "0",
+    transform: "translate(50%, -50%)",
+    zIndex: "banner",
     stroke: "white",
     color:
       deviationIconColor[


### PR DESCRIPTION
Denne endringen bruker litt større ikoner på de store travel tagsa.

Addresses #520 