### PR TITLE
Add key to list of links in footer

### DIFF
--- a/apps/docs/app/features/layouts/footer/Footer.tsx
+++ b/apps/docs/app/features/layouts/footer/Footer.tsx
@@ -26,7 +26,7 @@ export const Footer = () => {
         aria-label="Ressurser"
       >
         {menu?.menuItems.map((item) => (
-          <MenuItem title={item.title} url={item.url} />
+          <MenuItem title={item.title} url={item.url} key={title} />
         ))}
       </Flex>
     </Flex>


### PR DESCRIPTION
Denne PRen fikser en bug der jeg ikke hadde lagt til en `key` prop på en liste med rendrede lenker i footeren på siden. Ingen big deal i dette usecaset, men det er jo frustrerende å få en warning i consolen hele tiden.