### PR TITLE
Autosuggest tweaks plus plus

### DIFF
--- a/.changeset/soft-falcons-wash.md
+++ b/.changeset/soft-falcons-wash.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Autosuggest: Fix a bug where the onSelectionChanged was called with no item on nested lists

--- a/apps/docs/app/routes/_base.$category.$slug/route.tsx
+++ b/apps/docs/app/routes/_base.$category.$slug/route.tsx
@@ -245,7 +245,7 @@ const ComponentSections = ({ sections }: ComponentSectionsProps) => {
     <Tabs colorScheme="green" variant="square" size="md" mt={4} isFitted isLazy>
       <TabList>
         {sections.map((section) => (
-          <Tab key={getSlugFromSection(section)}>
+          <Tab key={section._id}>
             {getCorrectTitle({
               title: section.title,
               customTitle: section.customTitle,

--- a/apps/docs/app/routes/_base.komponenter_.oversikt/route.tsx
+++ b/apps/docs/app/routes/_base.komponenter_.oversikt/route.tsx
@@ -84,6 +84,7 @@ export default function ComponentsPage() {
                 src={urlBuilder.image(component.mainImage).width(300).url()}
                 alt={component.title}
                 backgroundColor="mint"
+                padding="1em"
                 width="100%"
                 height="10em"
                 objectFit="cover"

--- a/packages/spor-react/src/input/Autosuggest.tsx
+++ b/packages/spor-react/src/input/Autosuggest.tsx
@@ -99,6 +99,28 @@ type AutosuggestProps<T> = {
  *   );
  * };
  * ```
+ *
+ * The `fetcher` function can be any function that returns an iterable of items. This means that you can use any API library you want, as long as it returns an iterable of items.
+ *
+ * The items need to have a `key` property, which is used to identify the item. The `key` property can be any type, but it needs to be unique for each item.
+ *
+ * ```tsx
+ * [{ key: 'some-key', ...}, { key: 'some-other-key', ... }]
+ * ```
+ *
+ * You can also return a set of nested items, which will be rendered as a sub-list (or section). This is useful if you want to group your items. These items need to have a title prop (for labelling the section), as well as a `children` prop, which in turn will contain an iterable of items:
+ *
+ * ```tsx
+ * [
+ *   {
+ *    title: 'The title of the section',
+ *    children: [{ key: 'some-key', ... }]
+ *   },
+ *   {...}
+ * ]
+ * ```
+ *
+ * The `onSelectionChanged` will return the correct `item` (the one with the matching `key`), even if the item is in a sub-list.
  */
 export function Autosuggest<T extends object>({
   label,
@@ -114,11 +136,26 @@ export function Autosuggest<T extends object>({
       };
     },
   });
+
   const handleSelectionChange = (key: React.Key) => {
     if (!onSelectionChange) {
       return;
     }
-    return onSelectionChange(list.getItem(key));
+
+    let selectedItem = list.getItem(key);
+    if (!selectedItem) {
+      // If the item is not in the list, it might be in a sub-list
+      selectedItem = list.items
+        .flatMap((item) =>
+          "children" in item && Array.isArray(item.children)
+            ? item.children
+            : []
+        )
+        .find((child) => child.key === key);
+    }
+    if (selectedItem) {
+      onSelectionChange(selectedItem);
+    }
   };
   return (
     <Combobox

--- a/packages/spor-react/src/input/Autosuggest.tsx
+++ b/packages/spor-react/src/input/Autosuggest.tsx
@@ -53,6 +53,8 @@ type AutosuggestProps<T> = {
   InputProps,
   | "marginTop"
   | "marginBottom"
+  | "marginRight"
+  | "marginLeft"
   | "marginY"
   | "marginX"
   | "paddingTop"
@@ -125,7 +127,6 @@ type AutosuggestProps<T> = {
 export function Autosuggest<T extends object>({
   label,
   fetcher,
-  children,
   onSelectionChange,
   ...props
 }: AutosuggestProps<T>) {
@@ -166,8 +167,6 @@ export function Autosuggest<T extends object>({
       onSelectionChange={handleSelectionChange}
       isLoading={list.isLoading}
       {...props}
-    >
-      {children}
-    </Combobox>
+    />
   );
 }

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import { AriaComboBoxProps, useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
-import { ColorSpinner, FormControl, Input, InputProps, ListBox } from "..";
+import { ColorSpinner, Input, InputProps, ListBox } from "..";
 import { Popover } from "./Popover";
 
 export type ComboboxProps<T> = AriaComboBoxProps<T> & {
@@ -13,6 +13,8 @@ export type ComboboxProps<T> = AriaComboBoxProps<T> & {
     InputProps,
     | "marginTop"
     | "marginBottom"
+    | "marginRight"
+    | "marginLeft"
     | "marginY"
     | "marginX"
     | "paddingTop"
@@ -65,6 +67,8 @@ export function Combobox<T extends object>({
   marginTop,
   marginX,
   marginY,
+  marginRight,
+  marginLeft,
   paddingBottom,
   paddingRight,
   paddingTop,
@@ -98,7 +102,7 @@ export function Combobox<T extends object>({
   );
 
   return (
-    <FormControl>
+    <>
       <Input
         {...inputProps}
         ref={inputRef}
@@ -110,6 +114,8 @@ export function Combobox<T extends object>({
         borderTopRightRadius={borderTopRightRadius}
         marginBottom={marginBottom}
         marginTop={marginTop}
+        marginRight={marginRight}
+        marginLeft={marginLeft}
         marginX={marginX}
         marginY={marginY}
         paddingBottom={paddingBottom}
@@ -153,6 +159,6 @@ export function Combobox<T extends object>({
           </ListBox>
         </Popover>
       )}
-    </FormControl>
+    </>
   );
 }


### PR DESCRIPTION
## Bakgrunn
Etter å ha testa ut Autosuggest i prod, ser vi at vi har behov for et par flere tweaks, props og noen bugfikses.

## Løsning
- Fiks slik at onSelectionChange propen til Autosuggest fungerer som forventet med nøsta lister)
- Legg til støtte for marginLeft og marginRight
- Fiks et par bugs på selve dokumentasjonssiden