### PR TITLE
Endre mengden blur på den minste skyggen

### DIFF
--- a/.changeset/warm-trees-talk.md
+++ b/.changeset/warm-trees-talk.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-design-tokens": patch
+---
+
+Change the amount of blur on the smallest shadow token to be in line with what's in Figma

--- a/packages/spor-design-tokens/tokens/depth/shadow.json
+++ b/packages/spor-design-tokens/tokens/depth/shadow.json
@@ -3,7 +3,7 @@
     "shadow": {
       "sm": {
         "keepDetails": true,
-        "value": "0 1px 5px rgba(0, 0, 0, 0.2)",
+        "value": "0 1px 4px rgba(0, 0, 0, 0.2)",
         "color": "{color.palette.black.value}",
         "blur": 2,
         "spread": 0,


### PR DESCRIPTION
## Bakgrunn
Mengden blur på den minste skyggestørrelsen vår var litt for høy i design-tokenene.

## Løsning
Endre mengden blur til å være det samme som i Figma.

Fixes #682 