### PR TITLE
Pad timepicker and datepicker dates and times with a leading zero

### DIFF
--- a/.changeset/thirty-rules-doubt.md
+++ b/.changeset/thirty-rules-doubt.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-datepicker-react": patch
+---
+
+Pad all dates and times to be at least two digits (padded with a leading zero)

--- a/packages/spor-datepicker-react/src/DateTimeSegment.tsx
+++ b/packages/spor-datepicker-react/src/DateTimeSegment.tsx
@@ -43,7 +43,14 @@ export const DateTimeSegment = ({ segment, state }: DateTimeSegmentProps) => {
         color: "white",
       }}
     >
-      {segment.text}
+      {isPaddable(segment.type) ? segment.text.padStart(2, "0") : segment.text}
     </Box>
   );
 };
+
+const isPaddable = (segmentType: DateSegment["type"]) =>
+  segmentType === "month" ||
+  segmentType === "day" ||
+  segmentType === "hour" ||
+  segmentType === "minute" ||
+  segmentType === "second";


### PR DESCRIPTION
## Bakgrunn
Før skrev vi bare 9:11 eller 4:20. Det gjorde at størrelsen på date- og timepickerne endret seg når man kom seg opp i tosifra tidspunkt og datoer.

## Løsning
Legg til en 0 før alle datoer og tidspunkt på ett siffer.

Fixes #661 