### PR TITLE
Export the TravelTag, InfoTag and LineIcon prop types

### DIFF
--- a/.changeset/healthy-insects-study.md
+++ b/.changeset/healthy-insects-study.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-linjetag-react": patch
+---
+
+Export the props types for external usage

--- a/packages/spor-linjetag-react/src/InfoTag.tsx
+++ b/packages/spor-linjetag-react/src/InfoTag.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { LineIcon } from "./LineIcon";
 import type { TagProps } from "./types";
 
+export type InfoTagProps = TagProps;
+
 /**
  * An info tag component.
  *
@@ -29,7 +31,7 @@ export const InfoTag = ({
   size = "md",
   title,
   description,
-}: TagProps) => {
+}: InfoTagProps) => {
   const styles = useMultiStyleConfig("InfoTag", { variant, size });
   return (
     <Box sx={styles.container}>

--- a/packages/spor-linjetag-react/src/LineIcon.tsx
+++ b/packages/spor-linjetag-react/src/LineIcon.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { getCorrectIcon } from "./icons";
 import { TagProps } from "./types";
 
-type LineIconProps = BoxProps & {
+export type LineIconProps = BoxProps & {
   variant: TagProps["variant"];
   size: TagProps["size"];
 };

--- a/packages/spor-linjetag-react/src/TravelTag.tsx
+++ b/packages/spor-linjetag-react/src/TravelTag.tsx
@@ -17,7 +17,7 @@ import React from "react";
 import { LineIcon } from "./LineIcon";
 import type { TagProps } from "./types";
 
-type TravelTagProps = TagProps &
+export type TravelTagProps = TagProps &
   BoxProps & {
     deviationLevel?: "critical" | "major" | "minor" | "info" | "none";
     isDisabled?: boolean;


### PR DESCRIPTION
## Bakgrunn
Det var ønskelig å hente ut prop typene til linjetags

## Løsning
Eksporter prop-typene til de forskjellige linjetag-komponentene.

Closes #666  👿