### PR TITLE
Nye komponenter: ProgressLoader og ProgressBar

### DIFF
--- a/.changeset/serious-kings-obey.md
+++ b/.changeset/serious-kings-obey.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-loader-react": minor
+---
+
+Add new components ProgressBar and ProgressLoader

--- a/packages/spor-loader-react/package.json
+++ b/packages/spor-loader-react/package.json
@@ -37,6 +37,8 @@
   },
   "dependencies": {
     "lottie-react": "^2.3.1",
+    "react-aria": "^3.22.0",
+    "@vygruppen/spor-i18n-react": "*",
     "@vygruppen/spor-loader": "*"
   }
 }

--- a/packages/spor-loader-react/src/ProgressBar.tsx
+++ b/packages/spor-loader-react/src/ProgressBar.tsx
@@ -1,0 +1,168 @@
+import { Box, BoxProps, Flex, Text, useInterval } from "@chakra-ui/react";
+import { createTexts, useTranslation } from "@vygruppen/spor-i18n-react";
+import React, { useMemo, useState } from "react";
+import { useProgressBar } from "react-aria";
+
+type ProgressBarProps = {
+  /** The percentage of progress made.
+   *
+   * The value must be between 0 and 100 */
+  value: number;
+  /** The height of the progress bar.
+   * Defaults to .5rem
+   **/
+  height?: BoxProps["height"];
+  /** The width of the progress bar.
+   *
+   * Defaults to the width of its container
+   **/
+  width?: BoxProps["width"];
+
+  /** Pass if no label is passed to the label */
+  "aria-label": string;
+  /** Optional text shown below the loader.
+   *
+   * If you pass an array of strings, the text will rotate every 5 seconds. If you want to change the delay, pass the delay in milliseconds to the `labelRotationDelay` prop.
+   */
+  label: string | string[];
+  /** The number of milliseconds a label is shown, if an array of strings is passed to the `label` prop.
+   *
+   * Defaults to 5000 (5 seconds).
+   */
+  labelRotationDelay?: number;
+};
+
+/**
+ * Shows the progress of a loading process.
+ *
+ * You can pass the amount of progress with the `value` prop:
+ *
+ * ```tsx
+ * <ProgressBar value={50} />
+ * ```
+ *
+ *  You can also pass a label to show below the loader:
+ *
+ * ```tsx
+ * <ProgressBar value={50} label="Loading..." />
+ * ```
+ *
+ * If you pass an array of strings, the text will rotate every 5 seconds. If you want to change the delay, pass the delay in milliseconds to the `labelRotationDelay` prop.
+ *
+ * ```tsx
+ * <ProgressBar value={50} label={["Loading...", "Almost there..."]} />
+ * ```
+ *
+ * If you don't pass a value, the loader will show an indeterminate progress bar:
+ *
+ * ```tsx
+ * <ProgressBar label="Loading..." />
+ * ```
+ *
+ * If you don't pass a label, you should pass an `aria-label` prop:
+ *
+ * ```tsx
+ * <ProgressBar aria-label="Loading..." />
+ * ```
+ */
+export const ProgressBar = ({
+  value,
+  label,
+  labelRotationDelay = 5000,
+  height = "0.5rem",
+  width = "100%",
+  "aria-label": ariaLabel,
+}: ProgressBarProps) => {
+  const { t } = useTranslation();
+  const currentLoadingText = useRotatingLabel({
+    label,
+    delay: labelRotationDelay,
+  });
+  const { labelProps, progressBarProps } = useProgressBar({
+    isIndeterminate: value === undefined,
+    value,
+    "aria-label": ariaLabel || t(texts.fallbackLabel(value)),
+  });
+  const { indeterminateValue, direction } = useIndeterminateValue(value);
+  return (
+    <Box
+      {...progressBarProps}
+      title={t(texts.fallbackLabel(indeterminateValue))}
+      minWidth="100px"
+    >
+      <Flex
+        backgroundColor="coralGreen"
+        borderRadius="sm"
+        width={width}
+        justifyContent={direction === "right" ? "flex-start" : "flex-end"}
+      >
+        <Box
+          backgroundColor="greenHaze"
+          borderRadius="sm"
+          height={height}
+          width={`${indeterminateValue}%`}
+          maxWidth="100%"
+          transition="width .2s ease-out"
+        />
+      </Flex>
+      {currentLoadingText && (
+        <Text
+          textAlign="center"
+          marginTop={2}
+          fontWeight="bold"
+          {...labelProps}
+        >
+          {currentLoadingText}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+const texts = createTexts({
+  fallbackLabel: (value) => ({
+    nb: `${value}% ferdig`,
+    nn: `${value}% ferdig`,
+    sv: `${value}% klart`,
+    en: `${value}% done`,
+  }),
+});
+
+type UseRotatingLabelArgs = {
+  label?: string | string[];
+  delay: number;
+};
+const useRotatingLabel = ({ label, delay }: UseRotatingLabelArgs) => {
+  const loadingTextArray = useMemo(
+    () => (Array.isArray(label) ? label : [label]),
+    [label]
+  );
+  const [currentLoadingTextIndex, setCurrentLoadingTextIndex] = useState(0);
+
+  useInterval(() => {
+    setCurrentLoadingTextIndex(
+      (prevIndex) => (prevIndex + 1) % loadingTextArray.length
+    );
+  }, delay);
+  return loadingTextArray[currentLoadingTextIndex];
+};
+
+const useIndeterminateValue = (value?: number) => {
+  const [indeterminateValue, setIndeterminateValue] = useState(0);
+  const [direction, setDirection] = useState<"left" | "right">("right");
+  useInterval(() => {
+    setIndeterminateValue((prevValue) => {
+      const valueToAdd = Math.max(Math.round(Math.random() * 10));
+      const newValue = (prevValue + valueToAdd) % 100;
+      if (newValue < prevValue) {
+        setDirection((prevDirection) =>
+          prevDirection === "left" ? "right" : "left"
+        );
+      }
+      return newValue;
+    });
+  }, 100);
+  if (value !== undefined)
+    return { indeterminateValue: value, direction: "right" };
+  return { indeterminateValue, direction };
+};

--- a/packages/spor-loader-react/src/ProgressLoader.tsx
+++ b/packages/spor-loader-react/src/ProgressLoader.tsx
@@ -1,27 +1,14 @@
-import {
-  Box,
-  BoxProps,
-  chakra,
-  Text,
-  useInterval,
-  useTheme,
-} from "@chakra-ui/react";
+import { Box, BoxProps, Text } from "@chakra-ui/react";
 import { createTexts, useTranslation } from "@vygruppen/spor-i18n-react";
-import { motion } from "framer-motion";
-import React, { useMemo, useRef, useState } from "react";
+import React, { useId, useRef } from "react";
 import { useProgressBar } from "react-aria";
-
-const MotionPath = motion(chakra.path);
+import { useRotatingLabel } from "./useRotatingLabel";
 
 type ProgressLoaderProps = {
   /** The percentage of progress made.
    *
    * The value must be between 0 and 100 */
-  value?: number;
-  /** The height of the progress bar.
-   * Defaults to .5rem
-   **/
-  height?: BoxProps["height"];
+  value: number;
   /** The width of the progress bar.
    *
    * Defaults to the width of its container
@@ -63,16 +50,10 @@ type ProgressLoaderProps = {
  * <ProgressLoader value={50} label={["Loading...", "Almost done..."]} />
  * ```
  *
- * If you don't pass a value, the loader will show an indeterminate progress bar:
- *
- * ```tsx
- * <ProgressLoader label="Fetching your trips..." />
- * ```
- *
  * If you don't pass a label, you should pass an `aria-label` prop:
  *
  * ```tsx
- * <ProgressLoader aria-label="Fetching your trips..." />
+ * <ProgressLoader value={50} aria-label="Fetching your trips..." />
  * ```
  */
 export const ProgressLoader = ({
@@ -80,6 +61,7 @@ export const ProgressLoader = ({
   label,
   labelRotationDelay = 5000,
   "aria-label": ariaLabel,
+  width,
 }: ProgressLoaderProps) => {
   const { t } = useTranslation();
   const currentLoadingText = useRotatingLabel({
@@ -89,57 +71,46 @@ export const ProgressLoader = ({
   const { labelProps, progressBarProps } = useProgressBar({
     isIndeterminate: value === undefined,
     value,
+    "aria-label": ariaLabel ?? t(texts.fallbackLabel(value ?? "?")),
   });
   const pathRef = useRef<SVGPathElement>(null);
-  const isIndeterminate = value === undefined;
   const progressPathLength = pathRef.current?.getTotalLength() ?? 0;
-  const progress = isIndeterminate
-    ? progressPathLength
-    : ((value - 100) / 100) * progressPathLength;
-  const theme = useTheme();
+  const progress = ((value - 100) / 100) * progressPathLength;
+  const id = useId();
   return (
-    <Box {...progressBarProps} minWidth="100px">
+    <Box {...progressBarProps} minWidth="100px" width={width}>
       <Box as="svg" viewBox="0 0 246 78" fill="none">
         <Box
           as="path"
-          id="start-dot"
+          id={`${id}-start-dot`}
           d="M14.0479 44.8251C19.4332 44.8251 23.7988 40.5242 23.7988 35.2187C23.7988 29.9133 19.4332 25.6124 14.0479 25.6124C8.66254 25.6124 4.29688 29.9133 4.29688 35.2187C4.29688 40.5242 8.66254 44.8251 14.0479 44.8251Z"
           fill="#FFB466"
         />
         <Box
           as="path"
-          id="track"
+          id={`${id}-track`}
           d="M204.911 39.1156C204.911 39.1156 175.012 46.8319 157.651 30.4354C140.29 14.0388 121 21.7547 110.391 47.6529C103.22 65.157 78.9634 67.0859 67.9533 47.6529C59.8376 33.3287 36.125 37.1866 36.125 37.1866"
           stroke="coralGreen"
           strokeWidth="13.6469"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        <MotionPath
-          id="progress"
+        <Box
+          as="path"
+          id={`${id}-progress`}
           d="M204.911 39.1156C204.911 39.1156 175.012 46.8319 157.651 30.4354C140.29 14.0388 121 21.7547 110.391 47.6529C103.22 65.157 78.9634 67.0859 67.9533 47.6529C59.8376 33.3287 36.125 37.1866 36.125 37.1866"
-          stroke={theme.colors.greenHaze}
+          stroke="greenHaze"
           strokeWidth="13.6469"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeDasharray={progressPathLength}
           strokeDashoffset={progress}
-          animate={{
-            strokeDashoffset: isIndeterminate
-              ? [-progress, 0, -progress / 2, progress, -progress]
-              : undefined,
-          }}
-          transition={{
-            duration: 3,
-            ease: "easeInOut",
-            repeat: Infinity,
-            repeatType: "loop",
-          }}
+          transition="stroke-dashoffset .2s ease-out"
           ref={pathRef as any}
         />
         <Box
           as="path"
-          id="end-dot"
+          id={`${id}-end-dot`}
           d="M226.025 44.8251C231.411 44.8251 235.776 40.5242 235.776 35.2187C235.776 29.9133 231.411 25.6124 226.025 25.6124C220.64 25.6124 216.274 29.9133 216.274 35.2187C216.274 40.5242 220.64 44.8251 226.025 44.8251Z"
           fill="#688CBA"
         />
@@ -166,22 +137,3 @@ const texts = createTexts({
     en: `${value}% done`,
   }),
 });
-
-type UseRotatingLabelArgs = {
-  label?: string | string[];
-  delay: number;
-};
-const useRotatingLabel = ({ label, delay }: UseRotatingLabelArgs) => {
-  const loadingTextArray = useMemo(
-    () => (Array.isArray(label) ? label : [label]),
-    [label]
-  );
-  const [currentLoadingTextIndex, setCurrentLoadingTextIndex] = useState(0);
-
-  useInterval(() => {
-    setCurrentLoadingTextIndex(
-      (prevIndex) => (prevIndex + 1) % loadingTextArray.length
-    );
-  }, delay);
-  return loadingTextArray[currentLoadingTextIndex];
-};

--- a/packages/spor-loader-react/src/ProgressLoader.tsx
+++ b/packages/spor-loader-react/src/ProgressLoader.tsx
@@ -1,0 +1,187 @@
+import {
+  Box,
+  BoxProps,
+  chakra,
+  Text,
+  useInterval,
+  useTheme,
+} from "@chakra-ui/react";
+import { createTexts, useTranslation } from "@vygruppen/spor-i18n-react";
+import { motion } from "framer-motion";
+import React, { useMemo, useRef, useState } from "react";
+import { useProgressBar } from "react-aria";
+
+const MotionPath = motion(chakra.path);
+
+type ProgressLoaderProps = {
+  /** The percentage of progress made.
+   *
+   * The value must be between 0 and 100 */
+  value?: number;
+  /** The height of the progress bar.
+   * Defaults to .5rem
+   **/
+  height?: BoxProps["height"];
+  /** The width of the progress bar.
+   *
+   * Defaults to the width of its container
+   **/
+  width?: BoxProps["width"];
+
+  /** Pass if no label is passed to the label */
+  "aria-label": string;
+  /** Optional text shown below the loader.
+   *
+   * If you pass an array of strings, the text will rotate every 5 seconds. If you want to change the delay, pass the delay in milliseconds to the `labelRotationDelay` prop.
+   */
+  label: string | string[];
+  /** The number of milliseconds a label is shown, if an array of strings is passed to the `label` prop.
+   *
+   * Defaults to 5000 (5 seconds).
+   */
+  labelRotationDelay?: number;
+};
+
+/**
+ * Shows the progress of a loading process.
+ *
+ * You can pass the amount of progress with the `value` prop:
+ *
+ * ```tsx
+ * <ProgressLoader value={50} />
+ * ```
+ *
+ * You can also pass a label to show below the loader:
+ *
+ * ```tsx
+ * <ProgressLoader value={50} label="Loading..." />
+ * ```
+ *
+ * If you pass an array of strings, the text will rotate every 5 seconds. If you want to change the delay, pass the delay in milliseconds to the `labelRotationDelay` prop.
+ *
+ * ```tsx
+ * <ProgressLoader value={50} label={["Loading...", "Almost done..."]} />
+ * ```
+ *
+ * If you don't pass a value, the loader will show an indeterminate progress bar:
+ *
+ * ```tsx
+ * <ProgressLoader label="Fetching your trips..." />
+ * ```
+ *
+ * If you don't pass a label, you should pass an `aria-label` prop:
+ *
+ * ```tsx
+ * <ProgressLoader aria-label="Fetching your trips..." />
+ * ```
+ */
+export const ProgressLoader = ({
+  value,
+  label,
+  labelRotationDelay = 5000,
+  "aria-label": ariaLabel,
+}: ProgressLoaderProps) => {
+  const { t } = useTranslation();
+  const currentLoadingText = useRotatingLabel({
+    label,
+    delay: labelRotationDelay,
+  });
+  const { labelProps, progressBarProps } = useProgressBar({
+    isIndeterminate: value === undefined,
+    value,
+  });
+  const pathRef = useRef<SVGPathElement>(null);
+  const isIndeterminate = value === undefined;
+  const progressPathLength = pathRef.current?.getTotalLength() ?? 0;
+  const progress = isIndeterminate
+    ? progressPathLength
+    : ((value - 100) / 100) * progressPathLength;
+  const theme = useTheme();
+  return (
+    <Box {...progressBarProps} minWidth="100px">
+      <Box as="svg" viewBox="0 0 246 78" fill="none">
+        <Box
+          as="path"
+          id="start-dot"
+          d="M14.0479 44.8251C19.4332 44.8251 23.7988 40.5242 23.7988 35.2187C23.7988 29.9133 19.4332 25.6124 14.0479 25.6124C8.66254 25.6124 4.29688 29.9133 4.29688 35.2187C4.29688 40.5242 8.66254 44.8251 14.0479 44.8251Z"
+          fill="#FFB466"
+        />
+        <Box
+          as="path"
+          id="track"
+          d="M204.911 39.1156C204.911 39.1156 175.012 46.8319 157.651 30.4354C140.29 14.0388 121 21.7547 110.391 47.6529C103.22 65.157 78.9634 67.0859 67.9533 47.6529C59.8376 33.3287 36.125 37.1866 36.125 37.1866"
+          stroke="coralGreen"
+          strokeWidth="13.6469"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <MotionPath
+          id="progress"
+          d="M204.911 39.1156C204.911 39.1156 175.012 46.8319 157.651 30.4354C140.29 14.0388 121 21.7547 110.391 47.6529C103.22 65.157 78.9634 67.0859 67.9533 47.6529C59.8376 33.3287 36.125 37.1866 36.125 37.1866"
+          stroke={theme.colors.greenHaze}
+          strokeWidth="13.6469"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeDasharray={progressPathLength}
+          strokeDashoffset={progress}
+          animate={{
+            strokeDashoffset: isIndeterminate
+              ? [-progress, 0, -progress / 2, progress, -progress]
+              : undefined,
+          }}
+          transition={{
+            duration: 3,
+            ease: "easeInOut",
+            repeat: Infinity,
+            repeatType: "loop",
+          }}
+          ref={pathRef as any}
+        />
+        <Box
+          as="path"
+          id="end-dot"
+          d="M226.025 44.8251C231.411 44.8251 235.776 40.5242 235.776 35.2187C235.776 29.9133 231.411 25.6124 226.025 25.6124C220.64 25.6124 216.274 29.9133 216.274 35.2187C216.274 40.5242 220.64 44.8251 226.025 44.8251Z"
+          fill="#688CBA"
+        />
+      </Box>
+      {currentLoadingText && (
+        <Text
+          textAlign="center"
+          marginTop={2}
+          fontWeight="bold"
+          {...labelProps}
+        >
+          {currentLoadingText}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+const texts = createTexts({
+  fallbackLabel: (value) => ({
+    nb: `${value}% ferdig`,
+    nn: `${value}% ferdig`,
+    sv: `${value}% klart`,
+    en: `${value}% done`,
+  }),
+});
+
+type UseRotatingLabelArgs = {
+  label?: string | string[];
+  delay: number;
+};
+const useRotatingLabel = ({ label, delay }: UseRotatingLabelArgs) => {
+  const loadingTextArray = useMemo(
+    () => (Array.isArray(label) ? label : [label]),
+    [label]
+  );
+  const [currentLoadingTextIndex, setCurrentLoadingTextIndex] = useState(0);
+
+  useInterval(() => {
+    setCurrentLoadingTextIndex(
+      (prevIndex) => (prevIndex + 1) % loadingTextArray.length
+    );
+  }, delay);
+  return loadingTextArray[currentLoadingTextIndex];
+};

--- a/packages/spor-loader-react/src/index.tsx
+++ b/packages/spor-loader-react/src/index.tsx
@@ -7,6 +7,8 @@ export * from "./DarkSpinner";
 export * from "./LightFullScreenLoader";
 export * from "./LightInlineLoader";
 export * from "./LightSpinner";
+export * from "./ProgressBar";
+export * from "./ProgressLoader";
 export * from "./Skeleton";
 export * from "./SkeletonCircle";
 export * from "./SkeletonText";

--- a/packages/spor-loader-react/src/useRotatingLabel.tsx
+++ b/packages/spor-loader-react/src/useRotatingLabel.tsx
@@ -1,0 +1,22 @@
+import { useInterval } from "@chakra-ui/react";
+import { useMemo, useState } from "react";
+
+type UseRotatingLabelArgs = {
+  label?: string | string[];
+  delay: number;
+};
+/** Returns a label from a set of labels */
+export const useRotatingLabel = ({ label, delay }: UseRotatingLabelArgs) => {
+  const loadingTextArray = useMemo(
+    () => (Array.isArray(label) ? label : [label]),
+    [label]
+  );
+  const [currentLoadingTextIndex, setCurrentLoadingTextIndex] = useState(0);
+
+  useInterval(() => {
+    setCurrentLoadingTextIndex(
+      (prevIndex) => (prevIndex + 1) % loadingTextArray.length
+    );
+  }, delay);
+  return loadingTextArray[currentLoadingTextIndex];
+};


### PR DESCRIPTION
Denne PRen legger til to nye komponenter – ProgressLoader og ProgressBar.

ProgressBar er en tynn strek du kan spesifisere bredden til med `value`– en verdi mellom 0 og 100 (i prosent). 

<img width="141" alt="image" src="https://user-images.githubusercontent.com/1307267/217375801-ed74b54e-2902-4258-ab60-bd47a022319b.png">

ProgressLoader er en illustrasjon du kan spesifisere lengden til med `value` - samme som over.

<img width="148" alt="image" src="https://user-images.githubusercontent.com/1307267/217375877-32d0760d-38c0-40c7-a36e-fcf204372082.png">

Om du ikke vet hvor langt i prosessen man har kommet, kan man også droppe å sende inn `value` til disse komponentene, og da ser det slik ut:

| ProgressBar | ProgressLoader |
| --- | --- | 
| ![2023-02-07 22 51 26](https://user-images.githubusercontent.com/1307267/217375659-e23de001-ab16-4148-9f58-274c55fe69c3.gif) | ![2023-02-07 22 50 59](https://user-images.githubusercontent.com/1307267/217375690-69c35205-f7fb-4b70-8293-366b0baf3d54.gif) |

Du kan også sende inn en `label`, som vises under, for å beskrive hva man venter på (eller hvordan prosessen går). Du kan også sende inn en array med strings til `label`– da vil den iterere gjennom strengene hvert 5. sekund (eller `labelRotationDelay`propen, om du vil spesifisere den). 

