### PR TITLE
Ny komponent: Counter

### DIFF
--- a/.changeset/long-turkeys-thank.md
+++ b/.changeset/long-turkeys-thank.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Add new component - Counter

--- a/package-lock.json
+++ b/package-lock.json
@@ -34398,7 +34398,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.3.5",

--- a/packages/spor-react/src/input/Counter.tsx
+++ b/packages/spor-react/src/input/Counter.tsx
@@ -2,6 +2,7 @@ import {
   chakra,
   useColorModeValue,
   useControllableState,
+  useFormControl,
 } from "@chakra-ui/react";
 import React from "react";
 import {
@@ -12,6 +13,7 @@ import {
   createTexts,
   useTranslation,
 } from "..";
+import { getBoxShadowString } from "../theme/utils/box-shadow-utils";
 import { focusVisible } from "../theme/utils/focus-utils";
 
 type CounterProps = {
@@ -27,6 +29,8 @@ type CounterProps = {
   minValue?: number;
   /** Optional maximum value. Defaults to 99 */
   maxValue?: number;
+  /** Whether the counter is disabled or not */
+  isDisabled?: boolean;
 } & BoxProps;
 /** A simple counter component
  *
@@ -44,12 +48,14 @@ type CounterProps = {
  * ```
  */
 export function Counter({
-  name,
+  name: nameProp,
+  id: idProp,
   value: valueProp,
   defaultValue = 1,
   onChange: onChangeProp,
   minValue = 0,
   maxValue = 99,
+  isDisabled,
   ...boxProps
 }: CounterProps) {
   const { t } = useTranslation();
@@ -58,10 +64,9 @@ export function Counter({
     onChange: onChangeProp,
     defaultValue,
   });
+  const formControlProps = useFormControl({ id: idProp, isDisabled });
   const textColor = useColorModeValue("darkGrey", "white");
   const backgroundColor = useColorModeValue("white", "darkGrey");
-  const focusedTextColor = useColorModeValue("white", "darkGrey");
-  const focusedBackgroundColor = useColorModeValue("darkTeal", "white");
 
   return (
     <Flex alignItems="center" {...boxProps}>
@@ -70,23 +75,41 @@ export function Counter({
         aria-label={t(texts.decrementButtonAriaLabel)}
         onClick={() => onChange(value - 1)}
         visibility={value <= minValue ? "hidden" : "visible"}
+        isDisabled={formControlProps.disabled}
       />
       <chakra.input
         type="number"
-        name={name}
+        name={nameProp}
         value={value}
+        {...formControlProps}
         fontSize="sm"
         fontWeight="bold"
-        width="2ch"
-        marginX={2}
+        width="3ch"
+        marginX={1}
+        paddingX={1}
         borderRadius="xs"
         textAlign="center"
         backgroundColor={backgroundColor}
         color={textColor}
+        transition="all .1s ease-out"
+        _hover={{
+          boxShadow: getBoxShadowString({
+            borderColor: "currentColor",
+            borderWidth: 2,
+          }),
+          _disabled: {
+            boxShadow: "none",
+          },
+        }}
+        _disabled={{
+          opacity: 0.5,
+        }}
         _focus={{
           outline: "none",
-          backgroundColor: focusedBackgroundColor,
-          color: focusedTextColor,
+          boxShadow: getBoxShadowString({
+            borderColor: "primaryGreen",
+            borderWidth: 2,
+          }),
         }}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           const numericInput = Number(e.target.value);
@@ -101,6 +124,7 @@ export function Counter({
         aria-label={t(texts.incrementButtonAriaLabel)}
         onClick={() => onChange(value + 1)}
         visibility={value >= maxValue ? "hidden" : "visible"}
+        isDisabled={formControlProps.disabled}
       />
     </Flex>
   );
@@ -115,6 +139,8 @@ type VerySmallButtonProps = {
   onClick: () => void;
   /** Whether or not the button is hidden */
   visibility?: "visible" | "hidden";
+  /** Whether or not the button is disabled */
+  isDisabled?: boolean;
 };
 /** Internal override for extra small icon buttons */
 const VerySmallButton = (props: VerySmallButtonProps) => {

--- a/packages/spor-react/src/input/Counter.tsx
+++ b/packages/spor-react/src/input/Counter.tsx
@@ -1,0 +1,183 @@
+import { chakra } from "@chakra-ui/react";
+import {
+  Box,
+  BoxProps,
+  Flex,
+  IconButton,
+  createTexts,
+  useTranslation,
+} from "@vygruppen/spor-react";
+import React from "react";
+
+type CounterProps = {
+  /** The name of the input field */
+  name?: string;
+  /** The current value */
+  value?: number;
+  /** Callback for when the value changes */
+  onChange?: (value: number) => void;
+  /** Optional minimum value. Defaults to 0 */
+  minValue?: number;
+  /** Optional maximum value. Defaults to 99 */
+  maxValue?: number;
+} & BoxProps;
+/** A simple counter component
+ *
+ * Allows you to choose a given integer value, like for example the number of
+ * adults on your journey.
+ *
+ * ```tsx
+ * <Counter value={value} onChange={setValue} />
+ * ```
+ *
+ * You can also set a minimum and/or maximum value:
+ *
+ * ```tsx
+ * <Counter value={value} onChange={setValue} minValue={1} maxValue={10} />
+ * ```
+ */
+export function Counter({
+  name,
+  value = 1,
+  onChange = () => {},
+  minValue = 0,
+  maxValue = 99,
+  ...boxProps
+}: CounterProps) {
+  const { t } = useTranslation();
+  return (
+    <Flex alignItems="center" {...boxProps}>
+      <VerySmallButton
+        icon={<SubtractIcon color="white" />}
+        aria-label={t(texts.decrementButtonAriaLabel)}
+        onClick={() => onChange(value - 1)}
+        visibility={value <= minValue ? "hidden" : "visible"}
+      />
+      <chakra.input
+        type="number"
+        name={name}
+        fontSize="sm"
+        width="2ch"
+        marginX={2}
+        borderRadius="xs"
+        textAlign="center"
+        value={value}
+        _focus={{
+          outline: "none",
+          backgroundColor: "darkTeal",
+          color: "white",
+        }}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          const numericInput = Number(e.target.value);
+          if (Number.isNaN(numericInput)) {
+            return;
+          }
+          onChange(numericInput);
+        }}
+      />
+      <VerySmallButton
+        icon={<AddIcon color="white" />}
+        aria-label={t(texts.incrementButtonAriaLabel)}
+        onClick={() => onChange(value + 1)}
+        visibility={value >= maxValue ? "hidden" : "visible"}
+      />
+    </Flex>
+  );
+}
+
+type VerySmallButtonProps = {
+  /** The icon to render */
+  icon: React.ReactNode;
+  /** Accessible label for the icon */
+  "aria-label": string;
+  /** Callback for when the button is clicked */
+  onClick: () => void;
+  /** Whether or not the button is hidden */
+  visibility?: "visible" | "hidden";
+};
+/** Internal override for extra small icon buttons */
+const VerySmallButton = (props: VerySmallButtonProps) => {
+  return (
+    <IconButton
+      variant="primary"
+      size="xs"
+      minWidth="24px"
+      minHeight="24px"
+      _focus={{
+        boxShadow:
+          "inset 0 0 0 2px var(--spor-colors-pine), inset 0 0 0 3px white",
+        "&:not(:focus-visible)": {
+          boxShadow: "none",
+        },
+      }}
+      _focusVisible={{
+        boxShadow:
+          "inset 0 0 0 2px var(--spor-colors-pine), inset 0 0 0 3px white",
+      }}
+      {...props}
+    />
+  );
+};
+
+const SubtractIcon = (props: BoxProps) => (
+  <Box
+    as="svg"
+    viewBox="0 0 30 30"
+    width="24"
+    height="24"
+    stroke="currentColor"
+    {...props}
+  >
+    <line
+      x1="9"
+      y1="15"
+      x2="21"
+      y2="15"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </Box>
+);
+
+const AddIcon = (props: BoxProps) => (
+  <Box
+    as="svg"
+    viewBox="0 0 30 30"
+    width="24"
+    height="24"
+    stroke="currentColor"
+    {...props}
+  >
+    <line
+      x1="9"
+      y1="15"
+      x2="21"
+      y2="15"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="15"
+      y1="9"
+      x2="15"
+      y2="21"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </Box>
+);
+
+const texts = createTexts({
+  decrementButtonAriaLabel: {
+    nb: "Trekk fra 1",
+    en: "Subtract 1",
+    nn: "Trekk frå 1",
+    sv: "Subtrahera 1",
+  },
+  incrementButtonAriaLabel: {
+    nb: "Legg til 1",
+    en: "Add 1",
+    nn: "Legg til 1",
+    sv: "Lägg till 1",
+  },
+});

--- a/packages/spor-react/src/input/Counter.tsx
+++ b/packages/spor-react/src/input/Counter.tsx
@@ -46,6 +46,15 @@ type CounterProps = {
  * ```tsx
  * <Counter value={value} onChange={setValue} minValue={1} maxValue={10} />
  * ```
+ *
+ * You can use the Counter inside of a FormControl component to get IDs etc linked up automatically:
+ *
+ * ```tsx
+ * <FormControl>
+ *   <FormLabel>Number of adults</FormLabel>
+ *   <Counter />
+ * </FormControl>
+ * ```
  */
 export function Counter({
   name: nameProp,

--- a/packages/spor-react/src/input/Counter.tsx
+++ b/packages/spor-react/src/input/Counter.tsx
@@ -76,6 +76,7 @@ export function Counter({
         name={name}
         value={value}
         fontSize="sm"
+        fontWeight="bold"
         width="2ch"
         marginX={2}
         borderRadius="xs"

--- a/packages/spor-react/src/input/Counter.tsx
+++ b/packages/spor-react/src/input/Counter.tsx
@@ -1,4 +1,9 @@
-import { chakra } from "@chakra-ui/react";
+import {
+  chakra,
+  useColorModeValue,
+  useControllableState,
+} from "@chakra-ui/react";
+import React from "react";
 import {
   Box,
   BoxProps,
@@ -6,14 +11,16 @@ import {
   IconButton,
   createTexts,
   useTranslation,
-} from "@vygruppen/spor-react";
-import React from "react";
+} from "..";
+import { focusVisible } from "../theme/utils/focus-utils";
 
 type CounterProps = {
   /** The name of the input field */
   name?: string;
   /** The current value */
   value?: number;
+  /** A default value, if uncontrolled */
+  defaultValue?: number;
   /** Callback for when the value changes */
   onChange?: (value: number) => void;
   /** Optional minimum value. Defaults to 0 */
@@ -38,13 +45,24 @@ type CounterProps = {
  */
 export function Counter({
   name,
-  value = 1,
-  onChange = () => {},
+  value: valueProp,
+  defaultValue = 1,
+  onChange: onChangeProp,
   minValue = 0,
   maxValue = 99,
   ...boxProps
 }: CounterProps) {
   const { t } = useTranslation();
+  const [value, onChange] = useControllableState<number>({
+    value: valueProp,
+    onChange: onChangeProp,
+    defaultValue,
+  });
+  const textColor = useColorModeValue("darkGrey", "white");
+  const backgroundColor = useColorModeValue("white", "darkGrey");
+  const focusedTextColor = useColorModeValue("white", "darkGrey");
+  const focusedBackgroundColor = useColorModeValue("darkTeal", "white");
+
   return (
     <Flex alignItems="center" {...boxProps}>
       <VerySmallButton
@@ -62,10 +80,12 @@ export function Counter({
         borderRadius="xs"
         textAlign="center"
         value={value}
+        backgroundColor={backgroundColor}
+        color={textColor}
         _focus={{
           outline: "none",
-          backgroundColor: "darkTeal",
-          color: "white",
+          backgroundColor: focusedBackgroundColor,
+          color: focusedTextColor,
         }}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           const numericInput = Number(e.target.value);
@@ -87,7 +107,7 @@ export function Counter({
 
 type VerySmallButtonProps = {
   /** The icon to render */
-  icon: React.ReactNode;
+  icon: React.ReactElement;
   /** Accessible label for the icon */
   "aria-label": string;
   /** Callback for when the button is clicked */
@@ -103,17 +123,13 @@ const VerySmallButton = (props: VerySmallButtonProps) => {
       size="xs"
       minWidth="24px"
       minHeight="24px"
-      _focus={{
-        boxShadow:
-          "inset 0 0 0 2px var(--spor-colors-pine), inset 0 0 0 3px white",
-        "&:not(:focus-visible)": {
-          boxShadow: "none",
+      {...focusVisible({
+        notFocus: { boxShadow: "none" },
+        focus: {
+          boxShadow:
+            "inset 0 0 0 2px var(--spor-colors-pine), inset 0 0 0 3px white",
         },
-      }}
-      _focusVisible={{
-        boxShadow:
-          "inset 0 0 0 2px var(--spor-colors-pine), inset 0 0 0 3px white",
-      }}
+      })}
       {...props}
     />
   );

--- a/packages/spor-react/src/input/Counter.tsx
+++ b/packages/spor-react/src/input/Counter.tsx
@@ -74,12 +74,12 @@ export function Counter({
       <chakra.input
         type="number"
         name={name}
+        value={value}
         fontSize="sm"
         width="2ch"
         marginX={2}
         borderRadius="xs"
         textAlign="center"
-        value={value}
         backgroundColor={backgroundColor}
         color={textColor}
         _focus={{

--- a/packages/spor-react/src/input/Counter.tsx
+++ b/packages/spor-react/src/input/Counter.tsx
@@ -124,7 +124,7 @@ const VerySmallButton = (props: VerySmallButtonProps) => {
       size="xs"
       minWidth="24px"
       minHeight="24px"
-      {...focusVisible({
+      sx={focusVisible({
         notFocus: { boxShadow: "none" },
         focus: {
           boxShadow:

--- a/packages/spor-react/src/input/index.tsx
+++ b/packages/spor-react/src/input/index.tsx
@@ -5,6 +5,7 @@ export * from "./CardSelect";
 export * from "./Checkbox";
 export * from "./CheckboxGroup";
 export * from "./ChoiceChip";
+export * from "./Counter";
 export * from "./FormControl";
 export * from "./FormErrorMessage";
 export * from "./FormLabel";


### PR DESCRIPTION
## Bakgrunn
Vi trenger en counter komponent i det nye reisesøket. Vi har ikke implementert dette fra før av.

## Løsning
Implementer en Counter, med minus og pluss knapper.

Åpen for å snakke om navnet på det, samt staten der man kan trykke på teksten og endre den.

Siden jeg bruker `<input type="number" />` så kan man også bruke piltastene. Gøyalt å bruke plattformen innimellom!

![2023-05-22 23 00 47](https://github.com/nsbno/spor/assets/1307267/aa72c39a-3ccc-49a6-a1f5-007c190ae2db)
