### PR TITLE
Improve how multiline links are rendered

### DIFF
--- a/.changeset/flat-frogs-jog.md
+++ b/.changeset/flat-frogs-jog.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-theme-react": patch
+"@vygruppen/spor-link-react": patch
+---
+
+Improve how multi-line links are rendered

--- a/packages/spor-theme-react/src/components/link.ts
+++ b/packages/spor-theme-react/src/components/link.ts
@@ -17,6 +17,7 @@ const config = defineStyleConfig({
     color: "inherit",
     display: "inline",
     position: "relative",
+    boxDecorationBreak: "clone",
 
     "&:focus, &:focus-visible, &:active, &:hover": {
       backgroundImage: "none",


### PR DESCRIPTION
## Bakgrunn
Se #651 

## Løsning
Legg til `box-decoration-break: clone`-propen, som gjør lenkene mye penere når de brekker over flere linjer.

Fixes #651 