### PR TITLE
Change the text color of light blue badges

### DIFF
--- a/.changeset/nine-colts-hear.md
+++ b/.changeset/nine-colts-hear.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-theme-react": patch
+"@vygruppen/spor-typography-react": patch
+---
+
+Change the text color of light blue badges

--- a/packages/spor-theme-react/src/components/badge.ts
+++ b/packages/spor-theme-react/src/components/badge.ts
@@ -89,7 +89,7 @@ const colorCombinations: Record<ColorScheme, ColorSpec> = {
   "light-blue": {
     backgroundColor: "lightBlue",
     borderColor: "ocean",
-    color: "darkGrey",
+    color: "darkBlue",
   },
   "dark-blue": {
     backgroundColor: "darkBlue",


### PR DESCRIPTION
## Bakgrunn
Det var implementert feil tekstfarge i light-blue varianten av badges.

## Løsning
Endre til riktig farge (darkBlue).

Fixes #653 