### PR TITLE
Gjør datepicker høyden redigerbar

### DIFF
--- a/.changeset/seven-turtles-sparkle.md
+++ b/.changeset/seven-turtles-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+"@vygruppen/spor-theme-react": patch
+---
+
+Add option to specify minHeight for DatePicker and DateRangePicker

--- a/packages/spor-datepicker-react/src/DatePicker.tsx
+++ b/packages/spor-datepicker-react/src/DatePicker.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  BoxProps,
   InputGroup,
   Popover,
   PopoverAnchor,
@@ -22,10 +23,11 @@ import { DateField } from "./DateField";
 import { StyledField } from "./StyledField";
 import { useCurrentLocale } from "./utils";
 
-type DatePickerProps = AriaDatePickerProps<DateValue> & {
-  variant: ResponsiveValue<"simple" | "with-trigger">;
-  name?: string;
-};
+type DatePickerProps = AriaDatePickerProps<DateValue> &
+  Pick<BoxProps, "minHeight"> & {
+    variant: ResponsiveValue<"simple" | "with-trigger">;
+    name?: string;
+  };
 /**
  * A date picker component.
  *
@@ -38,6 +40,7 @@ type DatePickerProps = AriaDatePickerProps<DateValue> & {
 export function DatePicker({
   variant,
   errorMessage,
+  minHeight,
   ...props
 }: DatePickerProps) {
   const state = useDatePickerState({
@@ -102,6 +105,7 @@ export function DatePicker({
                   onClick={onFieldClick}
                   onKeyPress={handleEnterClick}
                   paddingX={3}
+                  minHeight={minHeight}
                 >
                   {!hasTrigger && (
                     <CalendarOutline24Icon mr={2} alignSelf="center" />

--- a/packages/spor-datepicker-react/src/DateRangePicker.tsx
+++ b/packages/spor-datepicker-react/src/DateRangePicker.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  BoxProps,
   FormLabel,
   InputGroup,
   Popover,
@@ -23,11 +24,12 @@ import { RangeCalendar } from "./RangeCalendar";
 import { StyledField } from "./StyledField";
 import { useCurrentLocale } from "./utils";
 
-type DateRangePickerProps = AriaDateRangePickerProps<DateValue> & {
-  startLabel?: string;
-  endLabel?: string;
-  variant: ResponsiveValue<"simple" | "with-trigger">;
-};
+type DateRangePickerProps = AriaDateRangePickerProps<DateValue> &
+  Pick<BoxProps, "minHeight"> & {
+    startLabel?: string;
+    endLabel?: string;
+    variant: ResponsiveValue<"simple" | "with-trigger">;
+  };
 /**
  * A date range picker component.
  *
@@ -37,7 +39,11 @@ type DateRangePickerProps = AriaDateRangePickerProps<DateValue> & {
  * <DateRangePicker startLabel="From" endLabel="To" variant="simple" />
  * ```
  */
-export function DateRangePicker({ variant, ...props }: DateRangePickerProps) {
+export function DateRangePicker({
+  variant,
+  minHeight,
+  ...props
+}: DateRangePickerProps) {
   const state = useDateRangePickerState({
     ...props,
     shouldCloseOnSelect: true,
@@ -107,6 +113,7 @@ export function DateRangePicker({ variant, ...props }: DateRangePickerProps) {
                 variant={responsiveVariant}
                 onClick={onFieldClick}
                 onKeyPress={handleEnterClick}
+                minHeight={minHeight}
               >
                 {!hasTrigger && (
                   <CalendarOutline24Icon mr={2} alignSelf="center" />

--- a/packages/spor-theme-react/src/components/datepicker.ts
+++ b/packages/spor-theme-react/src/components/datepicker.ts
@@ -24,7 +24,9 @@ const config = helpers.defineMultiStyleConfig({
       transitionDuration: "fast",
       display: "flex",
       flex: 1,
-      paddingY: 1.5,
+      paddingY: 0.5,
+      minHeight: 64,
+      alignItems: "center",
       _hover: {
         boxShadow: getBoxShadowString({
           borderColor: "darkGrey",


### PR DESCRIPTION
Denne endringen gjør det mulig å sette en `minHeight` på DatePicker. By default er den 64px, men du kan sette den til f.eks. 54 px for å stemme mer overens med inputfelter f.eks.

```tsx
<DatePicker minHeight={54} />
```

Det brukes `minHeight` istedenfor `height` så man lar boksen vokse med tekststørrelser, for eksempel. Jeg velger å ikke endre default-høyden siden det er slik den er designet, men det kan vi sikkert ta en diskusjon på.

Fixes #534 