### PR TITLE
Add a dialog component to make focus management work as expected

### DIFF
--- a/.changeset/dry-rockets-jog.md
+++ b/.changeset/dry-rockets-jog.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-input-react": patch
+---
+
+Fix bug for CardSelect component where it didn't set its focus correctly

--- a/packages/spor-input-react/src/CardSelect.tsx
+++ b/packages/spor-input-react/src/CardSelect.tsx
@@ -14,6 +14,7 @@ import {
 import React, { useEffect, useRef, useState } from "react";
 import { AriaPositionProps, useButton, useOverlayTrigger } from "react-aria";
 import { useOverlayTriggerState } from "react-stately";
+import { Dialog } from "./Dialog";
 import { Popover } from "./Popover";
 
 type CardSelectProps = BoxProps & {
@@ -134,7 +135,7 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
               sx={styles.card}
               {...overlayProps}
             >
-              {children}
+              <Dialog aria-label={label}>{children}</Dialog>
             </Card>
           </Popover>
         )}

--- a/packages/spor-input-react/src/Dialog.tsx
+++ b/packages/spor-input-react/src/Dialog.tsx
@@ -1,0 +1,29 @@
+import { Box, Heading } from "@chakra-ui/react";
+import React, { useRef } from "react";
+import { AriaDialogProps, useDialog } from "react-aria";
+
+type DialogProps = AriaDialogProps & {
+  /** Optional title tag
+   *
+   * Important! If you don't pass a title, you must pass an `aria-label` prop to the dialog.
+   */
+  title?: string;
+  /** The content of the dialog */
+  children: React.ReactNode;
+};
+/** Internal component for creating card select popovers */
+export const Dialog = ({ title, children, ...props }: DialogProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const { dialogProps, titleProps } = useDialog(props, ref);
+
+  return (
+    <Box {...dialogProps} ref={ref} outline="none">
+      {title && (
+        <Heading as="h3" {...titleProps}>
+          {title}
+        </Heading>
+      )}
+      {children}
+    </Box>
+  );
+};


### PR DESCRIPTION
## Bakgrunn
Neste fokus-steg i CardSelect var ikke innholdet i CardSelect. Det opplevdes som en bug fra et UU-perspektiv.

## Løsning
Bruk react-aria sin useDialog hook til å lage en Dialog-komponent, som styrer fokus på riktig måte.

Closes #670 