### PR TITLE
Legg til støtte for å gi illustrasjoner størrelser

### DIFF
--- a/apps/docs/app/routes/__base/ressurser/illustrasjonsbibliotek/index.tsx
+++ b/apps/docs/app/routes/__base/ressurser/illustrasjonsbibliotek/index.tsx
@@ -34,6 +34,7 @@ type LoaderData = {
     title: string;
     imageLightBackground: SanityAsset;
     imageDarkBackground: SanityAsset;
+    size: "small" | "medium" | "large";
     tags: string[];
     description: string;
   }[];
@@ -62,6 +63,7 @@ export const loader = async () => {
       imageLightBackground,
       imageDarkBackground,
       tags,
+      size,
       description
     },
   "article": *[_type == "article" && slug.current == "illustrasjonsbibliotek"][0] {
@@ -87,13 +89,15 @@ export default function IllustrasjonerPage() {
   const { illustrations, article } = useLoaderData<typeof loader>();
   const [searchValue, setSearchValue] = useState("");
   const [background, setBackground] = useState("light");
+  const [size, setSize] = useState("all");
 
   const matchingIllustrations = useMemo(() => {
     const normalizedSearchValue = searchValue.toLowerCase().trim();
     return illustrations.filter(
       (illustration) =>
         illustration.title.toLowerCase().includes(normalizedSearchValue) ||
-        illustration.tags.includes(normalizedSearchValue)
+        illustration.tags.includes(normalizedSearchValue) ||
+        (illustration.size && illustration.size === size)
     );
   }, [illustrations, searchValue]);
 
@@ -135,6 +139,19 @@ export default function IllustrasjonerPage() {
           >
             <option value="light">Lys bakgrunn</option>
             <option value="dark">Mørk bakgrunn</option>
+          </NativeSelect>
+        </Box>
+        <Box>
+          <NativeSelect
+            label="Størrelse"
+            value={size}
+            onChange={(e) => setSize(e.target.value)}
+            width="fit-content"
+          >
+            <option value="all">Alle</option>
+            <option value="small">Små</option>
+            <option value="medium">Middels</option>
+            <option value="large">Store</option>
           </NativeSelect>
         </Box>
       </Flex>

--- a/apps/studio/schemas/documents/illustration.tsx
+++ b/apps/studio/schemas/documents/illustration.tsx
@@ -35,6 +35,21 @@ export const illustration = defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: "size",
+      title: "Size",
+      description:
+        "The illustrations are either meant to be used in certain sizes.",
+      type: "string",
+      options: {
+        list: [
+          { title: "Small", value: "small" },
+          { title: "Medium", value: "medium" },
+          { title: "Large", value: "large" },
+        ],
+        layout: "dropdown",
+      },
+    }),
+    defineField({
       name: "tags",
       title: "Tags",
       description:


### PR DESCRIPTION
Illustrasjonene vi har i Spor er ment for å brukes på forskjellige flater. Noen skal være store, andre kan nedskaleres endel, og noen skal bare være litt store ikoner.

Denne endringen gjør at man kan definere hvilken størrelse en illustrasjon er ment for, og filtrere ut basert på den størrelsen på nettsiden.