### PR TITLE
Specify the cjs server module format

### DIFF
--- a/apps/docs/remix.config.js
+++ b/apps/docs/remix.config.js
@@ -6,6 +6,7 @@ module.exports = {
   assetsBuildDirectory: "public/build",
   publicPath: "/build/",
   serverBuildPath: "build/index.js",
+  serverModuleFormat: "cjs",
   devServerPort: 8002,
   ignoredRouteFiles: [".*"],
   watchPaths: ["../../packages/*/dist/index.mjs"],


### PR DESCRIPTION
## Bakgrunn
Ny oppdatering i Remix krevde et nytt flagg for at bygget ikke brekker

## Løsning
Legg til nevnte flagg.