### PR TITLE
Ny komponent: PhoneNumberInput

### DIFF
--- a/.changeset/sharp-books-end.md
+++ b/.changeset/sharp-books-end.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Add new components – PhoneNumberInput and AttachedInputs

--- a/apps/docs/app/features/portable-text/interactive-code/LivePreview.tsx
+++ b/apps/docs/app/features/portable-text/interactive-code/LivePreview.tsx
@@ -15,7 +15,8 @@ export const LivePreview = (props: BoxProps) => {
         backgroundColor={isDarkMode ? "darkGrey" : "white"}
         color={isDarkMode ? "white" : "darkGrey"}
         transition="all .1s ease-out"
-        p={4}
+        padding={4}
+        paddingRight={8}
         position="relative"
         {...props}
       >

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "dependencies": {
         "@changesets/cli": "^2.19.0",
+        "awesome-phonenumber": "^5.5.0",
         "patch-package": "^6.4.7",
         "prettier": "^2.5.1",
         "rimraf": "^3.0.2",
@@ -12427,6 +12428,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/awesome-phonenumber": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/awesome-phonenumber/-/awesome-phonenumber-5.5.0.tgz",
+      "integrity": "sha512-jb70XQfn+7JQJEiKFwEFQmGKHe83bnJA6HcHUlDzBX0DaRTq9ye7NpNvriNFrOdxl3LYtvM+/0H8TgLWWf70hA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/axe-core": {
@@ -33648,7 +33657,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.3.5",
@@ -43422,6 +43431,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+    },
+    "awesome-phonenumber": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/awesome-phonenumber/-/awesome-phonenumber-5.5.0.tgz",
+      "integrity": "sha512-jb70XQfn+7JQJEiKFwEFQmGKHe83bnJA6HcHUlDzBX0DaRTq9ye7NpNvriNFrOdxl3LYtvM+/0H8TgLWWf70hA=="
     },
     "axe-core": {
       "version": "4.6.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.19.0",
+    "awesome-phonenumber": "^5.5.0",
     "patch-package": "^6.4.7",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",

--- a/packages/spor-react/src/input/AttachedInputs.tsx
+++ b/packages/spor-react/src/input/AttachedInputs.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Flex, FlexProps } from "..";
+
+type AttachedInputsProps = FlexProps;
+/**
+ * Attaches several inputs together, so that they look like one input.
+ *
+ * ```tsx
+ * <AttachedInputs>
+ *   <Input />
+ *   <NativeSelect>
+ *     <SelectItem />
+ *   </NativeSelect>
+ * </AttachedInputs>
+ * ```
+ */
+export const AttachedInputs = ({
+  flexDirection = "row",
+  ...rest
+}: AttachedInputsProps) => {
+  const attachedStyles = {
+    horizontal: {
+      "> *:first-of-type:not(:last-of-type)": { borderEndRadius: 0 },
+      "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
+      "> *:not(:first-of-type):last-of-type": { borderStartRadius: 0 },
+    },
+    vertical: {
+      "> *:first-of-type:not(:last-of-type)": { borderBottomRadius: 0 },
+      "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
+      "> *:not(:first-of-type):last-of-type": { borderTopRadius: 0 },
+    },
+  };
+  const direction = flexDirection === "row" ? "horizontal" : "vertical";
+  return (
+    <Flex
+      role="group"
+      css={attachedStyles[direction]}
+      flexDirection={flexDirection}
+      {...rest}
+    />
+  );
+};

--- a/packages/spor-react/src/input/AttachedInputs.tsx
+++ b/packages/spor-react/src/input/AttachedInputs.tsx
@@ -20,21 +20,34 @@ export const AttachedInputs = ({
 }: AttachedInputsProps) => {
   const attachedStyles = {
     horizontal: {
-      "> *:first-of-type:not(:last-of-type)": { borderEndRadius: 0 },
-      "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
-      "> *:not(:first-of-type):last-of-type": { borderStartRadius: 0 },
+      "> *:first-of-type:not(:last-of-type) [data-attachable]": {
+        borderEndRadius: 0,
+      },
+      "> *:not(:first-of-type):not(:last-of-type) [data-attachable]": {
+        borderRadius: 0,
+      },
+      "> *:not(:first-of-type):last-of-type [data-attachable]": {
+        borderStartRadius: 0,
+      },
     },
     vertical: {
-      "> *:first-of-type:not(:last-of-type)": { borderBottomRadius: 0 },
-      "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
-      "> *:not(:first-of-type):last-of-type": { borderTopRadius: 0 },
+      "> *:first-of-type:not(:last-of-type) [data-attachable]": {
+        borderBottomRadius: 0,
+      },
+      "> *:not(:first-of-type):not(:last-of-type) [data-attachable]": {
+        borderRadius: 0,
+      },
+      "> *:not(:first-of-type):last-of-type [data-attachable]": {
+        borderTopRadius: 0,
+      },
     },
   };
   const direction = flexDirection === "row" ? "horizontal" : "vertical";
   return (
     <Flex
       role="group"
-      css={attachedStyles[direction]}
+      __css={attachedStyles[direction]}
+      display="flex"
       flexDirection={flexDirection}
       {...rest}
     />

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -110,6 +110,7 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
           sx={styles.trigger}
           {...buttonProps}
           width={width}
+          data-attachable
         >
           <Flex gap={1.5} alignItems="center">
             {icon}

--- a/packages/spor-react/src/input/CountryCodeSelect.tsx
+++ b/packages/spor-react/src/input/CountryCodeSelect.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import {
+  BoxProps,
+  InfoSelect,
+  SelectItem,
+  createTexts,
+  useTranslation,
+} from "..";
+
+import { getSupportedCallingCodes } from "awesome-phonenumber";
+
+const callingCodes = getSupportedCallingCodes()
+  .sort((a, b) => Number(a) - Number(b))
+  .map((code) => ({
+    key: `+${code}`,
+    value: `+${code}`,
+  }))
+  .filter((code) => code.key !== "+47"); // We're adding Norway to the top
+callingCodes.unshift({ key: "+47", value: "+47" }); // Norway
+
+type CountryCodeSelectProps = {
+  value: string;
+  onChange: (value: string | number) => void;
+  width?: BoxProps["width"];
+  height?: BoxProps["height"];
+};
+export const CountryCodeSelect = (props: CountryCodeSelectProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <InfoSelect
+      label={t(texts.countryCode)}
+      isLabelSrOnly={true}
+      items={callingCodes as any}
+      {...props}
+    >
+      {(item) => <SelectItem key={item.key}>{item.key}</SelectItem>}
+    </InfoSelect>
+  );
+};
+
+export default CountryCodeSelect;
+
+const texts = createTexts({
+  countryCode: {
+    nb: "Landkode",
+    nn: "Landskode",
+    en: "Country code",
+    sv: "Landskod",
+  },
+});

--- a/packages/spor-react/src/input/CountryCodeSelect.tsx
+++ b/packages/spor-react/src/input/CountryCodeSelect.tsx
@@ -21,6 +21,7 @@ callingCodes.unshift({ key: "+47", value: "+47" }); // Norway
 type CountryCodeSelectProps = {
   value: string;
   onChange: (value: string | number) => void;
+  name: string;
   width?: BoxProps["width"];
   height?: BoxProps["height"];
 };

--- a/packages/spor-react/src/input/FormErrorMessage.tsx
+++ b/packages/spor-react/src/input/FormErrorMessage.tsx
@@ -1,7 +1,7 @@
 import { Box, BoxProps, useFormControlContext } from "@chakra-ui/react";
 import React from "react";
 
-export type FormErrorMessageProps = {
+export type FormErrorMessageProps = BoxProps & {
   /**
    * The error message itself.
    */
@@ -32,7 +32,10 @@ export type FormErrorMessageProps = {
  *
  * @see https://spor.vy.no/komponenter/skjemaelementer
  */
-export const FormErrorMessage = ({ children }: FormErrorMessageProps) => {
+export const FormErrorMessage = ({
+  children,
+  ...boxProps
+}: FormErrorMessageProps) => {
   const formControlContext = useFormControlContext();
   if (!formControlContext) {
     throw new Error(
@@ -60,6 +63,7 @@ export const FormErrorMessage = ({ children }: FormErrorMessageProps) => {
         zIndex="popover"
         maxWidth="50ch"
         {...errorMessageProps}
+        {...boxProps}
       >
         <Arrow position="absolute" top="-0.25em" left="1em" />
         {children}

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -1,11 +1,11 @@
 import {
-  FormLabel,
-  forwardRef,
   Input as ChakraInput,
+  InputProps as ChakraInputProps,
+  FormLabel,
   InputGroup,
   InputLeftElement,
-  InputProps as ChakraInputProps,
   InputRightElement,
+  forwardRef,
   useFormControlContext,
 } from "@chakra-ui/react";
 import React, { useId } from "react";
@@ -42,8 +42,9 @@ export const Input = forwardRef<InputProps, "input">(
       <InputGroup position="relative">
         {leftIcon && <InputLeftElement>{leftIcon}</InputLeftElement>}
         <ChakraInput
-          pl={leftIcon ? 7 : undefined}
-          pr={rightIcon ? 7 : undefined}
+          data-attachable
+          paddingLeft={leftIcon ? 7 : undefined}
+          paddingRight={rightIcon ? 7 : undefined}
           {...props}
           id={inputId}
           ref={ref}

--- a/packages/spor-react/src/input/NativeSelect.tsx
+++ b/packages/spor-react/src/input/NativeSelect.tsx
@@ -30,7 +30,12 @@ export const NativeSelect = forwardRef<NativeSelectProps, "select">(
     const styles = useMultiStyleConfig("Select", props);
     return (
       <FormControl>
-        <ChakraSelect {...props} rootProps={{ __css: styles.root }} ref={ref} />
+        <ChakraSelect
+          data-attachable
+          {...props}
+          rootProps={{ __css: styles.root }}
+          ref={ref}
+        />
         {label && <FormLabel>{label}</FormLabel>}
       </FormControl>
     );

--- a/packages/spor-react/src/input/PasswordInput.tsx
+++ b/packages/spor-react/src/input/PasswordInput.tsx
@@ -34,6 +34,7 @@ export const PasswordInput = forwardRef<PasswordInputProps, "input">(
           paddingRight={10}
           paddingLeft={leftIcon ? 7 : undefined}
           ref={ref}
+          data-attachable
         />
         <FormLabel htmlFor={inputId} pointerEvents="none">
           {label}

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -31,12 +31,12 @@ type PhoneNumberInputProps = {
  * ```tsx
  * <PhoneNumberInput
  *   value={{ countryCode: '+47', phoneNumber: '81549300' }}
- * onChange={handleChange}
+ *   onChange={handleChange}
  * />
  * ```
  */
 export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
-  (props, ref) => {
+  ({ name, ...props }, ref) => {
     const { t } = useTranslation();
     const [value, onChange] = useControllableState({
       value: props.value,
@@ -69,6 +69,7 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
                 phoneNumber: value.phoneNumber,
               })
             }
+            name={props.name ? `${props.name}-country-code` : "country-code"}
             height="100%"
             width="6.25rem"
           />
@@ -77,6 +78,7 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
           ref={ref}
           label={t(texts.phoneNumber)}
           value={value.phoneNumber}
+          name={props.name ? `${props.name}-phone-number` : "phone-number"}
           onChange={(e) =>
             onChange({
               countryCode: value.countryCode,

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -1,5 +1,5 @@
 import { As, forwardRef, useControllableState } from "@chakra-ui/react";
-import React from "react";
+import React, { Suspense } from "react";
 import { InfoSelect, Input, SelectItem, createTexts, useTranslation } from "..";
 import { AttachedInputs } from "./AttachedInputs";
 
@@ -45,20 +45,31 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
     });
     return (
       <AttachedInputs>
-        <InfoSelect
-          items={countryCodes}
-          label={t(texts.countryCode)}
-          isLabelSrOnly={true}
-          value={value.countryCode}
-          onChange={(countryCode) =>
-            onChange({
-              countryCode: countryCode as string,
-              phoneNumber: value.phoneNumber,
-            })
+        <Suspense
+          fallback={
+            <InfoSelect
+              isLabelSrOnly
+              label=""
+              width="6.25rem"
+              height="100%"
+              value="+47"
+            >
+              <SelectItem key="+47">+47</SelectItem>
+            </InfoSelect>
           }
         >
-          {(item) => <SelectItem key={item.key}>{item.value}</SelectItem>}
-        </InfoSelect>
+          <LazyCountryCodeSelect
+            value={value.countryCode}
+            onChange={(countryCode) =>
+              onChange({
+                countryCode: countryCode as string,
+                phoneNumber: value.phoneNumber,
+              })
+            }
+            height="100%"
+            width="6.25rem"
+          />
+        </Suspense>
         <Input
           ref={ref}
           label={t(texts.phoneNumber)}
@@ -69,6 +80,8 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
               phoneNumber: e.target.value,
             })
           }
+          position="relative"
+          left="-1px" // Makes the borders overlap
         />
       </AttachedInputs>
     );
@@ -76,12 +89,6 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
 );
 
 const texts = createTexts({
-  countryCode: {
-    nb: "Landkode",
-    nn: "Landskode",
-    en: "Country code",
-    sv: "Landskod",
-  },
   phoneNumber: {
     nb: "Telefonnummer",
     nn: "Telefonnummer",
@@ -90,8 +97,4 @@ const texts = createTexts({
   },
 });
 
-const countryCodes = new Array(100)
-  .fill(null)
-  .map((_, i) => ({ key: `+${i + 1}`, value: `+${i + 1}` }))
-  .filter((item) => item.key !== "+47");
-countryCodes.unshift({ key: "+47", value: "+47" });
+const LazyCountryCodeSelect = React.lazy(() => import("./CountryCodeSelect"));

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -41,7 +41,10 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
     const [value, onChange] = useControllableState({
       value: props.value,
       onChange: props.onChange,
-      defaultValue: { countryCode: "+47", phoneNumber: "" },
+      defaultValue: {
+        countryCode: "+47",
+        phoneNumber: "",
+      },
     });
     return (
       <AttachedInputs>

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -1,4 +1,9 @@
-import { As, forwardRef, useControllableState } from "@chakra-ui/react";
+import {
+  As,
+  BoxProps,
+  forwardRef,
+  useControllableState,
+} from "@chakra-ui/react";
 import React, { Suspense } from "react";
 import { InfoSelect, Input, SelectItem, createTexts, useTranslation } from "..";
 import { AttachedInputs } from "./AttachedInputs";
@@ -7,7 +12,7 @@ type CountryCodeAndPhoneNumber = {
   countryCode: string;
   phoneNumber: string;
 };
-type PhoneNumberInputProps = {
+type PhoneNumberInputProps = BoxProps & {
   /** The root name.
    *
    * Please note that when specifying the name, the rendered names will be `${name}-country-code` and `${name}-phone-number`, respectively
@@ -36,18 +41,21 @@ type PhoneNumberInputProps = {
  * ```
  */
 export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
-  ({ name, ...props }, ref) => {
+  (
+    { name, value: externalValue, onChange: externalOnChange, ...boxProps },
+    ref
+  ) => {
     const { t } = useTranslation();
     const [value, onChange] = useControllableState({
-      value: props.value,
-      onChange: props.onChange,
+      value: externalValue,
+      onChange: externalOnChange,
       defaultValue: {
         countryCode: "+47",
         phoneNumber: "",
       },
     });
     return (
-      <AttachedInputs>
+      <AttachedInputs {...boxProps}>
         <Suspense
           fallback={
             <InfoSelect
@@ -69,7 +77,7 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
                 phoneNumber: value.phoneNumber,
               })
             }
-            name={props.name ? `${props.name}-country-code` : "country-code"}
+            name={name ? `${name}-country-code` : "country-code"}
             height="100%"
             width="6.25rem"
           />
@@ -78,7 +86,7 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
           ref={ref}
           label={t(texts.phoneNumber)}
           value={value.phoneNumber}
-          name={props.name ? `${props.name}-phone-number` : "phone-number"}
+          name={name ? `${name}-phone-number` : "phone-number"}
           onChange={(e) =>
             onChange({
               countryCode: value.countryCode,

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -1,0 +1,97 @@
+import { As, forwardRef, useControllableState } from "@chakra-ui/react";
+import React from "react";
+import { InfoSelect, Input, SelectItem, createTexts, useTranslation } from "..";
+import { AttachedInputs } from "./AttachedInputs";
+
+type CountryCodeAndPhoneNumber = {
+  countryCode: string;
+  phoneNumber: string;
+};
+type PhoneNumberInputProps = {
+  /** The root name.
+   *
+   * Please note that when specifying the name, the rendered names will be `${name}-country-code` and `${name}-phone-number`, respectively
+   */
+  name?: string;
+  /** Callback for when the country code or phone number changes */
+  onChange?: (change: CountryCodeAndPhoneNumber) => void;
+  /** The optional value of the country code and phone number */
+  value?: CountryCodeAndPhoneNumber;
+};
+/**
+ * A component for entering phone numbers.
+ *
+ * ```tsx
+ * <PhoneNumberInput name="phone" />
+ * ```
+ *
+ * > Please note that when specifying the name, the rendered names will be `${name}-country-code` and `${name}-phone-number`, respectively
+ *
+ * The field can be controlled as well:
+ * ```tsx
+ * <PhoneNumberInput
+ *   value={{ countryCode: '+47', phoneNumber: '81549300' }}
+ * onChange={handleChange}
+ * />
+ * ```
+ */
+export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
+  (props, ref) => {
+    const { t } = useTranslation();
+    const [value, onChange] = useControllableState({
+      value: props.value,
+      onChange: props.onChange,
+      defaultValue: { countryCode: "+47", phoneNumber: "" },
+    });
+    return (
+      <AttachedInputs>
+        <InfoSelect
+          items={countryCodes}
+          label={t(texts.countryCode)}
+          isLabelSrOnly={true}
+          value={value.countryCode}
+          onChange={(countryCode) =>
+            onChange({
+              countryCode: countryCode as string,
+              phoneNumber: value.phoneNumber,
+            })
+          }
+        >
+          {(item) => <SelectItem key={item.key}>{item.value}</SelectItem>}
+        </InfoSelect>
+        <Input
+          ref={ref}
+          label={t(texts.phoneNumber)}
+          value={value.phoneNumber}
+          onChange={(e) =>
+            onChange({
+              countryCode: value.countryCode,
+              phoneNumber: e.target.value,
+            })
+          }
+        />
+      </AttachedInputs>
+    );
+  }
+);
+
+const texts = createTexts({
+  countryCode: {
+    nb: "Landkode",
+    nn: "Landskode",
+    en: "Country code",
+    sv: "Landskod",
+  },
+  phoneNumber: {
+    nb: "Telefonnummer",
+    nn: "Telefonnummer",
+    en: "Phone number",
+    sv: "Telefonnummer",
+  },
+});
+
+const countryCodes = new Array(100)
+  .fill(null)
+  .map((_, i) => ({ key: `+${i + 1}`, value: `+${i + 1}` }))
+  .filter((item) => item.key !== "+47");
+countryCodes.unshift({ key: "+47", value: "+47" });

--- a/packages/spor-react/src/input/SearchInput.tsx
+++ b/packages/spor-react/src/input/SearchInput.tsx
@@ -51,6 +51,7 @@ export const SearchInput = forwardRef<SearchInputProps, "input">(
           }}
           ref={ref}
           placeholder=" " // This is needed to make the label work as expected
+          data-attachable
         />
         <FormLabel htmlFor={inputId} pointerEvents="none">
           {label ?? t(texts.label)}

--- a/packages/spor-react/src/input/index.tsx
+++ b/packages/spor-react/src/input/index.tsx
@@ -14,6 +14,7 @@ export * from "./InputElement";
 export * from "./ListBox";
 export * from "./NativeSelect";
 export * from "./PasswordInput";
+export * from "./PhoneNumberInput";
 export * from "./Radio";
 export * from "./RadioGroup";
 export * from "./SearchInput";

--- a/packages/spor-react/src/input/index.tsx
+++ b/packages/spor-react/src/input/index.tsx
@@ -1,5 +1,6 @@
 export { FormHelperText, InputGroup } from "@chakra-ui/react";
 export type { InputGroupProps } from "@chakra-ui/react";
+export * from "./AttachedInputs";
 export * from "./CardSelect";
 export * from "./Checkbox";
 export * from "./CheckboxGroup";

--- a/packages/spor-react/src/theme/components/info-select.ts
+++ b/packages/spor-react/src/theme/components/info-select.ts
@@ -1,7 +1,6 @@
 import { anatomy } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
-import { colors } from "../foundations";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
 import { srOnly } from "../utils/sr-utils";
@@ -33,14 +32,11 @@ const config = helpers.defineMultiStyleConfig({
       alignItems: "center",
       fontSize: "mobile.md",
       boxShadow: getBoxShadowString({
-        borderColor: mode(
-          colors.blackAlpha[400],
-          colors.whiteAlpha[400]
-        )(props),
+        borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
       }),
       _hover: {
         boxShadow: getBoxShadowString({
-          borderColor: "darkGrey",
+          borderColor: mode("darkGrey", "whiteAlpha.600")(props),
           borderWidth: 2,
         }),
       },
@@ -53,7 +49,9 @@ const config = helpers.defineMultiStyleConfig({
           outline: "none",
         },
         notFocus: {
-          boxShadow: getBoxShadowString({ borderColor: "darkGrey" }),
+          boxShadow: getBoxShadowString({
+            borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
+          }),
         },
       }),
       _disabled: {

--- a/packages/spor-react/src/theme/components/info-select.ts
+++ b/packages/spor-react/src/theme/components/info-select.ts
@@ -4,6 +4,7 @@ import { mode } from "@chakra-ui/theme-tools";
 import { colors } from "../foundations";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
+import { srOnly } from "../utils/sr-utils";
 
 const parts = anatomy("InfoSelect").parts(
   "container",
@@ -19,6 +20,7 @@ const config = helpers.defineMultiStyleConfig({
     container: {},
     label: {
       position: "relative",
+      ...(props.isLabelSrOnly ? srOnly : {}),
     },
     button: {
       appearance: "none",

--- a/packages/spor-react/src/theme/components/input.ts
+++ b/packages/spor-react/src/theme/components/input.ts
@@ -3,6 +3,7 @@ import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
 import { colors } from "../foundations";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
+import { mode } from "@chakra-ui/theme-tools";
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
@@ -13,14 +14,14 @@ const config = helpers.defineMultiStyleConfig({
       width: "100%",
       outline: "none",
       border: 0,
-      backgroundColor: "white",
+      backgroundColor: mode("white", "darkGrey")(props),
       borderRadius: "sm",
       transitionProperty: "common",
       transitionDuration: "fast",
       position: "relative",
       px: 3,
       height: "54px",
-      fontSize: "18px",
+      fontSize: "mobile.md",
 
       boxShadow: getBoxShadowString({ borderColor: colors.blackAlpha[400] }),
       _hover: {
@@ -84,7 +85,7 @@ const config = helpers.defineMultiStyleConfig({
       "&:not(:placeholder-shown)": {
         pt: "16px",
         "& + label": {
-          transform: "scale(0.825) translateY(-10px)",  
+          transform: "scale(0.825) translateY(-10px)",
         },
       },
     },

--- a/packages/spor-react/src/theme/components/input.ts
+++ b/packages/spor-react/src/theme/components/input.ts
@@ -1,9 +1,8 @@
 import { inputAnatomy as parts } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import { colors } from "../foundations";
+import { mode } from "@chakra-ui/theme-tools";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
-import { mode } from "@chakra-ui/theme-tools";
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
@@ -23,10 +22,12 @@ const config = helpers.defineMultiStyleConfig({
       height: "54px",
       fontSize: "mobile.md",
 
-      boxShadow: getBoxShadowString({ borderColor: colors.blackAlpha[400] }),
+      boxShadow: getBoxShadowString({
+        borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
+      }),
       _hover: {
         boxShadow: getBoxShadowString({
-          borderColor: "darkGrey",
+          borderColor: mode("darkGrey", "whiteAlpha.600")(props),
           borderWidth: 2,
         }),
       },

--- a/packages/spor-react/src/theme/utils/sr-utils.ts
+++ b/packages/spor-react/src/theme/utils/sr-utils.ts
@@ -1,0 +1,13 @@
+/** All the styles you need to hide something visually, while still making it available for screen readers */
+export const srOnly = {
+  border: "0 !important",
+  clip: "rect(1px, 1px, 1px, 1px) !important",
+  clipPath: "inset(50%) !important",
+  height: "1px !important",
+  margin: "-1px !important",
+  overflow: "hidden !important",
+  padding: "0 !important",
+  position: "absolute !important",
+  width: "1px !important",
+  whiteSpace: "nowrap !important",
+};


### PR DESCRIPTION
## Bakgrunn
Under omskrivningen av profilsiden trengte vi en måte å hente inn og vise telefonnummere. Det hadde vi ikke, så da var det på tide å lage det!

## Løsning
Lag en ny komponent, `PhoneNumberInput`, som henter inn landkode og telefonnummer.

Den ser slik ut:

![2023-04-20 15 11 23](https://user-images.githubusercontent.com/1307267/233376775-b26b5f62-b055-4bbe-ab51-118a87cceac6.gif)

Den bruker `awesome-phonenumber` biblioteket som gir oss alle landkodene i verden. Det veier endel, men blir code-splittet ut, og hentet inn asynkront i bakgrunnen. Ganske kult!

APIet er ganske greit:

```tsx
<PhoneNumberInput name="telefonnummer" />
```

Du kan også kontrollere den med `onChange` og `value`:

```tsx
const [state, setState] = useState({ countryCode: '+47', phoneNumber: '' });

<PhoneNumberInput
  value={state}
  onChange={setState}
/>
```

Den fungerer også veldig bra med `<FormControl>`-komponenten!

```tsx
<FormControl isInvalid={errors.phoneNumber}>
  <PhoneNumberInput name="phoneNumber" />
</FormControl>
```

I tillegg til denne komponenten, inkluderer denne PRen også et par småfikser her og der.