### PR TITLE
Fiks at DatePicker kræsjer om den ikke er wrappet i en FormControl

### DIFF
--- a/.changeset/quiet-wasps-walk.md
+++ b/.changeset/quiet-wasps-walk.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Fix a bug where you had to wrap your DatePicker component in a FormControl

--- a/packages/spor-datepicker-react/src/DatePicker.tsx
+++ b/packages/spor-datepicker-react/src/DatePicker.tsx
@@ -53,7 +53,7 @@ export function DatePicker({
     shouldCloseOnSelect: true,
     errorMessage,
     isRequired: props.isRequired ?? formControlProps?.isRequired,
-    validationState: formControlProps.isInvalid ? "invalid" : "valid",
+    validationState: formControlProps?.isInvalid ? "invalid" : "valid",
   });
   const ref = useRef(null);
   const {


### PR DESCRIPTION
Koden antok at man hadde wrappet DatePicker-komponenten i en FormControl. Det skal man ikke trenge. 

Fikset dette med å legge til et spørsmålstegn på riktig plass :)