### PR TITLE
Use heading props

### DIFF
--- a/.changeset/healthy-buttons-marry.md
+++ b/.changeset/healthy-buttons-marry.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix a typing issue with Heading

--- a/packages/spor-react/src/typography/Heading.tsx
+++ b/packages/spor-react/src/typography/Heading.tsx
@@ -26,6 +26,10 @@ export type HeadingProps = Omit<ChakraHeadingProps, "textStyle" | "as"> & {
  * <Heading as="h1" variant="2xl">Look at me!</Heading>
  * ```
  */
-export const Heading = ({ as, variant = "xl-display", ...props }: any) => {
+export const Heading = ({
+  as,
+  variant = "xl-display",
+  ...props
+}: HeadingProps) => {
   return <Text as={as} textStyle={variant} {...props} />;
 };


### PR DESCRIPTION
## Bakgrunn
HeadingProps-definisjonen ble ikke brukt, som førte til at man ikke fikk de feilmeldingene man håpet på med v3.

## Løsning
Bruk propsa!