### PR TITLE
Samme tekststørrelse i alle inputfelt

### DIFF
--- a/.changeset/hot-toys-admire.md
+++ b/.changeset/hot-toys-admire.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Set the correct text size on all inputs and selects

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -31,6 +31,7 @@ export const DateTimeSegment = ({ segment, state }: DateTimeSegmentProps) => {
       textAlign="end"
       outline="none"
       borderRadius="xs"
+      fontSize="mobile.md"
       color={
         segment.isPlaceholder
           ? "dimGrey"

--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -124,7 +124,6 @@ export const TimePicker = ({
       variant="simple"
       width="fit-content"
       paddingX={2}
-      paddingY={1}
       alignItems="center"
       justifyContent="space-between"
       gap={2}

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -25,7 +25,6 @@ const config = helpers.defineMultiStyleConfig({
       display: "flex",
       flex: 1,
       paddingY: 0.5,
-      minHeight: 64,
       alignItems: "center",
       _hover: {
         boxShadow: getBoxShadowString({

--- a/packages/spor-react/src/theme/components/info-select.ts
+++ b/packages/spor-react/src/theme/components/info-select.ts
@@ -29,6 +29,7 @@ const config = helpers.defineMultiStyleConfig({
       display: "flex",
       justifyContent: "space-between",
       alignItems: "center",
+      fontSize: "mobile.md",
       boxShadow: getBoxShadowString({
         borderColor: mode(
           colors.blackAlpha[400],

--- a/packages/spor-react/src/theme/components/select.ts
+++ b/packages/spor-react/src/theme/components/select.ts
@@ -29,7 +29,7 @@ const config = helpers.defineMultiStyleConfig({
     field: {
       ...Input.baseStyle!(props).field,
       appearance: "none",
-      pt: "16px",
+      paddingTop: "16px",
       "option, optgroup": {
         background: "white",
       },


### PR DESCRIPTION
## Bakgrunn
InfoSelect, NativeSelect, Datepicker og TimePicker hadde 16px i tekststørrelse. Det riktige var 18px.

## Løsning
Sett den til 18px.

I tillegg har alle inputfelter nå en høyde på 54px, slik designet tilsier.

Fixes #690 