### PR TITLE
Legg til en mønstret bakgrunn for gjennomsiktige designtokens

### DIFF
--- a/apps/docs/app/features/routes/ressurser/design-tokens/ColorTokens.tsx
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/ColorTokens.tsx
@@ -11,6 +11,7 @@ import {
 import { LinkableHeading } from "~/features/linkable-heading/LinkableHeading";
 import { toTitleCase } from "~/utils/stringUtils";
 import { SharedTokenLayout } from "./SharedTokenLayout";
+import translucentBackgroundUrl from "./translucent-background.svg";
 
 export function ColorTokens(props: BoxProps) {
   return (
@@ -125,16 +126,24 @@ const ColorGrid = ({ colors, ...rest }: ColorGridProps) => {
 type ColorTokenProps = BoxProps & { token: string };
 const ColorToken = ({ token, ...rest }: ColorTokenProps) => {
   const { aliasName, paletteName, colorValue } = useTokenInfo(token);
-  const isWhite = colorValue.toLowerCase() === "#ffffff";
+  const isWhite = aliasName?.includes("White");
+  const isTranslucent = paletteName?.includes("Alpha");
+
+  const colorBackground = isTranslucent
+    ? `linear-gradient(to right, ${colorValue}, ${colorValue}), url(${translucentBackgroundUrl})`
+    : colorValue;
 
   return (
     <Card colorScheme="white" borderRadius="sm" overflow="hidden" {...rest}>
       <Box
         height="60px"
-        backgroundColor={colorValue}
         border="1px solid"
         borderColor={isWhite ? "silver" : colorValue}
         borderTopRadius="sm"
+        position="relative"
+        background={colorBackground}
+        backgroundPosition="center center"
+        backgroundRepeat="repeat"
       />
       <Flex flexDirection="column" justifyContent="space-between" px={2}>
         <Box>

--- a/apps/docs/app/features/routes/ressurser/design-tokens/translucent-background.svg
+++ b/apps/docs/app/features/routes/ressurser/design-tokens/translucent-background.svg
@@ -1,0 +1,12 @@
+<svg
+  width="36"
+  height="36"
+  viewBox="0 0 36 36"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect width="18" height="18" fill="#F5F5F5" />
+  <rect y="18" width="18" height="18" fill="#EBEBEC" />
+  <rect x="18" width="18" height="18" fill="#EBEBEC" />
+  <rect x="18" y="18" width="18" height="18" fill="#F5F5F5" />
+</svg>


### PR DESCRIPTION
Denne endringen legger til en mønstret bakgrunn på de gjennomsiktige fargetokenene våre.

Slik ser det ut:

<img width="774" alt="image" src="https://user-images.githubusercontent.com/1307267/215781593-03070ba8-e4dc-41f1-bcd8-dd82a80ed445.png">