### PR TITLE
Add version to docs package.json

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "version": "0.0.1",
   "name": "@vygruppen/docs",
   "description": "A remix rewrite of the docs",
   "license": "MIT",


### PR DESCRIPTION
## Bakgrunn
Docker-bygget cacher avhengighetene mellom bygg, som gjør at den ikke laster ned nyeste versjon av Spor når en ny versjon av Spor blir lansert.

## Løsning
Innfør et versjonerings-felt i package.json. Dette burde på sikt oppdateres automatisk av en github action når vi releaser – men enn så lenge tester vi om det funker generelt sett.