### PR TITLE
Disable timepicker-knapper når feltet er disablet

### DIFF
--- a/.changeset/nice-moose-pay.md
+++ b/.changeset/nice-moose-pay.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Make the timepicker buttons disabled

--- a/packages/spor-datepicker-react/src/TimePicker.tsx
+++ b/packages/spor-datepicker-react/src/TimePicker.tsx
@@ -144,6 +144,8 @@ export const TimePicker = ({
         title={backwardsLabel}
         icon={<DropdownLeftFill24Icon />}
         onClick={handleBackwardsClick}
+        isDisabled={isDisabled}
+        style={isDisabled ? { backgroundColor: "transparent" } : {}}
       />
       <TimeField label={label} state={state} name={name} />
       <IconButton
@@ -154,6 +156,8 @@ export const TimePicker = ({
         title={forwardsLabel}
         icon={<DropdownRightFill24Icon />}
         onClick={handleForwardClick}
+        isDisabled={isDisabled}
+        style={isDisabled ? { backgroundColor: "transparent" } : {}}
       />
     </StyledField>
   );


### PR DESCRIPTION
### Bakgrunn
Det gikk an å tabbe seg inn til "bakover" og "fremover" knappene i et disabled Timepicker felt.

### Løsning
Sett isDisabled-propen på disse knappene. Overstyr bakgrunnsfargen til disse knappene, så de ikke får den grå bakgrunnsfargen man får med ghost-knapper.