### PR TITLE
Bytt ut spor.cloud.vy.no med spor.vy.no

### DIFF
--- a/.changeset/violet-kids-doubt.md
+++ b/.changeset/violet-kids-doubt.md
@@ -1,0 +1,13 @@
+---
+"@vygruppen/spor-media-controller-react": patch
+"@vygruppen/spor-icon-react-native": patch
+"@vygruppen/spor-datepicker-react": patch
+"@vygruppen/spor-linjetag-react": patch
+"@vygruppen/spor-button-react": patch
+"@vygruppen/spor-input-react": patch
+"@vygruppen/spor-icon-react": patch
+"@vygruppen/spor-tab-react": patch
+"@vygruppen/spor-react": patch
+---
+
+Update URL for documentation website

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is the monorepo containing Vy's design system, **Spor**, and its supporting
 
 This repo includes the following apps:
 
-- `docs`: a [Remix](https://remix.run) app documenting and demoing the design system. Available @ [spor.cloud.vy.no](https://spor.cloud.vy.no).
-- `studio`: a [Sanity](https://sanity.io) Studio app for creating and editing documentation content. Available @ [spor.cloud.vy.no/studio](https://spor.cloud.vy.no/studio).
+- `docs`: a [Remix](https://remix.run) app documenting and demoing the design system. Available @ [spor.vy.no](https://spor.vy.no).
+- `studio`: a [Sanity](https://sanity.io) Studio app for creating and editing documentation content. Available @ [spor.vy.no/studio](https://spor.vy.no/studio).
 
 This repo also includes a bunch of packages. The ones you need to know about are:
 
@@ -19,7 +19,7 @@ There are others as well, but most of them are meant for internal consumption.
 
 ## Documentation and demos
 
-Feel free to visit our documentation website on [spor.cloud.vy.no](https://spor.cloud.vy.no). You'll find live versions of all components, including extensive documentation. And the website is built by dogfooding the React component library!
+Feel free to visit our documentation website on [spor.vy.no](https://spor.vy.no). You'll find live versions of all components, including extensive documentation. And the website is built by dogfooding the React component library!
 
 If you want, you can also test it out in a [CodeSandbox](https://codesandbox.io/s/demo-spor-b137ig).
 
@@ -63,7 +63,7 @@ export const App = () => {
 };
 ```
 
-You'll find lots of components, and extensive documentation on the [documentation site](https://spor.cloud.vy.no/komponenter).
+You'll find lots of components, and extensive documentation on the [documentation site](https://spor.vy.no/komponenter).
 
 ## Usage (React Native)
 

--- a/apps/docs/app/features/linkable-heading/LinkableHeading.tsx
+++ b/apps/docs/app/features/linkable-heading/LinkableHeading.tsx
@@ -25,7 +25,7 @@ export const LinkableHeading = ({
   const text = getChildrenAsString(props.children);
   const id = props.id || slugify(text as string);
   const { onCopy, hasCopied } = useClipboard(
-    `https://spor.cloud.vy.no${location.pathname}#${id}`
+    `https://spor.vy.no${location.pathname}#${id}`
   );
   return (
     <Flex

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -38,4 +38,4 @@ Then, run the deploy command:
 $ sanity deploy
 ```
 
-This will trigger a build, followed by a deploy to the Sanity project. You can visit your newly deployed site at spor.sanity.studio (or spor.cloud.vy.no/studio).
+This will trigger a build, followed by a deploy to the Sanity project. You can visit your newly deployed site at spor.sanity.studio (or spor.vy.no/studio).

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
       const configuredClient = getClient({ apiVersion: "2022-10-06" });
       const host = window.location.href.includes("localhost")
         ? "http://localhost:3000"
-        : "https://spor.cloud.vy.no";
+        : "https://spor.vy.no";
 
       if (document._type === "article") {
         if (!document.category) {

--- a/packages/spor-button-react/src/Button.tsx
+++ b/packages/spor-button-react/src/Button.tsx
@@ -60,7 +60,7 @@ export type ButtonProps = Exclude<
  * </Button>
  * ```
  *
- * @see https://spor.cloud.vy.no/komponenter/button
+ * @see https://spor.vy.no/komponenter/button
  */
 export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
   const {

--- a/packages/spor-datepicker-react/src/TimePicker.tsx
+++ b/packages/spor-datepicker-react/src/TimePicker.tsx
@@ -56,7 +56,7 @@ type TimePickerProps = Omit<BoxProps, "defaultValue"> & {
  *
  * Note that the TimePicker uses the `Time` class to represent the time. This is a class that is part of the `@internationalized/date` package.
  *
- * @see https://spor.cloud.vy.no/komponenter/timepicker
+ * @see https://spor.vy.no/komponenter/timepicker
  */
 export const TimePicker = ({
   label: externalLabel,

--- a/packages/spor-icon-react-native/README.md
+++ b/packages/spor-icon-react-native/README.md
@@ -30,7 +30,7 @@ Instead, import only the icons you need as named imports.
 
 ### Available icons
 
-Please refer to the [documentation](https://spor.cloud.vy.no/ressurser/ikoner) for a complete list of icons:
+Please refer to the [documentation](https://spor.vy.no/ressurser/ikoner) for a complete list of icons:
 
 ## Development
 

--- a/packages/spor-icon-react/README.md
+++ b/packages/spor-icon-react/README.md
@@ -23,6 +23,7 @@ The naming scheme looks something like this:
 ```
 
 Then, use the icon(s) as follows:
+
 ```
 <AddFill18Icon />
 ```
@@ -45,7 +46,7 @@ This will probably only be interesting for the documentation site or other inter
 
 ### Available icons
 
-Please refer to the [documentation](https://spor.cloud.vy.no/ressurser/ikoner) for a complete list of icons:
+Please refer to the [documentation](https://spor.vy.no/ressurser/ikoner) for a complete list of icons:
 
 ## Development
 

--- a/packages/spor-input-react/src/CardSelect.tsx
+++ b/packages/spor-input-react/src/CardSelect.tsx
@@ -57,7 +57,7 @@ type CardSelectProps = BoxProps & {
  * </CardSelect>
  * ```
  *
- * @see https://spor.cloud.vy.no/komponenter/card-select
+ * @see https://spor.vy.no/komponenter/card-select
  */
 export const CardSelect = forwardRef<CardSelectProps, "button">(
   (

--- a/packages/spor-input-react/src/FormErrorMessage.tsx
+++ b/packages/spor-input-react/src/FormErrorMessage.tsx
@@ -30,7 +30,7 @@ export type FormErrorMessageProps = {
  * </FormControl>
  * ```
  *
- * @see https://spor.cloud.vy.no/komponenter/skjemaelementer
+ * @see https://spor.vy.no/komponenter/skjemaelementer
  */
 export const FormErrorMessage = ({ children }: FormErrorMessageProps) => {
   const formControlContext = useFormControlContext();

--- a/packages/spor-input-react/src/InfoSelect.tsx
+++ b/packages/spor-input-react/src/InfoSelect.tsx
@@ -133,7 +133,7 @@ type InfoSelectProps = {
  * </InfoSelect>
  * ```
  *
- * @see https://spor.cloud.vy.no/komponenter/info-select
+ * @see https://spor.vy.no/komponenter/info-select
  */
 export const InfoSelect = ({
   placeholder,

--- a/packages/spor-linjetag-react/src/InfoTag.tsx
+++ b/packages/spor-linjetag-react/src/InfoTag.tsx
@@ -22,7 +22,7 @@ import type { TagProps } from "./types";
  * />
  * ```
  *
- * @see https://spor.cloud.vy.no/komponenter/linjetags
+ * @see https://spor.vy.no/komponenter/linjetags
  */
 export const InfoTag = ({
   variant,
@@ -33,11 +33,7 @@ export const InfoTag = ({
   const styles = useMultiStyleConfig("InfoTag", { variant, size });
   return (
     <Box sx={styles.container}>
-      <LineIcon
-        variant={variant}
-        size={size}
-        sx={styles.iconContainer}
-      />
+      <LineIcon variant={variant} size={size} sx={styles.iconContainer} />
       <Box sx={styles.textContainer}>
         {title && (
           <Box as="span" sx={styles.title}>

--- a/packages/spor-linjetag-react/src/LineIcon.tsx
+++ b/packages/spor-linjetag-react/src/LineIcon.tsx
@@ -23,7 +23,7 @@ type LineIconProps = BoxProps & {
  * <LineIcon variant="subway" size="lg" />
  * ```
  *
- * @see https://spor.cloud.vy.no/komponenter/linjetags
+ * @see https://spor.vy.no/komponenter/linjetags
  */
 export const LineIcon = ({
   variant,

--- a/packages/spor-linjetag-react/src/TravelTag.tsx
+++ b/packages/spor-linjetag-react/src/TravelTag.tsx
@@ -58,7 +58,7 @@ type TravelTagProps = TagProps &
  * />
  * ```
  *
- * @see https://spor.cloud.vy.no/komponenter/linjetags
+ * @see https://spor.vy.no/komponenter/linjetags
  */
 export const TravelTag = forwardRef<TravelTagProps, As<any>>(
   (

--- a/packages/spor-media-controller-react/README.md
+++ b/packages/spor-media-controller-react/README.md
@@ -18,7 +18,7 @@ import {
 } from "@vygruppen/spor-media-controller-react";
 ```
 
-Please refer to the [documentation](https://spor.cloud.vy.no) for more information.
+Please refer to the [documentation](https://spor.vy.no) for more information.
 
 ## Development
 

--- a/packages/spor-react/README.md
+++ b/packages/spor-react/README.md
@@ -17,7 +17,7 @@ Import the components and functions you need as named imports:
 import { Button, Input } from "@vygruppen/spor-react";
 ```
 
-Each component and function comes with extensive documentation that shows up once you use it. Just hover over the component to make it show up in your IDE. Documentation is also available on [the documentation website](https://spor.cloud.vy.no).
+Each component and function comes with extensive documentation that shows up once you use it. Just hover over the component to make it show up in your IDE. Documentation is also available on [the documentation website](https://spor.vy.no).
 
 ## Development
 

--- a/packages/spor-tab-react/README.md
+++ b/packages/spor-tab-react/README.md
@@ -1,6 +1,7 @@
 # Tab (React)
 
 Tabs are used to switch between particular sets of content or functionality.
+
 ## Installation
 
 ```bash
@@ -11,14 +12,15 @@ $ npm install @vygruppen/spor-tab-react
 
 ```tsx
 import {
-  Tabs, 
-  TabList, 
-  TabPanels, 
-  Tab, 
-  TabPanel
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
 } from "@vygruppen/spor-tab-react";
 ```
-Please refer to the [documentation](https://spor.cloud.vy.no/komponenter/tabs) for further usage examples.
+
+Please refer to the [documentation](https://spor.vy.no/komponenter/tabs) for further usage examples.
 
 ## Development
 


### PR DESCRIPTION
## Bakgrunn
Jeg har endelig klart å overtale @jholtan til å kroke meg opp med spor.vy.no. 

## Løsning
Endre alle referanser fra spor.cloud.vy.no til spor.vy.no