### PR TITLE
Vis datovelgern litt kjærleik

### DIFF
--- a/.changeset/chilled-turkeys-invent.md
+++ b/.changeset/chilled-turkeys-invent.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Fix a bug where the calendar would be cut off by overflow hidden containers

--- a/.changeset/olive-numbers-know.md
+++ b/.changeset/olive-numbers-know.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Fix a bug where the input field would resize on smaller dates

--- a/.changeset/perfect-actors-share.md
+++ b/.changeset/perfect-actors-share.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Make Datepickers work with FormControl components

--- a/packages/spor-datepicker-react/src/DateField.tsx
+++ b/packages/spor-datepicker-react/src/DateField.tsx
@@ -35,7 +35,7 @@ export function DateField(props: DateFieldProps) {
   const { fieldProps, labelProps } = useDateField(props, state, ref);
 
   return (
-    <Box>
+    <Box minWidth="6rem">
       {props.label && (
         <FormLabel {...props.labelProps} {...labelProps} sx={styles.inputLabel}>
           {props.label}

--- a/packages/spor-datepicker-react/src/DatePicker.tsx
+++ b/packages/spor-datepicker-react/src/DatePicker.tsx
@@ -109,7 +109,7 @@ export function DatePicker({
                   minHeight={minHeight}
                 >
                   {!hasTrigger && (
-                    <CalendarOutline24Icon mr={2} alignSelf="center" />
+                    <CalendarOutline24Icon marginRight={2} alignSelf="center" />
                   )}
                   <DateField
                     label={props.label}

--- a/packages/spor-datepicker-react/src/DatePicker.tsx
+++ b/packages/spor-datepicker-react/src/DatePicker.tsx
@@ -7,6 +7,7 @@ import {
   PopoverArrow,
   PopoverBody,
   PopoverContent,
+  Portal,
   ResponsiveValue,
   useBreakpointValue,
 } from "@chakra-ui/react";
@@ -124,16 +125,18 @@ export function DatePicker({
               {errorMessage}
             </FormErrorMessage>
             {state.isOpen && !props.isDisabled && (
-              <PopoverContent
-                backgroundColor="white"
-                color="darkGrey"
-                boxShadow="md"
-              >
-                <PopoverArrow backgroundColor="white" />
-                <PopoverBody>
-                  <Calendar {...calendarProps} />
-                </PopoverBody>
-              </PopoverContent>
+              <Portal>
+                <PopoverContent
+                  backgroundColor="white"
+                  color="darkGrey"
+                  boxShadow="md"
+                >
+                  <PopoverArrow backgroundColor="white" />
+                  <PopoverBody>
+                    <Calendar {...calendarProps} />
+                  </PopoverBody>
+                </PopoverContent>
+              </Portal>
             )}
           </Popover>
         </Box>

--- a/packages/spor-datepicker-react/src/DatePicker.tsx
+++ b/packages/spor-datepicker-react/src/DatePicker.tsx
@@ -10,12 +10,13 @@ import {
   Portal,
   ResponsiveValue,
   useBreakpointValue,
+  useFormControlContext,
 } from "@chakra-ui/react";
 import { DateValue } from "@internationalized/date";
 import { useDatePicker } from "@react-aria/datepicker";
 import { useDatePickerState } from "@react-stately/datepicker";
 import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
-import { FormControl, FormErrorMessage } from "@vygruppen/spor-input-react";
+import { FormErrorMessage } from "@vygruppen/spor-input-react";
 import React, { useRef } from "react";
 import { AriaDatePickerProps, I18nProvider } from "react-aria";
 import { Calendar } from "./Calendar";
@@ -44,9 +45,13 @@ export function DatePicker({
   minHeight,
   ...props
 }: DatePickerProps) {
+  const formControlProps = useFormControlContext();
   const state = useDatePickerState({
     ...props,
     shouldCloseOnSelect: true,
+    errorMessage,
+    isRequired: props.isRequired ?? formControlProps?.isRequired,
+    validationState: formControlProps.isInvalid ? "invalid" : "valid",
   });
   const ref = useRef(null);
   const {
@@ -83,64 +88,62 @@ export function DatePicker({
 
   return (
     <I18nProvider locale={locale}>
-      <FormControl isInvalid={state.validationState === "invalid"}>
-        <Box position="relative" display="inline-flex" flexDirection="column">
-          <Popover
-            {...dialogProps}
-            isOpen={state.isOpen}
-            onClose={() => state.setOpen(false)}
-            onOpen={() => state.setOpen(true)}
-            closeOnBlur
-            closeOnEsc
-            returnFocusOnClose
+      <Box position="relative" display="inline-flex" flexDirection="column">
+        <Popover
+          {...dialogProps}
+          isOpen={state.isOpen}
+          onClose={() => state.setOpen(false)}
+          onOpen={() => state.setOpen(true)}
+          closeOnBlur
+          closeOnEsc
+          returnFocusOnClose
+        >
+          <InputGroup
+            {...groupProps}
+            ref={ref}
+            width="auto"
+            display="inline-flex"
           >
-            <InputGroup
-              {...groupProps}
-              ref={ref}
-              width="auto"
-              display="inline-flex"
-            >
-              <PopoverAnchor>
-                <StyledField
-                  variant={responsiveVariant}
-                  onClick={onFieldClick}
-                  onKeyPress={handleEnterClick}
-                  paddingX={3}
-                  minHeight={minHeight}
-                >
-                  {!hasTrigger && (
-                    <CalendarOutline24Icon marginRight={2} alignSelf="center" />
-                  )}
-                  <DateField
-                    label={props.label}
-                    labelProps={labelProps}
-                    name={props.name}
-                    {...fieldProps}
-                  />
-                </StyledField>
-              </PopoverAnchor>
-              {hasTrigger && <CalendarTriggerButton {...buttonProps} />}
-            </InputGroup>
-            <FormErrorMessage {...errorMessageProps}>
-              {errorMessage}
-            </FormErrorMessage>
-            {state.isOpen && !props.isDisabled && (
-              <Portal>
-                <PopoverContent
-                  backgroundColor="white"
-                  color="darkGrey"
-                  boxShadow="md"
-                >
-                  <PopoverArrow backgroundColor="white" />
-                  <PopoverBody>
-                    <Calendar {...calendarProps} />
-                  </PopoverBody>
-                </PopoverContent>
-              </Portal>
-            )}
-          </Popover>
-        </Box>
-      </FormControl>
+            <PopoverAnchor>
+              <StyledField
+                variant={responsiveVariant}
+                onClick={onFieldClick}
+                onKeyPress={handleEnterClick}
+                paddingX={3}
+                minHeight={minHeight}
+              >
+                {!hasTrigger && (
+                  <CalendarOutline24Icon marginRight={2} alignSelf="center" />
+                )}
+                <DateField
+                  label={props.label}
+                  labelProps={labelProps}
+                  name={props.name}
+                  {...fieldProps}
+                />
+              </StyledField>
+            </PopoverAnchor>
+            {hasTrigger && <CalendarTriggerButton {...buttonProps} />}
+          </InputGroup>
+          <FormErrorMessage {...errorMessageProps}>
+            {errorMessage}
+          </FormErrorMessage>
+          {state.isOpen && !props.isDisabled && (
+            <Portal>
+              <PopoverContent
+                backgroundColor="white"
+                color="darkGrey"
+                boxShadow="md"
+              >
+                <PopoverArrow backgroundColor="white" />
+                <PopoverBody>
+                  <Calendar {...calendarProps} />
+                </PopoverBody>
+              </PopoverContent>
+            </Portal>
+          )}
+        </Popover>
+      </Box>
     </I18nProvider>
   );
 }

--- a/packages/spor-datepicker-react/src/DateRangePicker.tsx
+++ b/packages/spor-datepicker-react/src/DateRangePicker.tsx
@@ -8,6 +8,7 @@ import {
   PopoverArrow,
   PopoverBody,
   PopoverContent,
+  Portal,
   ResponsiveValue,
   useBreakpointValue,
   useMultiStyleConfig,
@@ -136,17 +137,19 @@ export function DateRangePicker({
             {hasTrigger && <CalendarTriggerButton {...buttonProps} />}
           </InputGroup>
           {state.isOpen && (
-            <PopoverContent
-              backgroundColor="white"
-              color="darkGrey"
-              boxShadow="md"
-              maxWidth="none"
-            >
-              <PopoverArrow backgroundColor="white" />
-              <PopoverBody>
-                <RangeCalendar {...calendarProps} />
-              </PopoverBody>
-            </PopoverContent>
+            <Portal>
+              <PopoverContent
+                backgroundColor="white"
+                color="darkGrey"
+                boxShadow="md"
+                maxWidth="none"
+              >
+                <PopoverArrow backgroundColor="white" />
+                <PopoverBody>
+                  <RangeCalendar {...calendarProps} />
+                </PopoverBody>
+              </PopoverContent>
+            </Portal>
           )}
         </Popover>
       </Box>

--- a/packages/spor-datepicker-react/src/DateRangePicker.tsx
+++ b/packages/spor-datepicker-react/src/DateRangePicker.tsx
@@ -11,6 +11,7 @@ import {
   Portal,
   ResponsiveValue,
   useBreakpointValue,
+  useFormControlContext,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
 import { DateValue } from "@internationalized/date";
@@ -45,9 +46,13 @@ export function DateRangePicker({
   minHeight,
   ...props
 }: DateRangePickerProps) {
+  const formControlProps = useFormControlContext();
   const state = useDateRangePickerState({
     ...props,
     shouldCloseOnSelect: true,
+    errorMessage,
+    isRequired: props.isRequired ?? formControlProps?.isRequired,
+    validationState: formControlProps.isInvalid ? "invalid" : "valid",
   });
   const ref = useRef(null);
   const {

--- a/packages/spor-datepicker-react/src/DateTimeSegment.tsx
+++ b/packages/spor-datepicker-react/src/DateTimeSegment.tsx
@@ -27,7 +27,7 @@ export const DateTimeSegment = ({ segment, state }: DateTimeSegmentProps) => {
         fontVariantNumeric: "tabular-nums",
         boxSizing: "content-box",
       }}
-      px="1px"
+      paddingX="1px"
       textAlign="end"
       outline="none"
       borderRadius="xs"


### PR DESCRIPTION
Denne pull requesten fikser bugsa som blir meldt inn i #629 . 

- Man kan nå bruke datovelgerne inni komponenter som har `overflow:hidden;`
- Man har en minimumsbredde på felt som gjør at datovelgeren ikke blir større og mindre alt ettersom hvilken dato det er
- Man har nå mulighet til å bruke `FormControl`-komponenten til å sende ned om feltet er ugyldig eller ikke.