### PR TITLE
BUGFIX: Omits onChange in TimePickerProps

### DIFF
--- a/.changeset/silent-dolphins-fetch.md
+++ b/.changeset/silent-dolphins-fetch.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+TimePicker: Fixes typing bug in onChange prop

--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -12,7 +12,7 @@ import { StyledField } from "./StyledField";
 import { TimeField } from "./TimeField";
 import { getCurrentTime, useCurrentLocale } from "./utils";
 
-type TimePickerProps = Omit<BoxProps, "defaultValue"> & {
+type TimePickerProps = Omit<BoxProps, "defaultValue" | "onChange"> & {
   /** The label. Defaults to a localized version of "Time" */
   label?: string;
   /** The name of the form field, if used in a regular form */


### PR DESCRIPTION
## Bakgrunn
TimePicker sin onChange ga TypeScript feilmelding om man sendte inn en handler på formen `(value: TimeValue) => void` selv om dette var spesifisert i props. Årsaken er at `onChange` også ble dratt med fra BoxProps.

## Løsning
Omitter onChange fra BoxProps