### PR TITLE
Display text cursor for form labels inside of inputs

### DIFF
--- a/.changeset/stupid-rabbits-complain.md
+++ b/.changeset/stupid-rabbits-complain.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Input: Display text cursor for form labels inside of inputs.

--- a/packages/spor-react/src/theme/components/input.ts
+++ b/packages/spor-react/src/theme/components/input.ts
@@ -82,6 +82,7 @@ const config = helpers.defineMultiStyleConfig({
         my: 2,
         transition: ".1s ease-out",
         transformOrigin: "top left",
+        cursor: "text",
       },
       "&:not(:placeholder-shown)": {
         pt: "16px",


### PR DESCRIPTION
## Bakgrunn
Når man flytter musepekeren over labelen i et ikke-utfylt inputfelt, får man "vanlig" pil-musepeker, mens når man hovrer over resten av inputfeltet får man en tekst-musepeker. Dette ser litt rart ut.

## Løsning
Vis tekst-musepekeren uansett.