### PR TITLE
Legg til støtte for å endre årstall i DatePicker

### DIFF
--- a/.changeset/clever-candles-act.md
+++ b/.changeset/clever-candles-act.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": minor
+---
+
+Add support for changing years with the showYearPicker prop

--- a/.changeset/clever-candles-act.md
+++ b/.changeset/clever-candles-act.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-datepicker-react": minor
 ---
 
-Add support for changing years with the showYearPicker prop
+Add support for changing years with the showYearNavigation prop

--- a/packages/spor-datepicker-react/src/Calendar.tsx
+++ b/packages/spor-datepicker-react/src/Calendar.tsx
@@ -3,12 +3,15 @@ import { createCalendar, DateValue } from "@internationalized/date";
 import { useCalendar } from "@react-aria/calendar";
 import { useCalendarState } from "@react-stately/calendar";
 import React from "react";
-import { CalendarProps } from "react-aria";
+import { CalendarProps as ReactAriaCalendarProps } from "react-aria";
 import { CalendarGrid } from "./CalendarGrid";
 import { CalendarHeader } from "./CalendarHeader";
 import { useCurrentLocale } from "./utils";
 
-export function Calendar(props: CalendarProps<DateValue>) {
+type CalendarProps = ReactAriaCalendarProps<DateValue> & {
+  showYearPicker?: boolean;
+};
+export function Calendar({ showYearPicker, ...props }: CalendarProps) {
   const locale = useCurrentLocale();
   const state = useCalendarState({
     ...props,
@@ -16,16 +19,11 @@ export function Calendar(props: CalendarProps<DateValue>) {
     createCalendar,
   });
 
-  const { calendarProps, prevButtonProps, nextButtonProps, title } =
-    useCalendar(props, state);
+  const { calendarProps } = useCalendar(props, state);
 
   return (
     <Box {...calendarProps}>
-      <CalendarHeader
-        title={title}
-        previousButtonProps={prevButtonProps}
-        nextButtonProps={nextButtonProps}
-      />
+      <CalendarHeader state={state} showYearPicker={showYearPicker} />
       <CalendarGrid state={state} />
     </Box>
   );

--- a/packages/spor-datepicker-react/src/Calendar.tsx
+++ b/packages/spor-datepicker-react/src/Calendar.tsx
@@ -9,9 +9,9 @@ import { CalendarHeader } from "./CalendarHeader";
 import { useCurrentLocale } from "./utils";
 
 type CalendarProps = ReactAriaCalendarProps<DateValue> & {
-  showYearPicker?: boolean;
+  showYearNavigation?: boolean;
 };
-export function Calendar({ showYearPicker, ...props }: CalendarProps) {
+export function Calendar({ showYearNavigation, ...props }: CalendarProps) {
   const locale = useCurrentLocale();
   const state = useCalendarState({
     ...props,
@@ -23,7 +23,7 @@ export function Calendar({ showYearPicker, ...props }: CalendarProps) {
 
   return (
     <Box {...calendarProps}>
-      <CalendarHeader state={state} showYearPicker={showYearPicker} />
+      <CalendarHeader state={state} showYearNavigation={showYearNavigation} />
       <CalendarGrid state={state} />
     </Box>
   );

--- a/packages/spor-datepicker-react/src/CalendarHeader.tsx
+++ b/packages/spor-datepicker-react/src/CalendarHeader.tsx
@@ -14,11 +14,11 @@ import { useCurrentLocale } from "./utils";
 type CalendarHeaderProps = {
   state: CalendarState | RangeCalendarState;
   title?: string;
-  showYearPicker?: boolean;
+  showYearNavigation?: boolean;
 };
 export function CalendarHeader({
   state,
-  showYearPicker = false,
+  showYearNavigation = false,
   title,
 }: CalendarHeaderProps) {
   const locale = useCurrentLocale();
@@ -37,7 +37,7 @@ export function CalendarHeader({
     state.visibleRange.start.add({ years: 1 })
   );
   const areAllOtherYearsDisabled = isPreviousYearDisabled && isNextYearDisabled;
-  const isYearPickerVisible = showYearPicker && !areAllOtherYearsDisabled;
+  const isYearPickerVisible = showYearNavigation && !areAllOtherYearsDisabled;
 
   return (
     <Flex alignItems="center" paddingBottom="4" justifyContent="space-between">

--- a/packages/spor-datepicker-react/src/CalendarHeader.tsx
+++ b/packages/spor-datepicker-react/src/CalendarHeader.tsx
@@ -127,10 +127,10 @@ export const CalendarNavigator = ({
 
 const texts = createTexts({
   previous: {
-    nb: "Forrige måned",
-    nn: "Forrige månad",
-    sv: "Föregående månad",
-    en: "Previous month",
+    nb: "Forrige",
+    nn: "Forrige",
+    sv: "Föregående",
+    en: "Previous",
   },
   next: {
     nb: "Neste måned",

--- a/packages/spor-datepicker-react/src/CalendarHeader.tsx
+++ b/packages/spor-datepicker-react/src/CalendarHeader.tsx
@@ -133,10 +133,10 @@ const texts = createTexts({
     en: "Previous",
   },
   next: {
-    nb: "Neste måned",
-    nn: "Neste månad",
-    sv: "Nästa månad",
-    en: "Next month",
+    nb: "Neste",
+    nn: "Neste",
+    sv: "Nästa",
+    en: "Next",
   },
   month: {
     nb: "måned",

--- a/packages/spor-datepicker-react/src/CalendarNavigationButton.tsx
+++ b/packages/spor-datepicker-react/src/CalendarNavigationButton.tsx
@@ -7,7 +7,7 @@ type CalendarButtonProps = AriaButtonProps<"button"> & {
   icon: React.ReactElement;
   "aria-label": string;
 };
-export function MonthNavigationButton({
+export function CalendarNavigationButton({
   icon,
   "aria-label": ariaLabel,
   ...rest

--- a/packages/spor-datepicker-react/src/DatePicker.tsx
+++ b/packages/spor-datepicker-react/src/DatePicker.tsx
@@ -29,7 +29,7 @@ type DatePickerProps = AriaDatePickerProps<DateValue> &
   Pick<BoxProps, "minHeight"> & {
     variant: ResponsiveValue<"simple" | "with-trigger">;
     name?: string;
-    showYearPicker?: boolean;
+    showYearNavigation?: boolean;
   };
 /**
  * A date picker component.
@@ -44,7 +44,7 @@ export function DatePicker({
   variant,
   errorMessage,
   minHeight,
-  showYearPicker,
+  showYearNavigation,
   ...props
 }: DatePickerProps) {
   const formControlProps = useFormControlContext();
@@ -141,7 +141,7 @@ export function DatePicker({
                 <PopoverBody>
                   <Calendar
                     {...calendarProps}
-                    showYearPicker={showYearPicker}
+                    showYearNavigation={showYearNavigation}
                   />
                 </PopoverBody>
               </PopoverContent>

--- a/packages/spor-datepicker-react/src/DatePicker.tsx
+++ b/packages/spor-datepicker-react/src/DatePicker.tsx
@@ -29,6 +29,7 @@ type DatePickerProps = AriaDatePickerProps<DateValue> &
   Pick<BoxProps, "minHeight"> & {
     variant: ResponsiveValue<"simple" | "with-trigger">;
     name?: string;
+    showYearPicker?: boolean;
   };
 /**
  * A date picker component.
@@ -43,6 +44,7 @@ export function DatePicker({
   variant,
   errorMessage,
   minHeight,
+  showYearPicker,
   ...props
 }: DatePickerProps) {
   const formControlProps = useFormControlContext();
@@ -137,7 +139,10 @@ export function DatePicker({
               >
                 <PopoverArrow backgroundColor="white" />
                 <PopoverBody>
-                  <Calendar {...calendarProps} />
+                  <Calendar
+                    {...calendarProps}
+                    showYearPicker={showYearPicker}
+                  />
                 </PopoverBody>
               </PopoverContent>
             </Portal>

--- a/packages/spor-datepicker-react/src/RangeCalendar.tsx
+++ b/packages/spor-datepicker-react/src/RangeCalendar.tsx
@@ -3,12 +3,13 @@ import { createCalendar, DateValue } from "@internationalized/date";
 import { useRangeCalendar } from "@react-aria/calendar";
 import { useRangeCalendarState } from "@react-stately/calendar";
 import React, { useRef } from "react";
-import { RangeCalendarProps } from "react-aria";
+import { RangeCalendarProps as ReactAriaRangeCalendarProps } from "react-aria";
 import { CalendarGrid } from "./CalendarGrid";
 import { CalendarHeader } from "./CalendarHeader";
 import { useCurrentLocale } from "./utils";
 
-export function RangeCalendar(props: RangeCalendarProps<DateValue>) {
+type RangeCalendarProps = ReactAriaRangeCalendarProps<DateValue>;
+export function RangeCalendar(props: RangeCalendarProps) {
   const locale = useCurrentLocale();
   const state = useRangeCalendarState({
     ...props,
@@ -18,16 +19,11 @@ export function RangeCalendar(props: RangeCalendarProps<DateValue>) {
   });
 
   const ref = useRef(null);
-  const { calendarProps, prevButtonProps, nextButtonProps, title } =
-    useRangeCalendar(props, state, ref);
+  const { calendarProps, title } = useRangeCalendar(props, state, ref);
 
   return (
     <Box {...calendarProps} ref={ref}>
-      <CalendarHeader
-        title={title}
-        previousButtonProps={prevButtonProps}
-        nextButtonProps={nextButtonProps}
-      />
+      <CalendarHeader state={state} title={title} />
       <Box display="flex" gap="8">
         <CalendarGrid state={state} />
         <CalendarGrid state={state} offset={{ months: 1 }} />


### PR DESCRIPTION
Denne PRen legger til støtte for å kunne endre år i UIen til DatePicker-komponenten.

Før måtte man trykke veldig mange ganger på bakover- eller fremover-knappene, eller skrive inn for hånd. Nå kan man sette `showYearPicker`-propen, og kunne hoppe mellom år i kalenderen.

Si gjerne hva dere synes om navnet `showYearPicker` - om det funker eller om vi burde velge noe annet. 

Merk at det ikke er støtte for å gjøre det samme i `DateRangePicker` per i dag. Det går nok an, men var litt mer tricky enn jeg orket å utforske i dag.

Fixes #535 