### PR TITLE
Tillat box props på ProgressLoader og ProgressBar

### DIFF
--- a/.changeset/real-bats-eat.md
+++ b/.changeset/real-bats-eat.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-loader-react": patch
+---
+
+Make it possible to use box props on ProgressBar and ProgressLoader

--- a/packages/spor-loader-react/src/ProgressBar.tsx
+++ b/packages/spor-loader-react/src/ProgressBar.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { useProgressBar } from "react-aria";
 import { useRotatingLabel } from "./useRotatingLabel";
 
-type ProgressBarProps = {
+type ProgressBarProps = BoxProps & {
   /** The percentage of progress made.
    *
    * The value must be between 0 and 100 */
@@ -67,6 +67,7 @@ export const ProgressBar = ({
   height = "0.5rem",
   width = "100%",
   "aria-label": ariaLabel,
+  ...rest
 }: ProgressBarProps) => {
   const { t } = useTranslation();
   const currentLoadingText = useRotatingLabel({
@@ -79,33 +80,41 @@ export const ProgressBar = ({
     "aria-label": ariaLabel || t(texts.label(value)),
   });
   return (
-    <Box {...progressBarProps} title={t(texts.label(value))} minWidth="100px">
-      <Flex
-        backgroundColor="coralGreen"
-        borderRadius="sm"
-        width={width}
-        justifyContent="flex-start"
+    <>
+      <Box
+        {...progressBarProps}
+        title={t(texts.label(value))}
+        minWidth="100px"
+        {...rest}
       >
-        <Box
-          backgroundColor="greenHaze"
+        <Flex
+          backgroundColor="coralGreen"
           borderRadius="sm"
-          height={height}
-          width={`${value}%`}
-          maxWidth="100%"
-          transition="width .2s ease-out"
-        />
-      </Flex>
-      {currentLoadingText && (
-        <Text
-          textAlign="center"
-          marginTop={2}
-          fontWeight="bold"
-          {...labelProps}
+          width={width}
+          justifyContent="flex-start"
+          marginX="auto"
         >
-          {currentLoadingText}
-        </Text>
-      )}
-    </Box>
+          <Box
+            backgroundColor="greenHaze"
+            borderRadius="sm"
+            height={height}
+            width={`${value}%`}
+            maxWidth="100%"
+            transition="width .2s ease-out"
+          />
+        </Flex>
+        {currentLoadingText && (
+          <Text
+            textAlign="center"
+            marginTop={2}
+            fontWeight="bold"
+            {...labelProps}
+          >
+            {currentLoadingText}
+          </Text>
+        )}
+      </Box>
+    </>
   );
 };
 

--- a/packages/spor-loader-react/src/ProgressLoader.tsx
+++ b/packages/spor-loader-react/src/ProgressLoader.tsx
@@ -4,7 +4,7 @@ import React, { useId, useRef } from "react";
 import { useProgressBar } from "react-aria";
 import { useRotatingLabel } from "./useRotatingLabel";
 
-type ProgressLoaderProps = {
+type ProgressLoaderProps = BoxProps & {
   /** The percentage of progress made.
    *
    * The value must be between 0 and 100 */
@@ -62,6 +62,7 @@ export const ProgressLoader = ({
   labelRotationDelay = 5000,
   "aria-label": ariaLabel,
   width,
+  ...rest
 }: ProgressLoaderProps) => {
   const { t } = useTranslation();
   const currentLoadingText = useRotatingLabel({
@@ -78,7 +79,7 @@ export const ProgressLoader = ({
   const progress = ((value - 100) / 100) * progressPathLength;
   const id = useId();
   return (
-    <Box {...progressBarProps} minWidth="100px" width={width}>
+    <Box {...progressBarProps} minWidth="100px" width={width} {...rest}>
       <Box as="svg" viewBox="0 0 246 78" fill="none">
         <Box
           as="path"


### PR DESCRIPTION
Denne PRen legger til støtte for å kunne bruke box props på ProgressLoader og ProgressBar. 

Det gjør det mulig å legge til margin og padding og maks-bredde osv.