### PR TITLE
Forbedre PhoneNumberInput

### DIFF
--- a/.changeset/odd-badgers-end.md
+++ b/.changeset/odd-badgers-end.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Improve the phone number input by only allowing digits, spaces and hyphens

--- a/package-lock.json
+++ b/package-lock.json
@@ -34031,7 +34031,7 @@
     },
     "packages/spor-design-tokens": {
       "name": "@vygruppen/spor-design-tokens",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "json-to-ts": "^1.7.0",
@@ -34057,7 +34057,7 @@
     },
     "packages/spor-icon": {
       "name": "@vygruppen/spor-icon",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "bestzip": "^2.2.0"
@@ -34086,7 +34086,7 @@
     },
     "packages/spor-icon-react": {
       "name": "@vygruppen/spor-icon-react",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@svgr/core": "^6.2.0",
@@ -34109,7 +34109,7 @@
     },
     "packages/spor-icon-react-native": {
       "name": "@vygruppen/spor-icon-react-native",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@shopify/restyle": "^2.1.0",
@@ -34398,7 +34398,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.3.5",

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -84,15 +84,18 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
         </Suspense>
         <Input
           ref={ref}
+          type="tel"
           label={t(texts.phoneNumber)}
           value={value.nationalNumber}
           name={name ? `${name}-phone-number` : "phone-number"}
-          onChange={(e) =>
+          onChange={(e) => {
+            // Removes everything but numbers, spaces and dashes
+            const strippedValue = e.target.value.replace(/[^\d\s-]/g, "");
             onChange({
               countryCode: value.countryCode,
-              nationalNumber: e.target.value,
-            })
-          }
+              nationalNumber: strippedValue,
+            });
+          }}
           position="relative"
           left="-1px" // Makes the borders overlap
         />


### PR DESCRIPTION
## Bakgrunn
Man kan i teorien skrive inn hva man vil i PhoneNumberInput, noe som kanskje ikke gir så mye mening. Man vil jo bare kunne skrive inn tall, kanskje et mellomrom eller to eller en bindestrek. Men gir man folk muligheten, så skriver folk inn mye tull, som igjen kan føre til dårligere datakvalitet.

## Løsning
Bare inkluder tall, bindestreker og mellomrom i godkjent input.

Om man limer inn noe med bokstaver i seg, fjernes bokstavene (men lovlige tegn blir igjen).
Om man skriver inn en bokstav, så ignoreres den.
Om man skrive inn tall (som man tross alt burde) funker det som det skal.

I tillegg la jeg til type="tel" på input-feltet, som får den til å fungere mye bedre på mobile flater.