### PR TITLE
Datepicker: Fiks feil dag til feil dato

### DIFF
--- a/.changeset/thin-pans-dress.md
+++ b/.changeset/thin-pans-dress.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Fix an issue with day-name and date alignment in the calendar for english users

--- a/packages/spor-datepicker-react/src/CalendarCell.tsx
+++ b/packages/spor-datepicker-react/src/CalendarCell.tsx
@@ -16,14 +16,8 @@ type CalendarCellProps = {
 };
 export function CalendarCell({ state, date, currentMonth }: CalendarCellProps) {
   const ref = useRef(null);
-  const {
-    cellProps,
-    buttonProps,
-    isSelected,
-    isInvalid,
-    isDisabled,
-    isUnavailable,
-  } = useCalendarCell({ date }, state, ref);
+  const { cellProps, buttonProps, isSelected, isDisabled, isUnavailable } =
+    useCalendarCell({ date }, state, ref);
 
   const isOutsideMonth = !isSameMonth(currentMonth, date);
   const styles = useMultiStyleConfig("Datepicker", {});

--- a/packages/spor-datepicker-react/src/utils.ts
+++ b/packages/spor-datepicker-react/src/utils.ts
@@ -15,7 +15,7 @@ export const useCurrentLocale = () => {
     case "sv":
       return "sv";
     case "en":
-      return "en";
+      return "en-GB";
     default:
       return "no";
   }


### PR DESCRIPTION
Denne PRen fikser en bug der man fikk feil dag på toppen av kalenderen. Dette kommer ifra at vi defaultet til den amerikanske måten å skrive datoer på, som starter uken på søndag istedenfor mandag.

Her spesifiserer vi at vi ønsker den britiske måten å skrive datoer på, som inkluderer dd/mm/yyyy, og at uker starter på mandager.

Fixes #601 