### PR TITLE
La bruker overstyre bredden på Datepicker ved behov.

### DIFF
--- a/.changeset/heavy-pigs-pump.md
+++ b/.changeset/heavy-pigs-pump.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+DatePicker: Make it possible to override width of datepicker

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -34,7 +34,7 @@ export function DateField(props: DateFieldProps) {
   const { fieldProps, labelProps } = useDateField(props, state, ref);
 
   return (
-    <Box minWidth="6rem">
+    <Box minWidth="6rem" width="100%">
       {props.label && (
         <FormLabel {...props.labelProps} {...labelProps} sx={styles.inputLabel}>
           {props.label}

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -26,7 +26,7 @@ import { StyledField } from "./StyledField";
 import { useCurrentLocale } from "./utils";
 
 type DatePickerProps = AriaDatePickerProps<DateValue> &
-  Pick<BoxProps, "minHeight"> & {
+  Pick<BoxProps, "minHeight" | "width"> & {
     variant: ResponsiveValue<"simple" | "with-trigger">;
     name?: string;
     showYearNavigation?: boolean;
@@ -45,6 +45,7 @@ export function DatePicker({
   errorMessage,
   minHeight,
   showYearNavigation,
+  width = "auto",
   ...props
 }: DatePickerProps) {
   const formControlProps = useFormControlContext();
@@ -92,7 +93,12 @@ export function DatePicker({
 
   return (
     <I18nProvider locale={locale}>
-      <Box position="relative" display="inline-flex" flexDirection="column">
+      <Box
+        position="relative"
+        display="inline-flex"
+        flexDirection="column"
+        width={width}
+      >
         <Popover
           {...dialogProps}
           isOpen={state.isOpen}
@@ -102,12 +108,7 @@ export function DatePicker({
           closeOnEsc
           returnFocusOnClose
         >
-          <InputGroup
-            {...groupProps}
-            ref={ref}
-            width="auto"
-            display="inline-flex"
-          >
+          <InputGroup {...groupProps} ref={ref} display="inline-flex">
             <PopoverAnchor>
               <StyledField
                 variant={responsiveVariant}


### PR DESCRIPTION
## Bakgrunn
Man ønsker å kunne tilpasse bredden på DatePicker-komponenten til å være litt bredere enn den er by default. Ikke fullbredde akkurat, men om man vil at komponenten skal passe inn i et grid for eksempel, kan det være fint å dra ut bredden noen piksler.

## Løsning
La konsumenten overstyre bredden. Typisk vil man kunne sette `width="100%"`, for å få den inn i et grid, eller ha det fullbredde på små flater. Du kan, som med andre box props, sende inn responsive verdier som et array.