### PR TITLE
Rename textStyle tilvariant for Text og Heading

### DIFF
--- a/.changeset/short-cats-swim.md
+++ b/.changeset/short-cats-swim.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-typography-react": patch
+---
+
+Deprecate the `textStyle` property in favor of `variant`

--- a/packages/spor-typography-react/src/Heading.tsx
+++ b/packages/spor-typography-react/src/Heading.tsx
@@ -4,16 +4,19 @@ import React from "react";
 
 type TextStyles = keyof typeof tokens.font.style;
 
-export type HeadingProps = ChakraHeadingProps & {
-  textStyle: TextStyles;
+export type HeadingProps = Exclude<ChakraHeadingProps, "textStyle"> & {
+  /** @deprecated Use `variant` instead */
+  textStyle?: TextStyles;
+  /** The size and style of the heading */
+  variant?: TextStyles;
 };
 /**
  * Create your own fancy headings with this component.
  *
- * You can specify the textStyle, which is one of "xs", "sm", "md", "lg", "xl-sans", "xs-serif" and "2xl". The default is "xl-sans".
+ * You can specify the variant, which is one of "xs", "sm", "md", "lg", "xl-sans", "xs-serif" and "2xl". The default is "xl-sans".
  *
  * ```tsx
- * <Heading textStyle="2xl">Look at me!</Heading>
+ * <Heading variant="2xl">Look at me!</Heading>
  * ```
  *
  * You can also specify what level of heading you want. You do this with the `as` prop. The default is "h2".
@@ -23,7 +26,8 @@ export type HeadingProps = ChakraHeadingProps & {
  * ```
  */
 export const Heading = ({
-  textStyle = "xl-display",
+  variant = "xl-display",
+  textStyle = variant,
   as = "h2",
   ...props
 }: any) => {

--- a/packages/spor-typography-react/src/Text.tsx
+++ b/packages/spor-typography-react/src/Text.tsx
@@ -5,15 +5,20 @@ import {
 } from "@chakra-ui/react";
 import React from "react";
 
-export type TextProps = ChakraTextProps;
+export type TextProps = Exclude<ChakraTextProps, "textStyle"> & {
+  /** @deprecated Use `variant` instead */
+  textStyle?: ChakraTextProps["textStyle"];
+  /** The size and style of the text.
+   *
+   * Defaults to "xl" */
+  variant?: ChakraTextProps["textStyle"];
+};
 /**
  * A paragraph of text.
  *
  * ```tsx
  * <Text>Welcome to this paragraph of text.</Text>
  * ```
- *
- * Note that you're most likely going to run into some issues auto-importing this component. That's because Text is a window global, and it'll be available wherever. So take care to import it thorougly. Alternatively, you can import `Paragraph`, which is an alias for the same component.
  */
 export const Text = forwardRef<TextProps, "p">(
   ({ fontSize = "xl", ...props }, ref) => {


### PR DESCRIPTION
Denne PRen renamer `textStyle`-propen til `Text` og `Heading` til `variant`. `textStyle` blir deprekert, og fjernes i neste major.