### PR TITLE
Fjern deprekerte komponenter

### DIFF
--- a/.changeset/selfish-roses-turn.md
+++ b/.changeset/selfish-roses-turn.md
@@ -1,0 +1,7 @@
+---
+"@vygruppen/spor-react": major
+---
+
+Remove deprecated components SelectItem, SelectItemLabel and SelectItemDescription.
+
+To migrate, use Item, ItemLabel and ItemDescription, respectively.

--- a/packages/spor-react/src/input/AttachedInputs.tsx
+++ b/packages/spor-react/src/input/AttachedInputs.tsx
@@ -9,7 +9,7 @@ type AttachedInputsProps = FlexProps;
  * <AttachedInputs>
  *   <Input />
  *   <NativeSelect>
- *     <SelectItem />
+ *     <Item />
  *   </NativeSelect>
  * </AttachedInputs>
  * ```

--- a/packages/spor-react/src/input/CountryCodeSelect.tsx
+++ b/packages/spor-react/src/input/CountryCodeSelect.tsx
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  BoxProps,
-  InfoSelect,
-  SelectItem,
-  createTexts,
-  useTranslation,
-} from "..";
+import { BoxProps, InfoSelect, Item, createTexts, useTranslation } from "..";
 
 import { getSupportedCallingCodes } from "awesome-phonenumber";
 
@@ -43,7 +37,7 @@ export const CountryCodeSelect = (props: CountryCodeSelectProps) => {
       items={callingCodes as any}
       {...props}
     >
-      {(item) => <SelectItem key={item.key}>{item.key}</SelectItem>}
+      {(item) => <Item key={item.key}>{item.key}</Item>}
     </InfoSelect>
   );
 };

--- a/packages/spor-react/src/input/InfoSelect.tsx
+++ b/packages/spor-react/src/input/InfoSelect.tsx
@@ -18,16 +18,16 @@ import { Popover } from "./Popover";
 
 type InfoSelectProps<T extends object> = {
   /**
-   * Either a render function accepting an item, and returning a <SelectItem />,
-   * or a list of <SelectItem />s.
+   * Either a render function accepting an item, and returning a <Item />,
+   * or a list of <Item />s.
    *
    * Render function example:
    * ```tsx
    * <Select items={items}>
    *   {(item) => (
-   *     <SelectItem key={item.value} value={item.value}>
+   *     <Item key={item.value} value={item.value}>
    *       {item.label}
-   *     </SelectItem>
+   *     </Item>
    *   )}
    * </Select>
    * ```
@@ -35,12 +35,12 @@ type InfoSelectProps<T extends object> = {
    * For this to work, the members in `items` need either a `key`
    * or an `id` property.
    *
-   * List of <SelectItem />s example:
+   * List of <Item />s example:
    * ```tsx
    * <Select label="Choose a color">
-   *   <SelectItem>Green</SelectItem>
-   *   <SelectItem>Blue</SelectItem>
-   *   <SelectItem>Yellow</SelectItem>
+   *   <Item>Green</Item>
+   *   <Item>Blue</Item>
+   *   <Item>Yellow</Item>
    * </Select>
    * ```
    **/
@@ -104,9 +104,9 @@ type InfoSelectProps<T extends object> = {
    *
    * ```tsx
    * <Select label="Choose a color" disabledKeys={["blue", "yellow"]}>
-   *   <SelectItem key="green">Green</SelectItem>
-   *   <SelectItem key="blue">Blue</SelectItem>
-   *   <SelectItem key="yellow">Yellow</SelectItem>
+   *   <Item key="green">Green</Item>
+   *   <Item key="blue">Blue</Item>
+   *   <Item key="yellow">Yellow</Item>
    * </Select>
    * ```
    **/

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -14,10 +14,8 @@ import {
   useListBoxSection,
   useOption,
 } from "react-aria";
-import { Item, type ListState, type SelectState } from "react-stately";
+import { type ListState, type SelectState } from "react-stately";
 
-/** @deprecated use Item instead */
-export const SelectItem = Item;
 export { Item, Section } from "react-stately";
 
 type ListBoxProps<T> = AriaListBoxProps<T> &
@@ -111,8 +109,6 @@ export function ItemLabel({ children }: { children: React.ReactNode }) {
     </Box>
   );
 }
-/** @deprecated use ItemLabel instead */
-export const SelectItemLabel = ItemLabel;
 
 /**
  * Renders a description for an Item.
@@ -128,8 +124,6 @@ export function ItemDescription({ children }: { children: React.ReactNode }) {
     </Box>
   );
 }
-/** @deprecated Use ItemDescription instead */
-export const SelectItemDescription = ItemDescription;
 
 type OptionProps = {
   item: Node<unknown>;

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -5,7 +5,7 @@ import {
   useControllableState,
 } from "@chakra-ui/react";
 import React, { Suspense } from "react";
-import { InfoSelect, Input, SelectItem, createTexts, useTranslation } from "..";
+import { InfoSelect, Input, Item, createTexts, useTranslation } from "..";
 import { AttachedInputs } from "./AttachedInputs";
 
 type CountryCodeAndPhoneNumber = {
@@ -65,7 +65,7 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
               height="100%"
               value="+47"
             >
-              <SelectItem key="+47">+47</SelectItem>
+              <Item key="+47">+47</Item>
             </InfoSelect>
           }
         >


### PR DESCRIPTION
## Bakgrunn
Det er en ny major på trappene, og da kan det være greit å fjerne eventuelle deprekerte features.

## Løsning
Fjern SelectItem, SelectItemLabel og SelectItemDescription til fordel for sine navnesøstre Item, ItemLabel og ItemDescription