### PR TITLE
Addresser litt PhoneNumberInput tilbakemeldinger

### DIFF
--- a/.changeset/lovely-keys-pay.md
+++ b/.changeset/lovely-keys-pay.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Address some feedback from real life usage

--- a/packages/spor-react/src/input/CountryCodeSelect.tsx
+++ b/packages/spor-react/src/input/CountryCodeSelect.tsx
@@ -9,14 +9,22 @@ import {
 
 import { getSupportedCallingCodes } from "awesome-phonenumber";
 
-const callingCodes = getSupportedCallingCodes()
+const prioritizedCountryCodes = [
+  { key: "+47", value: "+47" },
+  { key: "+46", value: "+46" },
+  { key: "+45", value: "+45" },
+];
+
+const sortedCallingCodes = getSupportedCallingCodes()
   .sort((a, b) => Number(a) - Number(b))
   .map((code) => ({
     key: `+${code}`,
     value: `+${code}`,
   }))
-  .filter((code) => code.key !== "+47"); // We're adding Norway to the top
-callingCodes.unshift({ key: "+47", value: "+47" }); // Norway
+  .filter(
+    (code) => !prioritizedCountryCodes.some((pCode) => pCode.key === code.key)
+  );
+const callingCodes = [...prioritizedCountryCodes, ...sortedCallingCodes];
 
 type CountryCodeSelectProps = {
   value: string;

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -10,7 +10,7 @@ import { AttachedInputs } from "./AttachedInputs";
 
 type CountryCodeAndPhoneNumber = {
   countryCode: string;
-  phoneNumber: string;
+  nationalNumber: string;
 };
 type PhoneNumberInputProps = BoxProps & {
   /** The root name.
@@ -51,7 +51,7 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
       onChange: externalOnChange,
       defaultValue: {
         countryCode: "+47",
-        phoneNumber: "",
+        nationalNumber: "",
       },
     });
     return (
@@ -74,7 +74,7 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
             onChange={(countryCode) =>
               onChange({
                 countryCode: countryCode as string,
-                phoneNumber: value.phoneNumber,
+                nationalNumber: value.nationalNumber,
               })
             }
             name={name ? `${name}-country-code` : "country-code"}
@@ -85,12 +85,12 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
         <Input
           ref={ref}
           label={t(texts.phoneNumber)}
-          value={value.phoneNumber}
+          value={value.nationalNumber}
           name={name ? `${name}-phone-number` : "phone-number"}
           onChange={(e) =>
             onChange({
               countryCode: value.countryCode,
-              phoneNumber: e.target.value,
+              nationalNumber: e.target.value,
             })
           }
           position="relative"


### PR DESCRIPTION
## Bakgrunn
Etter å ha tatt den nye PhoneNumberInput i bruk på et faktisk produkt fikk vi litt tilbakemeldinger.

## Løsning
Endre objektet man får tilbake fra å være `{ countryCode: string; phoneNumber: string }` til `{ countryCode: string; nationalNumber: string }`.

Og legg til `+45 (danmark)` og `+46 (sverige)` på toppen av lista av nummere