### PR TITLE
Reimplementer oversettelsesfunksjonalitet

### DIFF
--- a/.changeset/angry-dingos-cry.md
+++ b/.changeset/angry-dingos-cry.md
@@ -1,0 +1,7 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Implement all of i18n locally instead of using an external library.
+
+This also adds support for nested hierarchies of keys, as well as fetching the current language through the useTranslation hook

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
     },
     "apps/docs": {
       "name": "@vygruppen/docs",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.4.4",
@@ -5352,14 +5353,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
-    },
-    "node_modules/@leile/lobo-t": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@leile/lobo-t/-/lobo-t-1.0.5.tgz",
-      "integrity": "sha512-A2OaWFEFfs9Gvs5K8IhMgGeHvve+zABWM4kWs849ypvOKDNlWzUFp6rGe6SDAPdUyl3D/9zSNSm5WcKzsqpy1w==",
-      "peerDependencies": {
-        "react": ">=16"
-      }
     },
     "node_modules/@lezer/common": {
       "version": "1.0.2",
@@ -33494,7 +33487,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "2.2.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.3.5",
@@ -33502,7 +33495,6 @@
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
         "@internationalized/date": "^3.0.1",
-        "@leile/lobo-t": "^1.0.5",
         "@vygruppen/spor-design-tokens": "*",
         "@vygruppen/spor-icon-react": "*",
         "@vygruppen/spor-loader": "*",
@@ -37353,12 +37345,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
-    },
-    "@leile/lobo-t": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@leile/lobo-t/-/lobo-t-1.0.5.tgz",
-      "integrity": "sha512-A2OaWFEFfs9Gvs5K8IhMgGeHvve+zABWM4kWs849ypvOKDNlWzUFp6rGe6SDAPdUyl3D/9zSNSm5WcKzsqpy1w==",
-      "requires": {}
     },
     "@lezer/common": {
       "version": "1.0.2",
@@ -42557,7 +42543,7 @@
         "fs-extra": "^11.1.1",
         "match-sorter": "^6.3.1",
         "picosanity": "^4.0.0",
-        "prism-react-renderer": "2.0.4",
+        "prism-react-renderer": "^2.0.4",
         "prismjs": "^1.29.0",
         "react": "^18.2.0",
         "react-aria": "^3.23.0",
@@ -42822,7 +42808,6 @@
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
         "@internationalized/date": "^3.0.1",
-        "@leile/lobo-t": "^1.0.5",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@vygruppen/spor-design-tokens": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5360,9 +5360,9 @@
       "integrity": "sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng=="
     },
     "node_modules/@lezer/highlight": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.4.tgz",
-      "integrity": "sha512-IECkFmw2l7sFcYXrV8iT9GeY4W0fU4CxX0WMwhmhMIVjoDdD1Hr6q3G2NqVtLg/yVe5n7i4menG3tJ2r4eCrPQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.5.tgz",
+      "integrity": "sha512-EsbRBpr1+g+VVX6ZbColI4YQ4bx+6uCpSt5ld/bRV3yRsPZoSItN5J3p5UX0FTkOLh8rduYOtEe93vFaAVUEvA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -9490,18 +9490,18 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.11.1.tgz",
-      "integrity": "sha512-tFoBu3be+R35mA5Ir/SgkVUgMfWwaUe0xfDei9KsNiSpudeNc2yhOxC51etZSj+QJ1hbp/5gFSn9ARAPnf48ug==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.11.2.tgz",
+      "integrity": "sha512-Ve3BH7Iq/Cr80Qj8haPyR/tCZklfq4ILSc73ylw/rUVL4L70O80+B5dwlX/sH1HONq1V7UBZ0mdOAFIhD9mgGg==",
       "dependencies": {
         "get-random-values-esm": "^1.0.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.11.1.tgz",
-      "integrity": "sha512-DSudmGPeltqD90TxEoFDPGlBa77uItn9xxShroZisZXh7RI8OU0aiP0/tkYiqLdhX+dWTuel9gea4485kuy4tg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.11.2.tgz",
+      "integrity": "sha512-zvigdVPTHNh/AVWOlvq3AYTvN/CQLC90K64QbnUql+tQp6GUYJo93JKW32A8+rW1DwQPmvs2X6gpN7eWJ+9XPA==",
       "dependencies": {
         "@babel/traverse": "^7.19.0",
         "@vercel/frameworks": "1.4.2",
@@ -9898,9 +9898,9 @@
       }
     },
     "node_modules/@sanity/client": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.1.1.tgz",
-      "integrity": "sha512-T93HCjJdvylcc1GysF52C3nYyBwiBvygzzIv44EGrRg/NPlWbr4Kc4WaLPmtIsZwadKL6g6F+tNETd5OSUykuA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.1.2.tgz",
+      "integrity": "sha512-8/NRBmyzJaT8ZNZxj3UmOAhvqKxDtXWysogsa4rn+o/Z+zS7upkToh1wSdvoFLcv9uHSYF6JGeycigjwO1Zpnw==",
       "dependencies": {
         "@sanity/eventsource": "^5.0.0",
         "get-it": "^8.1.0",
@@ -9937,9 +9937,9 @@
       "integrity": "sha512-tTi22KoKuER3sldXYl4c1Dq2zU7tMLDkljFiaUKVkBbu4PBvRGCFw75kXZnD2b4Bsp6vin+7sI+AKdCKRhfRuw=="
     },
     "node_modules/@sanity/diff": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.11.1.tgz",
-      "integrity": "sha512-X0aql5prnGedp5nLQRMQYLCi/DpcBFQEezu66N99/90UPhzEwyC/ZaYAlEvRLZgvbDCjtye9BLRZsbQ9X6RJlg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.11.2.tgz",
+      "integrity": "sha512-GpUN6nqcNlNeSHL5Fg0sS0zA2NJDg1QccfjY9qNFTnejPNt/BDEnZDAHpUQkYvsOxZSl/BLGmEzzzQEnIRvPkQ==",
       "dependencies": {
         "diff-match-patch": "^1.0.4"
       },
@@ -9979,9 +9979,9 @@
       }
     },
     "node_modules/@sanity/export": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.11.1.tgz",
-      "integrity": "sha512-yN/9vB3sqy2MGFTfr+ySKlipDD3lrJ38GqSiS7OLUCI0eUPVjw3OODKCq63byKndSKE+QSkaTlVGZCEMHWVdGQ==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.11.2.tgz",
+      "integrity": "sha512-AEZsrPHlQk5ms0bixTUBO2kHqyW7AqOxCffUtfjANts3HFxom6bySCTh9kUGD/O1DHENELOuYLmX9Xx23NNMOA==",
       "dependencies": {
         "archiver": "^5.0.0",
         "debug": "^3.2.7",
@@ -10056,13 +10056,13 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.11.1.tgz",
-      "integrity": "sha512-HvN0ODzbf6OXyhI/CvsFUoFu3PeU8+Mg5YzFXTjp5seO8ZIzb3iz9Fj5D0I06r951frDAxLVzZFoCF0nflcFPg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.11.2.tgz",
+      "integrity": "sha512-vmik6q1iUQjCkqPJi7INk1dOMDkRBJtSGuu229F0pv4WkwslZ0HfbhOBkNtPpbpi29zHrJE2dNQuPHXc1NJ24A==",
       "dependencies": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.11.1",
+        "@sanity/mutator": "3.11.2",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -10241,9 +10241,9 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.11.1.tgz",
-      "integrity": "sha512-uIOkh6zamvUYPMzvIvrT6F5JWhH9DL4OUNuSVwHrQne7tzQHpJPLxIHJ4jfiN62/7NeZ4+b9KhLKs8x61rdnwQ==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.11.2.tgz",
+      "integrity": "sha512-5CBmtTHLZJMGB+MrsvhpRh1ERHhMU5b9WxY8lpvqH0bZBwJeHxneVCfa4ddIOlQ+ck/kMRQacNH8x0j+Ofbgpw==",
       "dependencies": {
         "@sanity/uuid": "^3.0.1",
         "@types/diff-match-patch": "^1.0.32",
@@ -10261,15 +10261,15 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.11.1.tgz",
-      "integrity": "sha512-pC23/PaK59hhaXrVOl6vqHzIu41n4Dwgr5+aW9uZuy9VmHKaA0HczVdSPAF0W+5jvfl6+9m7679BjTExStcHYg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.11.2.tgz",
+      "integrity": "sha512-07ZZSnfX4xfzSgzGglEVuSB/S7KVuEl+sHYHm3hXEIToKxm/84iEFNcoj4mBOMQUVWEIzkFmystfvqfOMz5QOA==",
       "dependencies": {
-        "@sanity/block-tools": "3.11.1",
-        "@sanity/schema": "3.11.1",
+        "@sanity/block-tools": "3.11.2",
+        "@sanity/schema": "3.11.2",
         "@sanity/slate-react": "2.30.1",
-        "@sanity/types": "3.11.1",
-        "@sanity/util": "3.11.1",
+        "@sanity/types": "3.11.2",
+        "@sanity/util": "3.11.2",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -10293,12 +10293,12 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.11.1.tgz",
-      "integrity": "sha512-YD0Mhrbg+UYH96wkYI9axWNJwK+kGi8AHS9cSLbJ4n2QkVROgBvdPcC6OFxzWY50yhpp6IDP/pvBujefKx8n5g==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.11.2.tgz",
+      "integrity": "sha512-2JEEjRjadm864uFn+eg5T7Aw08u30WVj9h7aNz9w/AocNwKu3yEsuLZ6Y7cH5WStbrEW7sEmaXRQaitmnf68Uw==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.11.1",
+        "@sanity/types": "3.11.2",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -10340,11 +10340,11 @@
       "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
     },
     "node_modules/@sanity/types": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.11.1.tgz",
-      "integrity": "sha512-TmCtStfZcf1VTKrPFJOjVhWOvjlrBncn86/0UuE7Ftsgq12tQEyPCpKAzAT6E7uUmr15wMUSvCgXX8hn9/poKg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.11.2.tgz",
+      "integrity": "sha512-61/CESRoW41doHWMizMIRWinO7jEsJbXprfJ/5jGYXGwKvPue93nCbKmDfuq0eDyF1ELh5vN1HA2NPC9p7RhyA==",
       "dependencies": {
-        "@sanity/client": "^6.0.0",
+        "@sanity/client": "^6.1.1",
         "@types/react": "^18.0.25"
       }
     },
@@ -10386,9 +10386,9 @@
       "optional": true
     },
     "node_modules/@sanity/ui/node_modules/framer-motion": {
-      "version": "10.12.13",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.13.tgz",
-      "integrity": "sha512-JczRkFlu1ayXetPkUSoaUmoaK0+PsSHAnb25UFGiJeT2hTsX6IKwC+l0/rJYn+HdyzNbudWFKjeeNSHcykPI4Q==",
+      "version": "10.12.16",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.16.tgz",
+      "integrity": "sha512-w/SfWEIWJkYSgRHYBmln7EhcNo31ao8Xexol8lGXf1pR/tlnBtf1HcxoUmEiEh6pacB4/geku5ami53AAQWHMQ==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -10409,11 +10409,11 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.11.1.tgz",
-      "integrity": "sha512-Fmh1GH8xkgF6Q3wH8TTXMuJek8dVSotvnxBBhgZsX4+OY/g6+ix7QuXFnSZAmPZRNJB4aYq3aWcT3nDumigSQg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.11.2.tgz",
+      "integrity": "sha512-7rJjoGgOkH8mNTtm/T5c7Yz8XsxXWN4umThUHsY1Vtxua92tbpSUnekLW7YcO0AnU9zQrSECrFzpYvfyT4IbZA==",
       "dependencies": {
-        "@sanity/types": "3.11.1",
+        "@sanity/types": "3.11.2",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       },
@@ -10431,20 +10431,20 @@
       }
     },
     "node_modules/@sanity/validation": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.11.1.tgz",
-      "integrity": "sha512-iPomCFQZXaXIWnJSzrl58KeEs9+4/io0gtA+ks7vDcMyqhY7mL+OWw+do8pt/mEDy27nkE2/jzFxss+jaVn4HA==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.11.2.tgz",
+      "integrity": "sha512-xhziiAXrKQtzlio4FTXpiysB+E/TbKx+tXKwCgMNXu4L8QE4QaerH7N6ANvJ/6mu4TvAbTefVoMiUArfxlAKwQ==",
       "dependencies": {
-        "@sanity/types": "3.11.1",
+        "@sanity/types": "3.11.2",
         "date-fns": "^2.26.1",
         "lodash": "^4.17.21",
         "rxjs": "^7.8.0"
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.11.1.tgz",
-      "integrity": "sha512-lHAhgRBLASpsEBgvr2Kz81w3XLEZppVaiTiEWknNaQaGYGdTeRxruj9iE1GLi3lQoIiUlnFdzmhHzMRaiidymg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.11.2.tgz",
+      "integrity": "sha512-xS7Ux/HrKmGTR7xo5sCv2KkrJVKG8dmOKUt84DaorUfBmoNeMG/MK2Sk56zlLXyaxN08pXwwbUhETc+8F8xxrw==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -11247,9 +11247,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.6.tgz",
-      "integrity": "sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.7.tgz",
+      "integrity": "sha512-ojrXpSH2XFCmHm7Jy3q44nXDyN54+EYKP2lBhJ2bqfyPj6cIUW/FZW/Csdia34NQgq7KYcAlHi5184m4X88+yw==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -11348,9 +11348,9 @@
       "dev": true
     },
     "node_modules/@types/testing-library__jest-dom": {
-      "version": "5.14.5",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
-      "integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
+      "version": "5.14.6",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.6.tgz",
+      "integrity": "sha512-FkHXCb+ikSoUP4Y4rOslzTdX5sqYwMxfefKh1GmZ8ce1GOkEHntSp6b5cGadmNfp5e4BMEWOMx+WSKd5/MqlDA==",
       "dev": true,
       "dependencies": {
         "@types/jest": "*"
@@ -15272,9 +15272,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.404",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.404.tgz",
-      "integrity": "sha512-te57sWvQdpxmyd1GiswaodKdXdPgn9cN4ht8JlNa04QgtrfnUdWEo1261rY2vaC6TKaiHn0E7QerJWPKFCvMVw=="
+      "version": "1.4.405",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.405.tgz",
+      "integrity": "sha512-JdDgnwU69FMZURoesf9gNOej2Cms1XJFfLk24y1IBtnAdhTcJY/mXnokmpmxHN59PcykBP4bgUU98vLY44Lhuw=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -17979,9 +17979,9 @@
       "dev": true
     },
     "node_modules/groq": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-3.11.1.tgz",
-      "integrity": "sha512-g4UG/8+XFbZyrP54yJpM9Mhg7AP/lrgRdu44RrpXask9d3qF2LYMG38cWEyZxn1by6Hcl7ylbTJQzwg85+7QGw==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-3.11.2.tgz",
+      "integrity": "sha512-rg6G7fMbw2VUAsHmZxz/gJQxfeHkymSA5W97fUOyXFcHYfSK3bBDWyuTAPST7XkWWT9PDbYh4IWcjYSppEbWRA==",
       "engines": {
         "node": ">=14"
       }
@@ -23295,9 +23295,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mlly": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.1.tgz",
-      "integrity": "sha512-1aMEByaWgBPEbWV2BOPEMySRrzl7rIHXmQxam4DM8jVjalTQDjpN2ZKOLUrwyhfZQO7IXHml2StcHMhooDeEEQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.3.0.tgz",
+      "integrity": "sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.2",
@@ -23561,9 +23561,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
-      "integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q=="
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
     },
     "node_modules/node-stream-zip": {
       "version": "1.15.0",
@@ -24864,9 +24864,9 @@
       }
     },
     "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.2.tgz",
-      "integrity": "sha512-mR/pcIsQhU2UgKYOPjRCSgacmjn08pyrHk+Vrm8WEKjDWgqO43vdRkzmxyZOZWiKr6Ed9gpReQHhLUGVAcn9jw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.3.tgz",
+      "integrity": "sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==",
       "dev": true,
       "dependencies": {
         "icss-utils": "^5.0.0",
@@ -25475,9 +25475,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-live": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-live/-/react-live-4.1.1.tgz",
-      "integrity": "sha512-plF6Rgqq/01CYARIS1qcNlGTHHvKwGlwf+VgGrBFUTOst25IV7VlDF9gjTmJbJVqnZowdD2JwieR4idnkdlaIg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-live/-/react-live-4.1.2.tgz",
+      "integrity": "sha512-YPMD7oBOgLdlkbMunObcs5orQzDXOLuCKRpiSBYkuZsoB806FF8bWzdp6CJ5pO+mnc+upxut2dQYw0vZ6wn7og==",
       "dependencies": {
         "prism-react-renderer": "*",
         "sucrase": "^3.31.0",
@@ -28172,9 +28172,9 @@
       }
     },
     "node_modules/sanity": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.11.1.tgz",
-      "integrity": "sha512-Z7dy72ITdMEgBcy72dHPLP5bWl3HF16dsYSzedzlFGTUgDL/iizc+WWNS5PiSzQDuB5ez+hPErkTDZ3yC7e7hA==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.11.2.tgz",
+      "integrity": "sha512-sR1NGUBFbyDhPKGaDgrVmtJHlC5RppAhFCj6wpbUbB0wDpsJ78pyPvKPQIxG1beTO5t63+t8Dr2TpQ7qc8tUig==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
@@ -28186,26 +28186,26 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.11.1",
-        "@sanity/cli": "3.11.1",
-        "@sanity/client": "^6.0.0",
+        "@sanity/block-tools": "3.11.2",
+        "@sanity/cli": "3.11.2",
+        "@sanity/client": "^6.1.1",
         "@sanity/color": "^2.1.20",
-        "@sanity/diff": "3.11.1",
+        "@sanity/diff": "3.11.2",
         "@sanity/eventsource": "^5.0.0",
-        "@sanity/export": "3.11.1",
+        "@sanity/export": "3.11.2",
         "@sanity/generate-help-url": "^3.0.0",
         "@sanity/icons": "^2.3.0",
         "@sanity/image-url": "^1.0.2",
-        "@sanity/import": "3.11.1",
+        "@sanity/import": "3.11.2",
         "@sanity/logos": "^2.0.2",
-        "@sanity/mutator": "3.11.1",
-        "@sanity/portable-text-editor": "3.11.1",
-        "@sanity/schema": "3.11.1",
-        "@sanity/types": "3.11.1",
+        "@sanity/mutator": "3.11.2",
+        "@sanity/portable-text-editor": "3.11.2",
+        "@sanity/schema": "3.11.2",
+        "@sanity/types": "3.11.2",
         "@sanity/ui": "^1.3.3",
-        "@sanity/util": "3.11.1",
+        "@sanity/util": "3.11.2",
         "@sanity/uuid": "^3.0.1",
-        "@sanity/validation": "3.11.1",
+        "@sanity/validation": "3.11.2",
         "@tanstack/react-virtual": "3.0.0-beta.53",
         "@types/is-hotkey": "^0.1.7",
         "@types/react-copy-to-clipboard": "^5.0.2",
@@ -28305,21 +28305,22 @@
       }
     },
     "node_modules/sanity-plugin-iframe-pane": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sanity-plugin-iframe-pane/-/sanity-plugin-iframe-pane-2.3.0.tgz",
-      "integrity": "sha512-bTq1Fnj1AQv5FXOE/88z41tSlJkfd7Ra/+19CvFOkOdopr7nnCWtztaG+phlqm8cndIs+CMnSxaBByLf/RGcPQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-iframe-pane/-/sanity-plugin-iframe-pane-2.3.1.tgz",
+      "integrity": "sha512-WGY3LtrnAg1wjA7tNpmqATbP1VCAK+DbpMU/4xEoSOhjtZLWQEuKq98l0UcZUMSoO7B7bqG0o78yGS9Oy/28Iw==",
       "dependencies": {
         "@sanity/icons": "^2.2.2",
-        "@sanity/incompatible-plugin": "^1.0.4",
-        "@sanity/ui": "^1.3.0",
-        "usehooks-ts": "^2.9.1"
+        "@sanity/incompatible-plugin": "^1.0.0",
+        "@sanity/ui": "^1.0.0",
+        "usehooks-ts": "2.9.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "react": "^18",
-        "sanity": "^3.0.0"
+        "sanity": "^3",
+        "styled-components": "^5.2"
       }
     },
     "node_modules/sanity/node_modules/@emotion/is-prop-valid": {
@@ -28763,9 +28764,9 @@
       }
     },
     "node_modules/sanity/node_modules/framer-motion": {
-      "version": "10.12.13",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.13.tgz",
-      "integrity": "sha512-JczRkFlu1ayXetPkUSoaUmoaK0+PsSHAnb25UFGiJeT2hTsX6IKwC+l0/rJYn+HdyzNbudWFKjeeNSHcykPI4Q==",
+      "version": "10.12.16",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.16.tgz",
+      "integrity": "sha512-w/SfWEIWJkYSgRHYBmln7EhcNo31ao8Xexol8lGXf1pR/tlnBtf1HcxoUmEiEh6pacB4/geku5ami53AAQWHMQ==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -31507,26 +31508,26 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.9.8.tgz",
-      "integrity": "sha512-dTouGZBm4a2fE0OPafcTQERCp4i3ZOow0Pr0JlOyxKmzJy0JRwXypH013kbZoK6k1ET5tS/g9rwUXIM/AmWXXQ==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.9.9.tgz",
+      "integrity": "sha512-+ZS66LOT7ahKHxh6XrIdcmf2Yk9mNpAbPEj4iF2cs0cAeaDU3xLVPZFF0HbSho89Uxwhx7b5HBgPbdcjQTwQkg==",
       "hasInstallScript": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.9.8",
-        "turbo-darwin-arm64": "1.9.8",
-        "turbo-linux-64": "1.9.8",
-        "turbo-linux-arm64": "1.9.8",
-        "turbo-windows-64": "1.9.8",
-        "turbo-windows-arm64": "1.9.8"
+        "turbo-darwin-64": "1.9.9",
+        "turbo-darwin-arm64": "1.9.9",
+        "turbo-linux-64": "1.9.9",
+        "turbo-linux-arm64": "1.9.9",
+        "turbo-windows-64": "1.9.9",
+        "turbo-windows-arm64": "1.9.9"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.9.8.tgz",
-      "integrity": "sha512-PkTdBjPfgpj/Dob/6SjkzP0BBP80/KmFjLEocXVEECCLJE6tHKbWLRdvc79B0N6SufdYdZ1uvvoU3KPtBokSPw==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.9.9.tgz",
+      "integrity": "sha512-UDGM9E21eCDzF5t1F4rzrjwWutcup33e7ZjNJcW/mJDPorazZzqXGKEPIy9kXwKhamUUXfC7668r6ZuA1WXF2Q==",
       "cpu": [
         "x64"
       ],
@@ -31536,9 +31537,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.9.8.tgz",
-      "integrity": "sha512-sLwqOx3XV57QCEoJM9GnDDnnqidG8wf29ytxssBaWHBdeJTjupyrmzTUrX+tyKo3Q+CjWvbPLyqVqxT4g5NuXQ==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.9.9.tgz",
+      "integrity": "sha512-VyfkXzTJpYLTAQ9krq2myyEq7RPObilpS04lgJ4OO1piq76RNmSpX9F/t9JCaY9Pj/4TL7i0d8PM7NGhwEA5Ag==",
       "cpu": [
         "arm64"
       ],
@@ -31548,9 +31549,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.9.8.tgz",
-      "integrity": "sha512-AMg6VT6sW7aOD1uOs5suxglXfTYz9T0uVyKGKokDweGOYTWmuTMGU5afUT1tYRUwQ+kVPJI+83Atl5Ob0oBsgw==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.9.9.tgz",
+      "integrity": "sha512-Fu1MY29Odg8dHOqXcpIIGC3T63XLOGgnGfbobXMKdrC7JQDvtJv8TUCYciRsyknZYjyyKK1z6zKuYIiDjf3KeQ==",
       "cpu": [
         "x64"
       ],
@@ -31560,9 +31561,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.9.8.tgz",
-      "integrity": "sha512-tLnxFv+OIklwTjiOZ8XMeEeRDAf150Ry4BCivNwgTVFAqQGEqkFP6KGBy56hb5RRF1frPQpoPGipJNVm7c8m1w==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.9.9.tgz",
+      "integrity": "sha512-50LI8NafPuJxdnMCBeDdzgyt1cgjQG7FwkyY336v4e95WJPUVjrHdrKH6jYXhOUyrv9+jCJxwX1Yrg02t5yJ1g==",
       "cpu": [
         "arm64"
       ],
@@ -31572,9 +31573,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.9.8.tgz",
-      "integrity": "sha512-r3pCjvXTMR7kq2E3iqwFlN1R7pFO/TOsuUjMhOSPP7HwuuUIinAckU4I9foM3q7ZCQd1XXScBUt3niDyHijAqQ==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.9.9.tgz",
+      "integrity": "sha512-9IsTReoLmQl1IRsy3WExe2j2RKWXQyXujfJ4fXF+jp08KxjVF4/tYP2CIRJx/A7UP/7keBta27bZqzAjsmbSTA==",
       "cpu": [
         "x64"
       ],
@@ -31584,9 +31585,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.9.8.tgz",
-      "integrity": "sha512-CWzRbX2TM5IfHBC6uWM659qUOEDC4h0nn16ocG8yIq1IF3uZMzKRBHgGOT5m1BHom+R08V0NcjTmPRoqpiI0dg==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.9.9.tgz",
+      "integrity": "sha512-CUu4hpeQo68JjDr0V0ygTQRLbS+/sNfdqEVV+Xz9136vpKn2WMQLAuUBVZV0Sp0S/7i+zGnplskT0fED+W46wQ==",
       "cpu": [
         "arm64"
       ],
@@ -33490,7 +33491,7 @@
       "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/react": "^2.3.5",
+        "@chakra-ui/react": "^2.6.1",
         "@chakra-ui/theme-tools": "^2.0.12",
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
@@ -37352,9 +37353,9 @@
       "integrity": "sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng=="
     },
     "@lezer/highlight": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.4.tgz",
-      "integrity": "sha512-IECkFmw2l7sFcYXrV8iT9GeY4W0fU4CxX0WMwhmhMIVjoDdD1Hr6q3G2NqVtLg/yVe5n7i4menG3tJ2r4eCrPQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.5.tgz",
+      "integrity": "sha512-EsbRBpr1+g+VVX6ZbColI4YQ4bx+6uCpSt5ld/bRV3yRsPZoSItN5J3p5UX0FTkOLh8rduYOtEe93vFaAVUEvA==",
       "requires": {
         "@lezer/common": "^1.0.0"
       }
@@ -40687,18 +40688,18 @@
       }
     },
     "@sanity/block-tools": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.11.1.tgz",
-      "integrity": "sha512-tFoBu3be+R35mA5Ir/SgkVUgMfWwaUe0xfDei9KsNiSpudeNc2yhOxC51etZSj+QJ1hbp/5gFSn9ARAPnf48ug==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.11.2.tgz",
+      "integrity": "sha512-Ve3BH7Iq/Cr80Qj8haPyR/tCZklfq4ILSc73ylw/rUVL4L70O80+B5dwlX/sH1HONq1V7UBZ0mdOAFIhD9mgGg==",
       "requires": {
         "get-random-values-esm": "^1.0.0",
         "lodash": "^4.17.21"
       }
     },
     "@sanity/cli": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.11.1.tgz",
-      "integrity": "sha512-DSudmGPeltqD90TxEoFDPGlBa77uItn9xxShroZisZXh7RI8OU0aiP0/tkYiqLdhX+dWTuel9gea4485kuy4tg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.11.2.tgz",
+      "integrity": "sha512-zvigdVPTHNh/AVWOlvq3AYTvN/CQLC90K64QbnUql+tQp6GUYJo93JKW32A8+rW1DwQPmvs2X6gpN7eWJ+9XPA==",
       "requires": {
         "@babel/traverse": "^7.19.0",
         "@vercel/frameworks": "1.4.2",
@@ -40883,9 +40884,9 @@
       }
     },
     "@sanity/client": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.1.1.tgz",
-      "integrity": "sha512-T93HCjJdvylcc1GysF52C3nYyBwiBvygzzIv44EGrRg/NPlWbr4Kc4WaLPmtIsZwadKL6g6F+tNETd5OSUykuA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.1.2.tgz",
+      "integrity": "sha512-8/NRBmyzJaT8ZNZxj3UmOAhvqKxDtXWysogsa4rn+o/Z+zS7upkToh1wSdvoFLcv9uHSYF6JGeycigjwO1Zpnw==",
       "requires": {
         "@sanity/eventsource": "^5.0.0",
         "get-it": "^8.1.0",
@@ -40910,9 +40911,9 @@
       "integrity": "sha512-tTi22KoKuER3sldXYl4c1Dq2zU7tMLDkljFiaUKVkBbu4PBvRGCFw75kXZnD2b4Bsp6vin+7sI+AKdCKRhfRuw=="
     },
     "@sanity/diff": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.11.1.tgz",
-      "integrity": "sha512-X0aql5prnGedp5nLQRMQYLCi/DpcBFQEezu66N99/90UPhzEwyC/ZaYAlEvRLZgvbDCjtye9BLRZsbQ9X6RJlg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.11.2.tgz",
+      "integrity": "sha512-GpUN6nqcNlNeSHL5Fg0sS0zA2NJDg1QccfjY9qNFTnejPNt/BDEnZDAHpUQkYvsOxZSl/BLGmEzzzQEnIRvPkQ==",
       "requires": {
         "diff-match-patch": "^1.0.4"
       }
@@ -40948,9 +40949,9 @@
       }
     },
     "@sanity/export": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.11.1.tgz",
-      "integrity": "sha512-yN/9vB3sqy2MGFTfr+ySKlipDD3lrJ38GqSiS7OLUCI0eUPVjw3OODKCq63byKndSKE+QSkaTlVGZCEMHWVdGQ==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.11.2.tgz",
+      "integrity": "sha512-AEZsrPHlQk5ms0bixTUBO2kHqyW7AqOxCffUtfjANts3HFxom6bySCTh9kUGD/O1DHENELOuYLmX9Xx23NNMOA==",
       "requires": {
         "archiver": "^5.0.0",
         "debug": "^3.2.7",
@@ -41013,13 +41014,13 @@
       "integrity": "sha512-C4+jb2ny3ZbMgEkLd7Z3C75DsxcTEoE+axXQJsQ75ou0AKWGdVsP351hqK6mJUUxn5HCSlu3vznoh7Yljye4cQ=="
     },
     "@sanity/import": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.11.1.tgz",
-      "integrity": "sha512-HvN0ODzbf6OXyhI/CvsFUoFu3PeU8+Mg5YzFXTjp5seO8ZIzb3iz9Fj5D0I06r951frDAxLVzZFoCF0nflcFPg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.11.2.tgz",
+      "integrity": "sha512-vmik6q1iUQjCkqPJi7INk1dOMDkRBJtSGuu229F0pv4WkwslZ0HfbhOBkNtPpbpi29zHrJE2dNQuPHXc1NJ24A==",
       "requires": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.11.1",
+        "@sanity/mutator": "3.11.2",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -41177,9 +41178,9 @@
       "requires": {}
     },
     "@sanity/mutator": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.11.1.tgz",
-      "integrity": "sha512-uIOkh6zamvUYPMzvIvrT6F5JWhH9DL4OUNuSVwHrQne7tzQHpJPLxIHJ4jfiN62/7NeZ4+b9KhLKs8x61rdnwQ==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.11.2.tgz",
+      "integrity": "sha512-5CBmtTHLZJMGB+MrsvhpRh1ERHhMU5b9WxY8lpvqH0bZBwJeHxneVCfa4ddIOlQ+ck/kMRQacNH8x0j+Ofbgpw==",
       "requires": {
         "@sanity/uuid": "^3.0.1",
         "@types/diff-match-patch": "^1.0.32",
@@ -41199,15 +41200,15 @@
       }
     },
     "@sanity/portable-text-editor": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.11.1.tgz",
-      "integrity": "sha512-pC23/PaK59hhaXrVOl6vqHzIu41n4Dwgr5+aW9uZuy9VmHKaA0HczVdSPAF0W+5jvfl6+9m7679BjTExStcHYg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.11.2.tgz",
+      "integrity": "sha512-07ZZSnfX4xfzSgzGglEVuSB/S7KVuEl+sHYHm3hXEIToKxm/84iEFNcoj4mBOMQUVWEIzkFmystfvqfOMz5QOA==",
       "requires": {
-        "@sanity/block-tools": "3.11.1",
-        "@sanity/schema": "3.11.1",
+        "@sanity/block-tools": "3.11.2",
+        "@sanity/schema": "3.11.2",
         "@sanity/slate-react": "2.30.1",
-        "@sanity/types": "3.11.1",
-        "@sanity/util": "3.11.1",
+        "@sanity/types": "3.11.2",
+        "@sanity/util": "3.11.2",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -41225,12 +41226,12 @@
       }
     },
     "@sanity/schema": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.11.1.tgz",
-      "integrity": "sha512-YD0Mhrbg+UYH96wkYI9axWNJwK+kGi8AHS9cSLbJ4n2QkVROgBvdPcC6OFxzWY50yhpp6IDP/pvBujefKx8n5g==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.11.2.tgz",
+      "integrity": "sha512-2JEEjRjadm864uFn+eg5T7Aw08u30WVj9h7aNz9w/AocNwKu3yEsuLZ6Y7cH5WStbrEW7sEmaXRQaitmnf68Uw==",
       "requires": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.11.1",
+        "@sanity/types": "3.11.2",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -41269,11 +41270,11 @@
       }
     },
     "@sanity/types": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.11.1.tgz",
-      "integrity": "sha512-TmCtStfZcf1VTKrPFJOjVhWOvjlrBncn86/0UuE7Ftsgq12tQEyPCpKAzAT6E7uUmr15wMUSvCgXX8hn9/poKg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.11.2.tgz",
+      "integrity": "sha512-61/CESRoW41doHWMizMIRWinO7jEsJbXprfJ/5jGYXGwKvPue93nCbKmDfuq0eDyF1ELh5vN1HA2NPC9p7RhyA==",
       "requires": {
-        "@sanity/client": "^6.0.0",
+        "@sanity/client": "^6.1.1",
         "@types/react": "^18.0.25"
       }
     },
@@ -41306,9 +41307,9 @@
           "optional": true
         },
         "framer-motion": {
-          "version": "10.12.13",
-          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.13.tgz",
-          "integrity": "sha512-JczRkFlu1ayXetPkUSoaUmoaK0+PsSHAnb25UFGiJeT2hTsX6IKwC+l0/rJYn+HdyzNbudWFKjeeNSHcykPI4Q==",
+          "version": "10.12.16",
+          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.16.tgz",
+          "integrity": "sha512-w/SfWEIWJkYSgRHYBmln7EhcNo31ao8Xexol8lGXf1pR/tlnBtf1HcxoUmEiEh6pacB4/geku5ami53AAQWHMQ==",
           "requires": {
             "@emotion/is-prop-valid": "^0.8.2",
             "tslib": "^2.4.0"
@@ -41317,11 +41318,11 @@
       }
     },
     "@sanity/util": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.11.1.tgz",
-      "integrity": "sha512-Fmh1GH8xkgF6Q3wH8TTXMuJek8dVSotvnxBBhgZsX4+OY/g6+ix7QuXFnSZAmPZRNJB4aYq3aWcT3nDumigSQg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.11.2.tgz",
+      "integrity": "sha512-7rJjoGgOkH8mNTtm/T5c7Yz8XsxXWN4umThUHsY1Vtxua92tbpSUnekLW7YcO0AnU9zQrSECrFzpYvfyT4IbZA==",
       "requires": {
-        "@sanity/types": "3.11.1",
+        "@sanity/types": "3.11.2",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       }
@@ -41336,20 +41337,20 @@
       }
     },
     "@sanity/validation": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.11.1.tgz",
-      "integrity": "sha512-iPomCFQZXaXIWnJSzrl58KeEs9+4/io0gtA+ks7vDcMyqhY7mL+OWw+do8pt/mEDy27nkE2/jzFxss+jaVn4HA==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.11.2.tgz",
+      "integrity": "sha512-xhziiAXrKQtzlio4FTXpiysB+E/TbKx+tXKwCgMNXu4L8QE4QaerH7N6ANvJ/6mu4TvAbTefVoMiUArfxlAKwQ==",
       "requires": {
-        "@sanity/types": "3.11.1",
+        "@sanity/types": "3.11.2",
         "date-fns": "^2.26.1",
         "lodash": "^4.17.21",
         "rxjs": "^7.8.0"
       }
     },
     "@sanity/vision": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.11.1.tgz",
-      "integrity": "sha512-lHAhgRBLASpsEBgvr2Kz81w3XLEZppVaiTiEWknNaQaGYGdTeRxruj9iE1GLi3lQoIiUlnFdzmhHzMRaiidymg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.11.2.tgz",
+      "integrity": "sha512-xS7Ux/HrKmGTR7xo5sCv2KkrJVKG8dmOKUt84DaorUfBmoNeMG/MK2Sk56zlLXyaxN08pXwwbUhETc+8F8xxrw==",
       "requires": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -41976,9 +41977,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.6.tgz",
-      "integrity": "sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.7.tgz",
+      "integrity": "sha512-ojrXpSH2XFCmHm7Jy3q44nXDyN54+EYKP2lBhJ2bqfyPj6cIUW/FZW/Csdia34NQgq7KYcAlHi5184m4X88+yw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -42079,9 +42080,9 @@
       "dev": true
     },
     "@types/testing-library__jest-dom": {
-      "version": "5.14.5",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
-      "integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
+      "version": "5.14.6",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.6.tgz",
+      "integrity": "sha512-FkHXCb+ikSoUP4Y4rOslzTdX5sqYwMxfefKh1GmZ8ce1GOkEHntSp6b5cGadmNfp5e4BMEWOMx+WSKd5/MqlDA==",
       "dev": true,
       "requires": {
         "@types/jest": "*"
@@ -42803,7 +42804,7 @@
     "@vygruppen/spor-react": {
       "version": "file:packages/spor-react",
       "requires": {
-        "@chakra-ui/react": "^2.3.5",
+        "@chakra-ui/react": "2.6.1",
         "@chakra-ui/theme-tools": "^2.0.12",
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
@@ -45469,9 +45470,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.4.404",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.404.tgz",
-      "integrity": "sha512-te57sWvQdpxmyd1GiswaodKdXdPgn9cN4ht8JlNa04QgtrfnUdWEo1261rY2vaC6TKaiHn0E7QerJWPKFCvMVw=="
+      "version": "1.4.405",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.405.tgz",
+      "integrity": "sha512-JdDgnwU69FMZURoesf9gNOej2Cms1XJFfLk24y1IBtnAdhTcJY/mXnokmpmxHN59PcykBP4bgUU98vLY44Lhuw=="
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -47560,9 +47561,9 @@
       "dev": true
     },
     "groq": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-3.11.1.tgz",
-      "integrity": "sha512-g4UG/8+XFbZyrP54yJpM9Mhg7AP/lrgRdu44RrpXask9d3qF2LYMG38cWEyZxn1by6Hcl7ylbTJQzwg85+7QGw=="
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-3.11.2.tgz",
+      "integrity": "sha512-rg6G7fMbw2VUAsHmZxz/gJQxfeHkymSA5W97fUOyXFcHYfSK3bBDWyuTAPST7XkWWT9PDbYh4IWcjYSppEbWRA=="
     },
     "groq-js": {
       "version": "1.1.9",
@@ -51634,9 +51635,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mlly": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.1.tgz",
-      "integrity": "sha512-1aMEByaWgBPEbWV2BOPEMySRrzl7rIHXmQxam4DM8jVjalTQDjpN2ZKOLUrwyhfZQO7IXHml2StcHMhooDeEEQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.3.0.tgz",
+      "integrity": "sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.2",
@@ -51849,9 +51850,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
-      "integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q=="
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
     },
     "node-stream-zip": {
       "version": "1.15.0",
@@ -52805,9 +52806,9 @@
       "requires": {}
     },
     "postcss-modules-local-by-default": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.2.tgz",
-      "integrity": "sha512-mR/pcIsQhU2UgKYOPjRCSgacmjn08pyrHk+Vrm8WEKjDWgqO43vdRkzmxyZOZWiKr6Ed9gpReQHhLUGVAcn9jw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.3.tgz",
+      "integrity": "sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==",
       "dev": true,
       "requires": {
         "icss-utils": "^5.0.0",
@@ -53284,9 +53285,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-live": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-live/-/react-live-4.1.1.tgz",
-      "integrity": "sha512-plF6Rgqq/01CYARIS1qcNlGTHHvKwGlwf+VgGrBFUTOst25IV7VlDF9gjTmJbJVqnZowdD2JwieR4idnkdlaIg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-live/-/react-live-4.1.2.tgz",
+      "integrity": "sha512-YPMD7oBOgLdlkbMunObcs5orQzDXOLuCKRpiSBYkuZsoB806FF8bWzdp6CJ5pO+mnc+upxut2dQYw0vZ6wn7og==",
       "requires": {
         "prism-react-renderer": "*",
         "sucrase": "^3.31.0",
@@ -55451,9 +55452,9 @@
       }
     },
     "sanity": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.11.1.tgz",
-      "integrity": "sha512-Z7dy72ITdMEgBcy72dHPLP5bWl3HF16dsYSzedzlFGTUgDL/iizc+WWNS5PiSzQDuB5ez+hPErkTDZ3yC7e7hA==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.11.2.tgz",
+      "integrity": "sha512-sR1NGUBFbyDhPKGaDgrVmtJHlC5RppAhFCj6wpbUbB0wDpsJ78pyPvKPQIxG1beTO5t63+t8Dr2TpQ7qc8tUig==",
       "requires": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
@@ -55465,26 +55466,26 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.11.1",
-        "@sanity/cli": "3.11.1",
-        "@sanity/client": "^6.0.0",
+        "@sanity/block-tools": "3.11.2",
+        "@sanity/cli": "3.11.2",
+        "@sanity/client": "^6.1.1",
         "@sanity/color": "^2.1.20",
-        "@sanity/diff": "3.11.1",
+        "@sanity/diff": "3.11.2",
         "@sanity/eventsource": "^5.0.0",
-        "@sanity/export": "3.11.1",
+        "@sanity/export": "3.11.2",
         "@sanity/generate-help-url": "^3.0.0",
         "@sanity/icons": "^2.3.0",
         "@sanity/image-url": "^1.0.2",
-        "@sanity/import": "3.11.1",
+        "@sanity/import": "3.11.2",
         "@sanity/logos": "^2.0.2",
-        "@sanity/mutator": "3.11.1",
-        "@sanity/portable-text-editor": "3.11.1",
-        "@sanity/schema": "3.11.1",
-        "@sanity/types": "3.11.1",
+        "@sanity/mutator": "3.11.2",
+        "@sanity/portable-text-editor": "3.11.2",
+        "@sanity/schema": "3.11.2",
+        "@sanity/types": "3.11.2",
         "@sanity/ui": "^1.3.3",
-        "@sanity/util": "3.11.1",
+        "@sanity/util": "3.11.2",
         "@sanity/uuid": "^3.0.1",
-        "@sanity/validation": "3.11.1",
+        "@sanity/validation": "3.11.2",
         "@tanstack/react-virtual": "3.0.0-beta.53",
         "@types/is-hotkey": "^0.1.7",
         "@types/react-copy-to-clipboard": "^5.0.2",
@@ -55788,9 +55789,9 @@
           }
         },
         "framer-motion": {
-          "version": "10.12.13",
-          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.13.tgz",
-          "integrity": "sha512-JczRkFlu1ayXetPkUSoaUmoaK0+PsSHAnb25UFGiJeT2hTsX6IKwC+l0/rJYn+HdyzNbudWFKjeeNSHcykPI4Q==",
+          "version": "10.12.16",
+          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.16.tgz",
+          "integrity": "sha512-w/SfWEIWJkYSgRHYBmln7EhcNo31ao8Xexol8lGXf1pR/tlnBtf1HcxoUmEiEh6pacB4/geku5ami53AAQWHMQ==",
           "requires": {
             "@emotion/is-prop-valid": "^0.8.2",
             "tslib": "^2.4.0"
@@ -55901,14 +55902,14 @@
       }
     },
     "sanity-plugin-iframe-pane": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sanity-plugin-iframe-pane/-/sanity-plugin-iframe-pane-2.3.0.tgz",
-      "integrity": "sha512-bTq1Fnj1AQv5FXOE/88z41tSlJkfd7Ra/+19CvFOkOdopr7nnCWtztaG+phlqm8cndIs+CMnSxaBByLf/RGcPQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-iframe-pane/-/sanity-plugin-iframe-pane-2.3.1.tgz",
+      "integrity": "sha512-WGY3LtrnAg1wjA7tNpmqATbP1VCAK+DbpMU/4xEoSOhjtZLWQEuKq98l0UcZUMSoO7B7bqG0o78yGS9Oy/28Iw==",
       "requires": {
         "@sanity/icons": "^2.2.2",
-        "@sanity/incompatible-plugin": "^1.0.4",
-        "@sanity/ui": "^1.3.0",
-        "usehooks-ts": "^2.9.1"
+        "@sanity/incompatible-plugin": "^1.0.0",
+        "@sanity/ui": "^1.0.0",
+        "usehooks-ts": "2.9.1"
       }
     },
     "sax": {
@@ -57979,52 +57980,52 @@
       }
     },
     "turbo": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.9.8.tgz",
-      "integrity": "sha512-dTouGZBm4a2fE0OPafcTQERCp4i3ZOow0Pr0JlOyxKmzJy0JRwXypH013kbZoK6k1ET5tS/g9rwUXIM/AmWXXQ==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.9.9.tgz",
+      "integrity": "sha512-+ZS66LOT7ahKHxh6XrIdcmf2Yk9mNpAbPEj4iF2cs0cAeaDU3xLVPZFF0HbSho89Uxwhx7b5HBgPbdcjQTwQkg==",
       "requires": {
-        "turbo-darwin-64": "1.9.8",
-        "turbo-darwin-arm64": "1.9.8",
-        "turbo-linux-64": "1.9.8",
-        "turbo-linux-arm64": "1.9.8",
-        "turbo-windows-64": "1.9.8",
-        "turbo-windows-arm64": "1.9.8"
+        "turbo-darwin-64": "1.9.9",
+        "turbo-darwin-arm64": "1.9.9",
+        "turbo-linux-64": "1.9.9",
+        "turbo-linux-arm64": "1.9.9",
+        "turbo-windows-64": "1.9.9",
+        "turbo-windows-arm64": "1.9.9"
       }
     },
     "turbo-darwin-64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.9.8.tgz",
-      "integrity": "sha512-PkTdBjPfgpj/Dob/6SjkzP0BBP80/KmFjLEocXVEECCLJE6tHKbWLRdvc79B0N6SufdYdZ1uvvoU3KPtBokSPw==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.9.9.tgz",
+      "integrity": "sha512-UDGM9E21eCDzF5t1F4rzrjwWutcup33e7ZjNJcW/mJDPorazZzqXGKEPIy9kXwKhamUUXfC7668r6ZuA1WXF2Q==",
       "optional": true
     },
     "turbo-darwin-arm64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.9.8.tgz",
-      "integrity": "sha512-sLwqOx3XV57QCEoJM9GnDDnnqidG8wf29ytxssBaWHBdeJTjupyrmzTUrX+tyKo3Q+CjWvbPLyqVqxT4g5NuXQ==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.9.9.tgz",
+      "integrity": "sha512-VyfkXzTJpYLTAQ9krq2myyEq7RPObilpS04lgJ4OO1piq76RNmSpX9F/t9JCaY9Pj/4TL7i0d8PM7NGhwEA5Ag==",
       "optional": true
     },
     "turbo-linux-64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.9.8.tgz",
-      "integrity": "sha512-AMg6VT6sW7aOD1uOs5suxglXfTYz9T0uVyKGKokDweGOYTWmuTMGU5afUT1tYRUwQ+kVPJI+83Atl5Ob0oBsgw==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.9.9.tgz",
+      "integrity": "sha512-Fu1MY29Odg8dHOqXcpIIGC3T63XLOGgnGfbobXMKdrC7JQDvtJv8TUCYciRsyknZYjyyKK1z6zKuYIiDjf3KeQ==",
       "optional": true
     },
     "turbo-linux-arm64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.9.8.tgz",
-      "integrity": "sha512-tLnxFv+OIklwTjiOZ8XMeEeRDAf150Ry4BCivNwgTVFAqQGEqkFP6KGBy56hb5RRF1frPQpoPGipJNVm7c8m1w==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.9.9.tgz",
+      "integrity": "sha512-50LI8NafPuJxdnMCBeDdzgyt1cgjQG7FwkyY336v4e95WJPUVjrHdrKH6jYXhOUyrv9+jCJxwX1Yrg02t5yJ1g==",
       "optional": true
     },
     "turbo-windows-64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.9.8.tgz",
-      "integrity": "sha512-r3pCjvXTMR7kq2E3iqwFlN1R7pFO/TOsuUjMhOSPP7HwuuUIinAckU4I9foM3q7ZCQd1XXScBUt3niDyHijAqQ==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.9.9.tgz",
+      "integrity": "sha512-9IsTReoLmQl1IRsy3WExe2j2RKWXQyXujfJ4fXF+jp08KxjVF4/tYP2CIRJx/A7UP/7keBta27bZqzAjsmbSTA==",
       "optional": true
     },
     "turbo-windows-arm64": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.9.8.tgz",
-      "integrity": "sha512-CWzRbX2TM5IfHBC6uWM659qUOEDC4h0nn16ocG8yIq1IF3uZMzKRBHgGOT5m1BHom+R08V0NcjTmPRoqpiI0dg==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.9.9.tgz",
+      "integrity": "sha512-CUu4hpeQo68JjDr0V0ygTQRLbS+/sNfdqEVV+Xz9136vpKn2WMQLAuUBVZV0Sp0S/7i+zGnplskT0fED+W46wQ==",
       "optional": true
     },
     "type-check": {

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -20,7 +20,6 @@
     "@chakra-ui/react": "^2.3.5",
     "@chakra-ui/theme-tools": "^2.0.12",
     "@internationalized/date": "^3.0.1",
-    "@leile/lobo-t": "^1.0.5",
     "@vygruppen/spor-design-tokens": "*",
     "@vygruppen/spor-icon-react": "*",
     "@vygruppen/spor-loader": "*",

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -17,14 +17,14 @@
     "directory": "packages/spor-react"
   },
   "dependencies": {
-    "@chakra-ui/react": "^2.3.5",
+    "@chakra-ui/react": "^2.6.1",
     "@chakra-ui/theme-tools": "^2.0.12",
+    "@emotion/react": "^11.10.4",
+    "@emotion/styled": "^11.10.4",
     "@internationalized/date": "^3.0.1",
     "@vygruppen/spor-design-tokens": "*",
     "@vygruppen/spor-icon-react": "*",
     "@vygruppen/spor-loader": "*",
-    "@emotion/react": "^11.10.4",
-    "@emotion/styled": "^11.10.4",
     "framer-motion": ">6.0.0",
     "lottie-react": "^2.3.1",
     "react-aria": "^3.23.0",
@@ -32,10 +32,10 @@
     "react-swipeable": "^7.0.0"
   },
   "devDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "tsup": "^6.2.2",
     "vitest": "^0.26.3",
     "vitest-axe": "^0.1.0",

--- a/packages/spor-react/src/i18n/index.tsx
+++ b/packages/spor-react/src/i18n/index.tsx
@@ -1,4 +1,4 @@
-import { initLobot } from "@leile/lobo-t";
+import React, { createContext, useContext } from "react";
 
 export enum Language {
   NorwegianBokmal = "nb",
@@ -7,18 +7,108 @@ export enum Language {
   English = "en",
 }
 
-export const { LanguageProvider, useTranslation } = initLobot<typeof Language>(
-  Language.NorwegianBokmal
-);
-
-type LanguageObject = {
-  [key in Language]: string;
+type TranslationObject = {
+  [key in Language]: string | React.ReactElement;
 };
-type LanguageFunction = (...args: (string | number)[]) => LanguageObject;
+type TranslationFunction = (...args: (string | number)[]) => TranslationObject;
 
+type Translation = TranslationObject | TranslationFunction;
 export type Translations = {
-  [key: string]: LanguageObject | LanguageFunction;
+  [key: string]: Translation | Translations;
 };
+
+const LanguageContext = createContext<Language | undefined>(undefined);
+type LanguageProviderProps = {
+  language: Language;
+  children: React.ReactElement;
+};
+/**
+ * A language provider component.
+ *
+ * This component should wrap your entire application. It will provide the language to all components that use it.
+ *
+ * This is done by the SporProvider component, so most likely, you won't need to use it directly, unless you want to use a specific language for a specific part of your application.
+ *
+ * ```tsx
+ * import { LanguageProvider, Language } from "@vygruppen/spor-react";
+ *
+ * const App = () => {
+ *   return (
+ *     <LanguageProvider language={Language.NorwegianBokmal}>
+ *       <Routes />
+ *     </LanguageProvider>
+ *   );
+ * }
+ * ```
+ *
+ */
+export function LanguageProvider({
+  language,
+  children,
+}: LanguageProviderProps) {
+  return (
+    <LanguageContext.Provider value={language}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+/**
+ * Gets the language from the language context.
+ *
+ * @internal
+ */
+function useLanguage() {
+  const language = useContext(LanguageContext);
+  if (!language) {
+    throw new Error("Please wrap your application in a LanguageProvider");
+  }
+  return language;
+}
+
+function isLanguageFunction(
+  translation: Translation
+): translation is TranslationFunction {
+  return typeof translation === "function";
+}
+
+/**
+ * A hook that returns translation utilities. Typically used to translate text.
+ *
+ * ```tsx
+ * const Example = () => {
+ *   const { t } = useTranslation();
+ *   return <p>{t(texts.greeting)}</p>;
+ * }
+ * const texts = {
+ *   greeting: {
+ *     nb: "Hei",
+ *     nn: "Hei",
+ *     sv: "Hej",
+ *     en: "Hello",
+ *   }
+ * }
+ * ```
+ *
+ * You can also use it to fetch the current language:
+ *
+ * ```tsx
+ * const Example = () => {
+ *   const { language } = useTranslation();
+ *   return <p>{language}</p>;
+ * };
+ * ```
+ */
+export function useTranslation() {
+  const language = useLanguage();
+  const t = (text: Translation) => {
+    if (isLanguageFunction(text)) {
+      return (...args: Array<string | number>) => text(...args)[language];
+    }
+    return text[language];
+  };
+  return { t, language } as const;
+}
 
 /** Utility function that creates type safe text objects with useTranslation
  *
@@ -29,6 +119,14 @@ export type Translations = {
  *   nn: "Døme",
  *   sv: "Exempel",
  *   en: "Example",
+ *  },
+ *  another: {
+ *    example: {
+ *      nb: <strong>Eksempel</strong>,
+ *      nn: <strong>Døme</strong>,
+ *      sv: <strong>Exempel</strong>,
+ *      en: <strong>Example</strong>,
+ *    }
  *  }
  * })
  * ```

--- a/packages/spor-react/src/i18n/index.tsx
+++ b/packages/spor-react/src/i18n/index.tsx
@@ -10,7 +10,9 @@ export enum Language {
 type TranslationObject = {
   [key in Language]: string | React.ReactElement;
 };
-type TranslationFunction = (...args: (string | number)[]) => TranslationObject;
+type TranslationFunction = (
+  ...args: Array<string | number>
+) => TranslationObject;
 
 type Translation = TranslationObject | TranslationFunction;
 export type Translations = {
@@ -66,12 +68,6 @@ function useLanguage() {
   return language;
 }
 
-function isLanguageFunction(
-  translation: Translation
-): translation is TranslationFunction {
-  return typeof translation === "function";
-}
-
 /**
  * A hook that returns translation utilities. Typically used to translate text.
  *
@@ -101,11 +97,8 @@ function isLanguageFunction(
  */
 export function useTranslation() {
   const language = useLanguage();
-  const t = (text: Translation) => {
-    if (isLanguageFunction(text)) {
-      return (...args: Array<string | number>) => text(...args)[language];
-    }
-    return text[language];
+  const t = (text: TranslationObject) => {
+    return text[language] as string;
   };
   return { t, language } as const;
 }

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -106,7 +106,7 @@ export function NumericStepper({
         transition="box-shadow .1s ease-out"
         visibility={value === 0 ? "hidden" : "visible"}
         aria-live="assertive"
-        aria-label={value}
+        aria-label={value.toString()}
         _hover={{
           boxShadow: getBoxShadowString({
             borderColor: "currentColor",

--- a/packages/spor-react/src/provider/SporProvider.tsx
+++ b/packages/spor-react/src/provider/SporProvider.tsx
@@ -51,7 +51,7 @@ export const SporProvider = ({
   ...props
 }: SporProviderProps) => {
   return (
-    <LanguageProvider value={language}>
+    <LanguageProvider language={language}>
       <ChakraProvider theme={theme} {...props}>
         <Global styles={fontFaces} />
         <Global


### PR DESCRIPTION
## Bakgrunn
Lobo-t er et søtt lite bibliotek, men det vedlikeholdes ikke lenger, og det den gjør er enkelt å gjøre selv.

## Løsning
Implementer en egen løsning for oversettelser, slik at vi eier all denne koden selv. Løsningen er en enkel løsning som er enkel å bruke på forskjellige vis.

En bonus-feature er at man nå kan nøste språkobjekter – så det blir litt enklere å holde orden på tekstene i komponenter som har mange av dem.

En litt mer gjennomgående forklaring av koden og approachen man følger kan man [lese i dette blogginnlegget](https://blogg.bekk.no/lag-ditt-eget-typesikre-oversettelsesbibliotek-54f066348540).