### PR TITLE
NumericStepper – skjule verdien dersom verdien er null + forbedret UU

### DIFF
--- a/.changeset/lemon-snakes-call.md
+++ b/.changeset/lemon-snakes-call.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+NumericStepper: Hide the input field / numeric value if the value is zero (0)

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -104,7 +104,9 @@ export function NumericStepper({
         backgroundColor={backgroundColor}
         color={textColor}
         transition="box-shadow .1s ease-out"
-        opacity={value === 0 ? 0 : 1}
+        visibility={value === 0 ? "hidden" : "visible"}
+        aria-live="assertive"
+        aria-label={value}
         _hover={{
           boxShadow: getBoxShadowString({
             borderColor: "currentColor",

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -103,7 +103,8 @@ export function NumericStepper({
         textAlign="center"
         backgroundColor={backgroundColor}
         color={textColor}
-        transition="all .1s ease-out"
+        transition="box-shadow .1s ease-out"
+        opacity={value === 0 ? 0 : 1}
         _hover={{
           boxShadow: getBoxShadowString({
             borderColor: "currentColor",


### PR DESCRIPTION
## Bakgrunn
Om man har valgt 0 ting, burde man ikke vise tallet. Og så burde tallet leses opp dersom man endrer verdien med knapper.

## Løsning
Implementer dette ved å bruke `visibility`, så den fortsetter å ta opp plass.

![2023-05-24 11 53 46](https://github.com/nsbno/spor/assets/1307267/ae652358-72ba-4779-9830-9d98e546a40e)

Also, legg til `aria-live="assertive"` og `aria-label`, slik at skjermlesere leser opp den nye verdien når man trykker på knapper.