### PR TITLE
Legg til noen props til Autosuggest og Combobox komponentene

### DIFF
--- a/.changeset/orange-mirrors-glow.md
+++ b/.changeset/orange-mirrors-glow.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add some spacing and styling props to both Combobox and Autosuggest

--- a/packages/spor-react/src/input/Autosuggest.tsx
+++ b/packages/spor-react/src/input/Autosuggest.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useAsyncList } from "react-stately";
-import { Combobox, ComboboxProps } from "../";
+import { Combobox, ComboboxProps, InputProps } from "../";
 
 type AutosuggestProps<T> = {
   /** The label of the search field */
@@ -42,7 +42,26 @@ type AutosuggestProps<T> = {
    * Callback for when the selection changes.
    */
   onSelectionChange?: ComboboxProps<T>["onSelectionChange"];
-};
+} & Pick<
+  InputProps,
+  | "marginTop"
+  | "marginBottom"
+  | "marginY"
+  | "marginX"
+  | "paddingTop"
+  | "paddingBottom"
+  | "paddingLeft"
+  | "paddingRight"
+  | "paddingY"
+  | "paddingX"
+  | "leftIcon"
+  | "rightIcon"
+  | "borderTopRightRadius"
+  | "borderTopLeftRadius"
+  | "borderBottomRightRadius"
+  | "borderBottomLeftRadius"
+  | "onFocus"
+>;
 /**
  * A component that provides an autocomplete search field with suggestions.
  *
@@ -79,6 +98,7 @@ export function Autosuggest<T extends object>({
   fetcher,
   children,
   onSelectionChange,
+  ...boxProps
 }: AutosuggestProps<T>) {
   const list = useAsyncList<T>({
     async load({ filterText }) {
@@ -95,6 +115,7 @@ export function Autosuggest<T extends object>({
       onInputChange={list.setFilterText}
       isLoading={list.isLoading}
       onSelectionChange={onSelectionChange}
+      {...boxProps}}
     >
       {children}
     </Combobox>

--- a/packages/spor-react/src/input/Autosuggest.tsx
+++ b/packages/spor-react/src/input/Autosuggest.tsx
@@ -115,7 +115,7 @@ export function Autosuggest<T extends object>({
       onInputChange={list.setFilterText}
       isLoading={list.isLoading}
       onSelectionChange={onSelectionChange}
-      {...boxProps}}
+      {...boxProps}
     >
       {children}
     </Combobox>

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import { AriaComboBoxProps, useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
-import { ColorSpinner, FormControl, Input, ListBox } from "..";
+import { ColorSpinner, FormControl, Input, InputProps, ListBox } from "..";
 import { Popover } from "./Popover";
 
 export type ComboboxProps<T> = AriaComboBoxProps<T> & {
@@ -9,7 +9,26 @@ export type ComboboxProps<T> = AriaComboBoxProps<T> & {
   label: string;
   /** Whether or not the combobox is waiting for new suggestions */
   isLoading?: boolean;
-};
+} & Pick<
+    InputProps,
+    | "marginTop"
+    | "marginBottom"
+    | "marginY"
+    | "marginX"
+    | "paddingTop"
+    | "paddingBottom"
+    | "paddingLeft"
+    | "paddingRight"
+    | "paddingY"
+    | "paddingX"
+    | "leftIcon"
+    | "rightIcon"
+    | "borderTopRightRadius"
+    | "borderTopLeftRadius"
+    | "borderBottomRightRadius"
+    | "borderBottomLeftRadius"
+    | "onFocus"
+  >;
 /**
  * A combobox is a combination of an input and a list of suggestions.
  *
@@ -36,6 +55,23 @@ export type ComboboxProps<T> = AriaComboBoxProps<T> & {
 export function Combobox<T extends object>({
   label,
   isLoading,
+  leftIcon,
+  rightIcon,
+  borderBottomLeftRadius = "sm",
+  borderBottomRightRadius = "sm",
+  borderTopLeftRadius = "sm",
+  borderTopRightRadius = "sm",
+  marginBottom,
+  marginTop,
+  marginX,
+  marginY,
+  paddingBottom,
+  paddingRight,
+  paddingTop,
+  paddingLeft,
+  paddingX,
+  paddingY,
+  onFocus,
   ...rest
 }: ComboboxProps<T>) {
   const { contains } = useFilter({ sensitivity: "base" });
@@ -67,7 +103,22 @@ export function Combobox<T extends object>({
         {...inputProps}
         ref={inputRef}
         label={label}
-        borderBottomRadius={state.isOpen ? 0 : "sm"}
+        onFocus={onFocus}
+        borderBottomLeftRadius={state.isOpen ? 0 : borderBottomLeftRadius}
+        borderBottomRightRadius={state.isOpen ? 0 : borderBottomRightRadius}
+        borderTopLeftRadius={borderTopLeftRadius}
+        borderTopRightRadius={borderTopRightRadius}
+        marginBottom={marginBottom}
+        marginTop={marginTop}
+        marginX={marginX}
+        marginY={marginY}
+        paddingBottom={paddingBottom}
+        paddingRight={paddingRight}
+        paddingTop={paddingTop}
+        paddingLeft={paddingLeft}
+        paddingX={paddingX}
+        paddingY={paddingY}
+        leftIcon={leftIcon}
         rightIcon={
           isLoading ? (
             <ColorSpinner
@@ -80,7 +131,9 @@ export function Combobox<T extends object>({
                 },
               }}
             />
-          ) : undefined
+          ) : (
+            rightIcon
+          )
         }
       />
       {state.isOpen && (

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -80,7 +80,7 @@ export function ListBox<T extends object>({
       sx={styles.container}
       aria-busy={isLoading}
     >
-      {[...state.collection].map((item) =>
+      {Array.from(state.collection).map((item) =>
         item.type === "section" ? (
           <ListBoxSection key={item.key} section={item} state={state} />
         ) : (
@@ -203,9 +203,11 @@ function ListBoxSection({ section, state }: ListBoxSectionProps) {
         </Box>
       )}
       <List {...groupProps} padding={0} listStyleType="none">
-        {[...state.collection.getChildren(section.key)].map((item) => (
-          <Option key={item.key} item={item} state={state} />
-        ))}
+        {Array.from(state.collection.getChildren(section.key)).map(
+          (item: any) => (
+            <Option key={item.key} item={item} state={state} />
+          )
+        )}
       </List>
     </ListItem>
   );

--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -10,7 +10,6 @@
     "module": "ESNext",
     "rootDir": "src",
     "outDir": "dist",
-    "jsx": "react",
-    "downlevelIteration": true
+    "jsx": "react"
   }
 }


### PR DESCRIPTION
## Bakgrunn
Da vi skulle ta i bruk Autosuggest-komponenten, så vi at vi hadde et større behov for tilpasning enn det komponenten i utgangspunktet støttet.

## Løsning
Legg til en rekke props for å overstyre margin, padding, ikoner og lytte til fokus.