### PR TITLE
Bruk riktig listbox item musepeker

### DIFF
--- a/.changeset/lemon-eggs-promise.md
+++ b/.changeset/lemon-eggs-promise.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Use correct cursor for listbox items

--- a/packages/spor-react/src/theme/components/listbox.ts
+++ b/packages/spor-react/src/theme/components/listbox.ts
@@ -29,6 +29,7 @@ const config = helpers.defineMultiStyleConfig({
       marginX: 1,
       borderRadius: "sm",
       color: mode("darkGrey", "white")(props),
+      cursor: "pointer",
       _hover: {
         backgroundColor: mode("seaMist", "darkTeal")(props),
         outline: "none",


### PR DESCRIPTION
## Bakgrunn
Før var det feil musepeker når man hovret noe i en listbox

## Løsning
Nå bruker man cursor: pointer;