### PR TITLE
NumericStepper: Forbedre label-oppførsel når verdien er 0

### DIFF
--- a/.changeset/strong-carrots-guess.md
+++ b/.changeset/strong-carrots-guess.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+NumericStepper: Make label work as "add one" button if the value is zero

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -93,6 +93,7 @@ export function Combobox<T extends object>({
     defaultFilter: contains,
     allowsEmptyCollection: Boolean(emptyContent),
     shouldCloseOnBlur: true,
+    label,
   });
 
   const {

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -94,6 +94,7 @@ export function NumericStepper({
         name={nameProp}
         value={value}
         {...formControlProps}
+        id={value !== 0 ? formControlProps.id : undefined}
         fontSize="sm"
         fontWeight="bold"
         width="3ch"
@@ -140,6 +141,7 @@ export function NumericStepper({
         onClick={() => onChange(value + 1)}
         visibility={value >= maxValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
+        id={value === 0 ? formControlProps.id : undefined}
       />
     </Flex>
   );
@@ -156,6 +158,8 @@ type VerySmallButtonProps = {
   visibility?: "visible" | "hidden";
   /** Whether or not the button is disabled */
   isDisabled?: boolean;
+  /** The ID of the button */
+  id?: string;
 };
 /** Internal override for extra small icon buttons */
 const VerySmallButton = (props: VerySmallButtonProps) => {


### PR DESCRIPTION
## Bakgrunn
Når verdien i en NumericStepper er 0, fungerer ikke labels. 

## Løsning
Når verdien i en NumericStepper er 0, vil et klikk på labelen legge til 1.