### PR TITLE
Returner hele objektet som blir valgt

### DIFF
--- a/.changeset/witty-insects-tease.md
+++ b/.changeset/witty-insects-tease.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Autosuggest: Return the entire item selected, not just the list

--- a/packages/spor-react/src/input/Autosuggest.tsx
+++ b/packages/spor-react/src/input/Autosuggest.tsx
@@ -39,9 +39,14 @@ type AutosuggestProps<T> = {
    * */
   children: ComboboxProps<T>["children"];
   /**
-   * Callback for when the selection changes.
+   * Callback for when the selection changes. Returns the entire item.
    */
-  onSelectionChange?: ComboboxProps<T>["onSelectionChange"];
+  onSelectionChange?: (item: T) => void;
+  /** What should open the menu.
+   *
+   * Defaults to "input"
+   */
+  menuTrigger?: ComboboxProps<T>["menuTrigger"];
 } & Pick<
   InputProps,
   | "marginTop"
@@ -98,7 +103,7 @@ export function Autosuggest<T extends object>({
   fetcher,
   children,
   onSelectionChange,
-  ...boxProps
+  ...props
 }: AutosuggestProps<T>) {
   const list = useAsyncList<T>({
     async load({ filterText }) {
@@ -107,15 +112,21 @@ export function Autosuggest<T extends object>({
       };
     },
   });
+  const handleSelectionChange = (key: React.Key) => {
+    if (!onSelectionChange) {
+      return;
+    }
+    return onSelectionChange(list.getItem(key));
+  };
   return (
     <Combobox
       label={label}
       items={list.items}
       inputValue={list.filterText}
       onInputChange={list.setFilterText}
+      onSelectionChange={handleSelectionChange}
       isLoading={list.isLoading}
-      onSelectionChange={onSelectionChange}
-      {...boxProps}
+      {...props}
     >
       {children}
     </Combobox>

--- a/packages/spor-react/src/input/Autosuggest.tsx
+++ b/packages/spor-react/src/input/Autosuggest.tsx
@@ -42,6 +42,8 @@ type AutosuggestProps<T> = {
    * Callback for when the selection changes. Returns the entire item.
    */
   onSelectionChange?: (item: T) => void;
+  /** The selected item key (controlled) */
+  selectedKey?: ComboboxProps<T>["selectedKey"];
   /** What should open the menu.
    *
    * Defaults to "input"


### PR DESCRIPTION
## Bakgrunn
Per i dag så returnerer vi bare key-en til hvilket objekt som ble valgt i en Autosuggest. Det er litt upraktisk, siden Autosuggest ikke eksponerer lista den henter – så vi får ikke hentet den riktige informasjonen.

## Løsning
Når man kaller `onSelectionChange`, returner hele objektet.