### PR TITLE
Legge til støtte for darkmode i DatePicker

### DIFF
--- a/.changeset/big-queens-ring.md
+++ b/.changeset/big-queens-ring.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add support for dark mode for Date Picker

--- a/packages/spor-react/src/datepicker/CalendarGrid.tsx
+++ b/packages/spor-react/src/datepicker/CalendarGrid.tsx
@@ -6,6 +6,7 @@ import { Language, useTranslation } from "../i18n";
 import { Text } from "../typography";
 import { CalendarCell } from "./CalendarCell";
 import { useCurrentLocale } from "./utils";
+import { useMultiStyleConfig } from "@chakra-ui/react";
 
 const weekDays: Record<Language, string[]> = {
   nb: ["Ma", "Ti", "On", "To", "Fr", "Lø", "Sø"],
@@ -39,16 +40,14 @@ export function CalendarGrid({ state, offset = {} }: CalendarGridProps) {
     <table {...gridProps}>
       <thead {...headerProps}>
         <tr>
-          {weekDays[language].map((day, index) => (
-            <Text
-              as="th"
-              key={index}
-              color={index < 5 ? "darkGrey" : "greenHaze"}
-              variant="sm"
-            >
-              {day}
-            </Text>
-          ))}
+          {weekDays[language].map((day, index) => {
+            const styles = useMultiStyleConfig("Datepicker", { index });
+            return (
+              <Text as="th" key={index} sx={styles.weekDays} variant="sm">
+                {day}
+              </Text>
+            );
+          })}
         </tr>
       </thead>
       <tbody>

--- a/packages/spor-react/src/datepicker/CalendarGrid.tsx
+++ b/packages/spor-react/src/datepicker/CalendarGrid.tsx
@@ -35,15 +35,20 @@ export function CalendarGrid({ state, offset = {} }: CalendarGridProps) {
   // Get the number of weeks in the month so we can render the proper number of rows.
   const weeksInMonth = getWeeksInMonth(state.visibleRange.start, locale);
   const weeksInMonthRange = new Array(weeksInMonth).fill(0).map((_, i) => i);
+  const styles = useMultiStyleConfig("Datepicker", {});
 
   return (
     <table {...gridProps}>
       <thead {...headerProps}>
         <tr>
           {weekDays[language].map((day, index) => {
-            const styles = useMultiStyleConfig("Datepicker", { index });
             return (
-              <Text as="th" key={index} sx={styles.weekDays} variant="sm">
+              <Text
+                as="th"
+                key={index}
+                sx={index < 5 ? styles.weekdays : styles.weekend}
+                variant="sm"
+              >
                 {day}
               </Text>
             );

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -139,7 +139,7 @@ export function DatePicker({
                 boxShadow="md"
                 sx={styles.calendar}
               >
-                <PopoverArrow backgroundColor="white" />
+                <PopoverArrow sx={styles.arrow} />
                 <PopoverBody>
                   <Calendar
                     {...calendarProps}

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -11,6 +11,7 @@ import {
   ResponsiveValue,
   useBreakpointValue,
   useFormControlContext,
+  useMultiStyleConfig,
 } from "@chakra-ui/react";
 import { DateValue } from "@internationalized/date";
 import { useDatePickerState } from "@react-stately/datepicker";
@@ -87,6 +88,8 @@ export function DatePicker({
 
   const hasTrigger = responsiveVariant === "with-trigger";
 
+  const styles = useMultiStyleConfig("Datepicker", {});
+
   return (
     <I18nProvider locale={locale}>
       <Box position="relative" display="inline-flex" flexDirection="column">
@@ -132,9 +135,9 @@ export function DatePicker({
           {state.isOpen && !props.isDisabled && (
             <Portal>
               <PopoverContent
-                backgroundColor="white"
                 color="darkGrey"
                 boxShadow="md"
+                sx={styles.calendar}
               >
                 <PopoverArrow backgroundColor="white" />
                 <PopoverBody>

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -152,12 +152,11 @@ export function DateRangePicker({
           {state.isOpen && (
             <Portal>
               <PopoverContent
-                backgroundColor="white"
-                color="darkGrey"
+                sx={styles.calendar}
                 boxShadow="md"
                 maxWidth="none"
               >
-                <PopoverArrow backgroundColor="white" />
+                <PopoverArrow sx={styles.arrow} />
                 <PopoverBody>
                   <RangeCalendar {...calendarProps} />
                 </PopoverBody>

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@chakra-ui/react";
+import { Box, useMultiStyleConfig } from "@chakra-ui/react";
 import React, { useRef } from "react";
 import { useDateSegment } from "react-aria";
 import { DateFieldState, DateSegment } from "react-stately";
@@ -18,6 +18,12 @@ export const DateTimeSegment = ({ segment, state }: DateTimeSegmentProps) => {
   const ref = useRef(null);
 
   const { segmentProps } = useDateSegment(segment, state, ref);
+
+  const styles = useMultiStyleConfig("Datepicker", {
+    isPlaceholder: segment.isPlaceholder,
+    isEditable: segment.isEditable,
+  });
+
   return (
     <Box
       {...segmentProps}
@@ -32,13 +38,7 @@ export const DateTimeSegment = ({ segment, state }: DateTimeSegmentProps) => {
       outline="none"
       borderRadius="xs"
       fontSize="mobile.md"
-      color={
-        segment.isPlaceholder
-          ? "dimGrey"
-          : segment.isEditable
-          ? "darkGrey"
-          : "osloGrey"
-      }
+      sx={styles.dateTimeSegment}
       _focus={{
         backgroundColor: "darkTeal",
         color: "white",

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -96,14 +96,14 @@ const config = defineStyleConfig({
         backgroundColor: "lightGrey",
       },
     },
-    additional: ({ colorMode }) => ({
+    additional: (props) => ({
       backgroundColor: "transparent",
-      color: mode("darkGrey", "white")({ colorMode }),
+      color: mode("darkGrey", "white")(props),
       fontWeight: "normal",
       boxShadow: `inset 0 0 0 1px ${mode(
         colors.blackAlpha[400],
         colors.whiteAlpha[400]
-      )({ colorMode })}`,
+      )(props)}`,
       ...focusVisible({
         focus: {
           boxShadow: getBoxShadowString({
@@ -115,7 +115,7 @@ const config = defineStyleConfig({
           boxShadow: `inset 0 0 0 1px ${mode(
             colors.blackAlpha[400],
             colors.whiteAlpha[400]
-          )({ colorMode })}`,
+          )(props)}`,
         },
       }),
       _hover: {
@@ -125,18 +125,18 @@ const config = defineStyleConfig({
         boxShadow: `inset 0 0 0 1px ${mode(
           colors.blackAlpha[400],
           colors.whiteAlpha[300]
-        )({ colorMode })}`,
-        backgroundColor: mode("mint", colors.whiteAlpha[300])({ colorMode }),
+        )(props)}`,
+        backgroundColor: mode("mint", "whiteAlpha.300")(props),
       },
     }),
-    ghost: ({colorMode}) => ({
+    ghost: (props) => ({
       backgroundColor: "transparent",
-      color: mode("darkGrey", "white")({colorMode}),
+      color: mode("darkGrey", "white")(props),
       fontWeight: "normal",
       ...focusVisible({
         focus: {
           boxShadow: getBoxShadowString({
-            borderColor: mode("greenHaze", "azure")({colorMode}),
+            borderColor: mode("greenHaze", "azure")(props),
             borderWidth: 2,
           }),
         },
@@ -145,13 +145,13 @@ const config = defineStyleConfig({
         },
       }),
       _hover: {
-        backgroundColor: mode("seaMist", "pine")({colorMode}),
+        backgroundColor: mode("seaMist", "pine")(props),
         _disabled: {
           color: "blackAlpha.300",
         },
       },
       _active: {
-        backgroundColor: mode("mint", colors.whiteAlpha[300])({colorMode}),
+        backgroundColor: mode("mint", "whiteAlpha.300")(props),
       },
     }),
     floating: {

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -129,14 +129,14 @@ const config = defineStyleConfig({
         backgroundColor: mode("mint", colors.whiteAlpha[300])({ colorMode }),
       },
     }),
-    ghost: () => ({
+    ghost: ({colorMode}) => ({
       backgroundColor: "transparent",
-      color: "darkGrey",
+      color: mode("darkGrey", "white")({colorMode}),
       fontWeight: "normal",
       ...focusVisible({
         focus: {
           boxShadow: getBoxShadowString({
-            borderColor: "greenHaze",
+            borderColor: mode("greenHaze", "azure")({colorMode}),
             borderWidth: 2,
           }),
         },
@@ -145,13 +145,13 @@ const config = defineStyleConfig({
         },
       }),
       _hover: {
-        backgroundColor: "seaMist",
+        backgroundColor: mode("seaMist", "pine")({colorMode}),
         _disabled: {
           color: "blackAlpha.300",
         },
       },
       _active: {
-        backgroundColor: "mint",
+        backgroundColor: mode("mint", colors.whiteAlpha[300])({colorMode}),
       },
     }),
     floating: {

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -9,7 +9,8 @@ const parts = anatomy("datepicker").parts(
   "calendarTriggerButton",
   "arrow",
   "calendar",
-  "weekDays",
+  "weekdays",
+  "weekend",
   "dateCell",
   "inputLabel",
   "dateTimeSegment"
@@ -129,8 +130,11 @@ const config = helpers.defineMultiStyleConfig({
       backgroundColor: mode("white", "night")(props),
       color: mode("darkGrey", "white")(props)
     },
-    weekDays: {
-      color: props.index < 5 ? mode("darkGrey", "white")(props) : mode("greenHaze", "azure")(props)
+    weekdays: {
+      color: mode("darkGrey", "white")(props),
+    },
+    weekend: {
+      color: mode("greenHaze", "azure")(props),
     },
     dateCell: {
       backgroundColor: mode("white", "night")(props),

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -25,7 +25,7 @@ const config = helpers.defineMultiStyleConfig({
     wrapper: {
       backgroundColor: mode("white", "night")(props),
       boxShadow: getBoxShadowString({
-        borderColor: mode(colors.blackAlpha["400"], colors.whiteAlpha["400"])(props),
+        borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
       }),
       transitionProperty: "box-shadow",
       transitionDuration: "fast",
@@ -55,12 +55,12 @@ const config = helpers.defineMultiStyleConfig({
       _disabled: {
         pointerEvents: "none",
         boxShadow: getBoxShadowString({
-          borderColor: mode("osloGrey", colors.whiteAlpha["400"])(props),
+          borderColor: mode("osloGrey", "whiteAlpha.400")(props),
           borderWidth: 1,
         }),
         _focus: {
           boxShadow: getBoxShadowString({
-            borderColor: mode("osloGrey", colors.whiteAlpha["400"])(props),
+            borderColor: mode("osloGrey", "whiteAlpha.400")(props),
             borderWidth: 1,
           }),
         },
@@ -68,19 +68,19 @@ const config = helpers.defineMultiStyleConfig({
     },
     inputLabel: {
       fontSize: "mobile.xs",
-      color: mode("osloGrey", "white")(props),
+      color: mode("darkGrey", "white")(props),
       margin: 0,
     },
     dateTimeSegment: {
       color: mode(
         props.isPlaceholder ? "dimGrey" : props.isEditable ? "darkGrey" : "osloGrey", 
-        props.isPlaceholder ? colors.whiteAlpha["400"] : "white"
+        props.isPlaceholder ? "whiteAlpha.400" : "white"
       )(props),
     },
     calendarTriggerButton: {
       backgroundColor: mode("white", "night")(props),
       boxShadow: `${getBoxShadowString({
-        borderColor: mode(colors.blackAlpha["400"], colors.whiteAlpha["400"])(props),
+        borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
       })}, inset 1px 0 0 1px ${mode("white", colors.night)(props)}`, // to make the shadow colors not multiply
       width: 8,
       display: "flex",

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -1,5 +1,5 @@
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import { anatomy } from "@chakra-ui/theme-tools";
+import { anatomy, mode } from "@chakra-ui/theme-tools";
 import { colors, zIndices } from "../foundations";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
@@ -7,18 +7,21 @@ import { focusVisible } from "../utils/focus-utils";
 const parts = anatomy("datepicker").parts(
   "wrapper",
   "calendarTriggerButton",
+  "calendar",
+  "weekDays",
   "dateCell",
-  "inputLabel"
+  "inputLabel",
+  "dateTimeSegment"
 );
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
 const config = helpers.defineMultiStyleConfig({
-  baseStyle: {
+  baseStyle: ({colorMode, isPlaceholder, isEditable, index }) => ({
     wrapper: {
-      backgroundColor: "white",
+      backgroundColor: mode("white", "night")({ colorMode }),
       boxShadow: getBoxShadowString({
-        borderColor: colors.blackAlpha["400"],
+        borderColor: mode(colors.blackAlpha["400"], colors.whiteAlpha["400"])({colorMode}),
       }),
       transitionProperty: "box-shadow",
       transitionDuration: "fast",
@@ -28,14 +31,14 @@ const config = helpers.defineMultiStyleConfig({
       alignItems: "center",
       _hover: {
         boxShadow: getBoxShadowString({
-          borderColor: "darkGrey",
+          borderColor: mode("darkGrey", "white")({colorMode}),
           borderWidth: 2,
         }),
         zIndex: zIndices.docked,
       },
       _focusWithin: {
         boxShadow: getBoxShadowString({
-          borderColor: "greenHaze",
+          borderColor: mode("greenHaze", "azure")({colorMode}),
           borderWidth: 2,
         }),
       },
@@ -48,12 +51,12 @@ const config = helpers.defineMultiStyleConfig({
       _disabled: {
         pointerEvents: "none",
         boxShadow: getBoxShadowString({
-          borderColor: "osloGrey",
+          borderColor: mode("osloGrey", colors.whiteAlpha["400"])({colorMode}),
           borderWidth: 1,
         }),
         _focus: {
           boxShadow: getBoxShadowString({
-            borderColor: "osloGrey",
+            borderColor: mode("osloGrey", colors.whiteAlpha["400"])({colorMode}),
             borderWidth: 1,
           }),
         },
@@ -61,13 +64,20 @@ const config = helpers.defineMultiStyleConfig({
     },
     inputLabel: {
       fontSize: "mobile.xs",
-      color: "darkGrey",
+      color: mode("osloGrey", "white")({colorMode}),
       margin: 0,
     },
+    dateTimeSegment: {
+      color: mode(
+        isPlaceholder ? "dimGrey" : isEditable ? "darkGrey" : "osloGrey", 
+        isPlaceholder ? colors.whiteAlpha["400"] : "white"
+      )({colorMode}),
+    },
     calendarTriggerButton: {
+      backgroundColor: mode("white", "night")({ colorMode }),
       boxShadow: `${getBoxShadowString({
-        borderColor: colors.blackAlpha["400"],
-      })}, inset 1px 0 0 1px white`, // to make the shadow colors not multiply
+        borderColor: mode(colors.blackAlpha["400"], colors.whiteAlpha["400"])({colorMode}),
+      })}, inset 1px 0 0 1px ${mode("white", colors.teal["600"])({colorMode})}`, // to make the shadow colors not multiply
       width: 8,
       display: "flex",
       alignItems: "center",
@@ -80,24 +90,24 @@ const config = helpers.defineMultiStyleConfig({
 
       _hover: {
         boxShadow: `${getBoxShadowString({
-          borderColor: "darkGrey",
+          borderColor: mode("darkGrey", "white")({colorMode}),
           borderWidth: 2,
-        })}, inset 2px 0 0 2px white`,
+        })}, inset 2px 0 0 2px ${mode("white", colors.teal["600"])({colorMode})}`,
       },
       _active: {
-        backgroundColor: "mint",
+        backgroundColor: mode("mint", "azure")({colorMode}),
       },
       ...focusVisible({
         focus: {
           outline: "none",
           boxShadow: getBoxShadowString({
-            borderColor: "greenHaze",
+            borderColor: mode("greenHaze", "azure")({colorMode}),
             borderWidth: 2,
           }),
         },
         notFocus: {
           boxShadow: getBoxShadowString({
-            borderColor: "darkGrey",
+            borderColor: mode("darkGrey", "white")({colorMode}),
             borderWidth: 1,
           }),
         },
@@ -109,9 +119,16 @@ const config = helpers.defineMultiStyleConfig({
         }),
       },
     },
+    calendar: {
+      backgroundColor: mode("white", "night")({ colorMode }),
+      color: mode("darkGrey", "white")({ colorMode })
+    },
+    weekDays: {
+      color: index < 5 ? mode("darkGrey", "white")({colorMode}) : mode("greenHaze", "azure")({colorMode})
+    },
     dateCell: {
-      backgroundColor: "white",
-      color: "darkGrey",
+      backgroundColor: mode("white", "night")({colorMode}),
+      color: mode("darkGrey", "white")({colorMode}),
       borderRadius: "50%",
       position: "relative",
       transition: ".1s ease-in-out",
@@ -122,14 +139,14 @@ const config = helpers.defineMultiStyleConfig({
       transitionSpeed: "fast",
 
       _hover: {
-        backgroundColor: "seaMist",
+        backgroundColor: mode("seaMist", "pine")({colorMode}),
       },
       ...focusVisible({
         focus: {
           outline: "none",
           boxShadow: getBoxShadowString({
             borderWidth: 2,
-            borderColor: "greenHaze",
+            borderColor: mode("greenHaze", "azure")({colorMode}),
           }),
         },
         notFocus: {
@@ -141,14 +158,14 @@ const config = helpers.defineMultiStyleConfig({
             }),
           },
           _active: {
-            color: "darkGrey",
+            color: mode("darkGrey", "white")({colorMode}),
           },
         },
       }),
       _active: {
         backgroundColor: "seaMist",
         boxShadow: "none",
-        color: "darkGrey",
+        color: mode("darkGrey", "white")({colorMode}),
       },
       _disabled: {
         color: "osloGrey",
@@ -156,7 +173,7 @@ const config = helpers.defineMultiStyleConfig({
         pointerEvents: "none",
       },
       _selected: {
-        backgroundColor: "darkTeal",
+        backgroundColor: mode("darkTeal", "pine")({colorMode}),
         color: "white",
         _active: {
           backgroundColor: "seaMist",
@@ -167,7 +184,7 @@ const config = helpers.defineMultiStyleConfig({
       "&[data-today]": {
         boxShadow: getBoxShadowString({
           borderWidth: 1,
-          borderColor: "osloGrey",
+          borderColor: mode("osloGrey", "dimGrey")({colorMode}),
         }),
       },
       "&[data-unavailable]": {
@@ -175,7 +192,7 @@ const config = helpers.defineMultiStyleConfig({
         color: "osloGrey",
       },
     },
-  },
+  }),
   variants: {
     simple: {
       wrapper: {

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -20,11 +20,11 @@ const $arrowBackground = cssVar("popper-arrow-bg");
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
 const config = helpers.defineMultiStyleConfig({
-  baseStyle: ({colorMode, isPlaceholder, isEditable, index }) => ({
+  baseStyle: (props) => ({
     wrapper: {
-      backgroundColor: mode("white", "night")({ colorMode }),
+      backgroundColor: mode("white", "night")(props),
       boxShadow: getBoxShadowString({
-        borderColor: mode(colors.blackAlpha["400"], colors.whiteAlpha["400"])({colorMode}),
+        borderColor: mode(colors.blackAlpha["400"], colors.whiteAlpha["400"])(props),
       }),
       transitionProperty: "box-shadow",
       transitionDuration: "fast",
@@ -34,14 +34,14 @@ const config = helpers.defineMultiStyleConfig({
       alignItems: "center",
       _hover: {
         boxShadow: getBoxShadowString({
-          borderColor: mode("darkGrey", "white")({colorMode}),
+          borderColor: mode("darkGrey", "white")(props),
           borderWidth: 2,
         }),
         zIndex: zIndices.docked,
       },
       _focusWithin: {
         boxShadow: getBoxShadowString({
-          borderColor: mode("greenHaze", "azure")({colorMode}),
+          borderColor: mode("greenHaze", "azure")(props),
           borderWidth: 2,
         }),
       },
@@ -54,12 +54,12 @@ const config = helpers.defineMultiStyleConfig({
       _disabled: {
         pointerEvents: "none",
         boxShadow: getBoxShadowString({
-          borderColor: mode("osloGrey", colors.whiteAlpha["400"])({colorMode}),
+          borderColor: mode("osloGrey", colors.whiteAlpha["400"])(props),
           borderWidth: 1,
         }),
         _focus: {
           boxShadow: getBoxShadowString({
-            borderColor: mode("osloGrey", colors.whiteAlpha["400"])({colorMode}),
+            borderColor: mode("osloGrey", colors.whiteAlpha["400"])(props),
             borderWidth: 1,
           }),
         },
@@ -67,20 +67,20 @@ const config = helpers.defineMultiStyleConfig({
     },
     inputLabel: {
       fontSize: "mobile.xs",
-      color: mode("osloGrey", "white")({colorMode}),
+      color: mode("osloGrey", "white")(props),
       margin: 0,
     },
     dateTimeSegment: {
       color: mode(
-        isPlaceholder ? "dimGrey" : isEditable ? "darkGrey" : "osloGrey", 
-        isPlaceholder ? colors.whiteAlpha["400"] : "white"
-      )({colorMode}),
+        props.isPlaceholder ? "dimGrey" : props.isEditable ? "darkGrey" : "osloGrey", 
+        props.isPlaceholder ? colors.whiteAlpha["400"] : "white"
+      )(props),
     },
     calendarTriggerButton: {
-      backgroundColor: mode("white", "night")({ colorMode }),
+      backgroundColor: mode("white", "night")(props),
       boxShadow: `${getBoxShadowString({
-        borderColor: mode(colors.blackAlpha["400"], colors.whiteAlpha["400"])({colorMode}),
-      })}, inset 1px 0 0 1px ${mode("white", colors.night)({colorMode})}`, // to make the shadow colors not multiply
+        borderColor: mode(colors.blackAlpha["400"], colors.whiteAlpha["400"])(props),
+      })}, inset 1px 0 0 1px ${mode("white", colors.night)(props)}`, // to make the shadow colors not multiply
       width: 8,
       display: "flex",
       alignItems: "center",
@@ -93,24 +93,24 @@ const config = helpers.defineMultiStyleConfig({
 
       _hover: {
         boxShadow: `${getBoxShadowString({
-          borderColor: mode("darkGrey", "white")({colorMode}),
+          borderColor: mode("darkGrey", "white")(props),
           borderWidth: 2,
-        })}, inset 2px 0 0 2px ${mode("white", colors.night)({colorMode})}`,
+        })}, inset 2px 0 0 2px ${mode("white", colors.night)(props)}`,
       },
       _active: {
-        backgroundColor: mode("mint", "azure")({colorMode}),
+        backgroundColor: mode("mint", "azure")(props),
       },
       ...focusVisible({
         focus: {
           outline: "none",
           boxShadow: getBoxShadowString({
-            borderColor: mode("greenHaze", "azure")({colorMode}),
+            borderColor: mode("greenHaze", "azure")(props),
             borderWidth: 2,
           }),
         },
         notFocus: {
           boxShadow: getBoxShadowString({
-            borderColor: mode("darkGrey", "white")({colorMode}),
+            borderColor: mode("darkGrey", "white")(props),
             borderWidth: 1,
           }),
         },
@@ -123,18 +123,18 @@ const config = helpers.defineMultiStyleConfig({
       },
     },
     arrow: {
-      [$arrowBackground.variable]: mode("white", colors.night)({ colorMode })
+      [$arrowBackground.variable]: mode("white", colors.night)(props)
     },
     calendar: {
-      backgroundColor: mode("white", "night")({ colorMode }),
-      color: mode("darkGrey", "white")({ colorMode })
+      backgroundColor: mode("white", "night")(props),
+      color: mode("darkGrey", "white")(props)
     },
     weekDays: {
-      color: index < 5 ? mode("darkGrey", "white")({colorMode}) : mode("greenHaze", "azure")({colorMode})
+      color: props.index < 5 ? mode("darkGrey", "white")(props) : mode("greenHaze", "azure")(props)
     },
     dateCell: {
-      backgroundColor: mode("white", "night")({colorMode}),
-      color: mode("darkGrey", "white")({colorMode}),
+      backgroundColor: mode("white", "night")(props),
+      color: mode("darkGrey", "white")(props),
       borderRadius: "50%",
       position: "relative",
       transition: ".1s ease-in-out",
@@ -145,14 +145,14 @@ const config = helpers.defineMultiStyleConfig({
       transitionSpeed: "fast",
 
       _hover: {
-        backgroundColor: mode("seaMist", "pine")({colorMode}),
+        backgroundColor: mode("seaMist", "pine")(props),
       },
       ...focusVisible({
         focus: {
           outline: "none",
           boxShadow: getBoxShadowString({
             borderWidth: 2,
-            borderColor: mode("greenHaze", "azure")({colorMode}),
+            borderColor: mode("greenHaze", "azure")(props),
           }),
         },
         notFocus: {
@@ -164,14 +164,14 @@ const config = helpers.defineMultiStyleConfig({
             }),
           },
           _active: {
-            color: mode("darkGrey", "white")({colorMode}),
+            color: mode("darkGrey", "white")(props),
           },
         },
       }),
       _active: {
         backgroundColor: "seaMist",
         boxShadow: "none",
-        color: mode("darkGrey", "white")({colorMode}),
+        color: mode("darkGrey", "white")(props),
       },
       _disabled: {
         color: "osloGrey",
@@ -179,7 +179,7 @@ const config = helpers.defineMultiStyleConfig({
         pointerEvents: "none",
       },
       _selected: {
-        backgroundColor: mode("darkTeal", "pine")({colorMode}),
+        backgroundColor: mode("darkTeal", "pine")(props),
         color: "white",
         _active: {
           backgroundColor: "seaMist",
@@ -190,7 +190,7 @@ const config = helpers.defineMultiStyleConfig({
       "&[data-today]": {
         boxShadow: getBoxShadowString({
           borderWidth: 1,
-          borderColor: mode("osloGrey", "dimGrey")({colorMode}),
+          borderColor: mode("osloGrey", "dimGrey")(props),
         }),
       },
       "&[data-unavailable]": {

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -1,5 +1,5 @@
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import { anatomy, mode } from "@chakra-ui/theme-tools";
+import { anatomy, cssVar, mode } from "@chakra-ui/theme-tools";
 import { colors, zIndices } from "../foundations";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
@@ -7,12 +7,15 @@ import { focusVisible } from "../utils/focus-utils";
 const parts = anatomy("datepicker").parts(
   "wrapper",
   "calendarTriggerButton",
+  "arrow",
   "calendar",
   "weekDays",
   "dateCell",
   "inputLabel",
   "dateTimeSegment"
 );
+
+const $arrowBackground = cssVar("popper-arrow-bg");
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
@@ -77,7 +80,7 @@ const config = helpers.defineMultiStyleConfig({
       backgroundColor: mode("white", "night")({ colorMode }),
       boxShadow: `${getBoxShadowString({
         borderColor: mode(colors.blackAlpha["400"], colors.whiteAlpha["400"])({colorMode}),
-      })}, inset 1px 0 0 1px ${mode("white", colors.teal["600"])({colorMode})}`, // to make the shadow colors not multiply
+      })}, inset 1px 0 0 1px ${mode("white", colors.night)({colorMode})}`, // to make the shadow colors not multiply
       width: 8,
       display: "flex",
       alignItems: "center",
@@ -92,7 +95,7 @@ const config = helpers.defineMultiStyleConfig({
         boxShadow: `${getBoxShadowString({
           borderColor: mode("darkGrey", "white")({colorMode}),
           borderWidth: 2,
-        })}, inset 2px 0 0 2px ${mode("white", colors.teal["600"])({colorMode})}`,
+        })}, inset 2px 0 0 2px ${mode("white", colors.night)({colorMode})}`,
       },
       _active: {
         backgroundColor: mode("mint", "azure")({colorMode}),
@@ -118,6 +121,9 @@ const config = helpers.defineMultiStyleConfig({
           borderWidth: 2,
         }),
       },
+    },
+    arrow: {
+      [$arrowBackground.variable]: mode("white", colors.night)({ colorMode })
     },
     calendar: {
       backgroundColor: mode("white", "night")({ colorMode }),


### PR DESCRIPTION
## Bakgrunn
For å kunne ta i bruk Spor i interne brukerflater, trenger vi støtte for darkMode. Derfor planlegger vi å legge til darkMode i Spor-komponentene etterhvert som vi trenger dem.

## Løsning
Jeg har lagt til mørke farger i datovelgeren. Jeg har prøvd å gjøre det så likt som mulig de komponentene som allerede har støtte for darkMode, men jeg har ikke gjort dette før, så tar gjerne imot innspill hvis dere vil ha noe annerledes 😊 

![image](https://github.com/nsbno/spor/assets/98820614/9b12a77d-ceb0-4b5a-8c34-c6097b20eac2)
![image](https://github.com/nsbno/spor/assets/98820614/c9e8fb65-9b61-464e-9bde-8bc8eed27f07)
<img width="355" alt="image" src="https://github.com/nsbno/spor/assets/98820614/069b3196-9eac-4636-8c53-9182011c24fd">

