### PR TITLE
Tillat placeholder prop på Input

### DIFF
--- a/packages/spor-input-react/src/Input.tsx
+++ b/packages/spor-input-react/src/Input.tsx
@@ -41,9 +41,9 @@ export const Input = forwardRef<InputProps, "input">(
           pl={leftIcon ? 7 : undefined}
           pr={rightIcon ? 7 : undefined}
           id={id}
+          placeholder=" " // This is needed to make the label work as expected
           {...props}
           ref={ref}
-          placeholder=" " // This is needed to make the label work as expected
         />
         <FormLabel htmlFor={id} pointerEvents="none">
           {label}


### PR DESCRIPTION
Vi (team personell) trenger et lavere input-felt. Løser dette ved å fjerne label via extendTheme, og trenger dermed å kunne sette placeholder