### PR TITLE
Et par input-tweaks

### DIFF
--- a/.changeset/chatty-trees-kneel.md
+++ b/.changeset/chatty-trees-kneel.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+DatePicker, TimePicker: Use cursor: text; everywhere inside of the date input field

--- a/.changeset/wild-tigers-boil.md
+++ b/.changeset/wild-tigers-boil.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Combobox: Make padding-right apply to the loading indicator as well

--- a/packages/spor-react/src/datepicker/TimeField.tsx
+++ b/packages/spor-react/src/datepicker/TimeField.tsx
@@ -28,6 +28,7 @@ export const TimeField = ({ state, ...props }: TimeFieldProps) => {
         htmlFor={fieldProps.id}
         marginBottom={0}
         fontSize="mobile.xs"
+        cursor="text"
       >
         {props.label}
       </FormLabel>

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { AriaComboBoxProps, useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
-import { ColorSpinner, Input, InputProps, ListBox } from "..";
+import { ColorSpinner, Input, InputProps, ListBox, useOutsideClick } from "..";
 import { Popover } from "./Popover";
 
 export type ComboboxProps<T> = AriaComboBoxProps<T> & {
@@ -94,6 +94,12 @@ export function Combobox<T extends object>({
     allowsEmptyCollection: Boolean(emptyContent),
     shouldCloseOnBlur: true,
     label,
+  });
+
+  useOutsideClick({
+    ref: listBoxRef,
+    handler: state.close,
+    enabled: true,
   });
 
   const {

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -160,6 +160,7 @@ export function Combobox<T extends object>({
           triggerRef={inputRef as any}
           ref={popoverRef}
           placement="bottom start"
+          shouldFlip={false}
         >
           <ListBox
             {...listBoxProps}

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -141,6 +141,7 @@ export function Combobox<T extends object>({
             <ColorSpinner
               width="1.5rem"
               alignSelf="center"
+              paddingRight={paddingRight}
               css={{
                 div: {
                   display: "flex",

--- a/packages/spor-react/src/input/Popover.tsx
+++ b/packages/spor-react/src/input/Popover.tsx
@@ -27,6 +27,18 @@ type PopoverProps = {
    * Defaults to "bottom"
    */
   placement?: AriaPopoverProps["placement"];
+  /**
+   * Whether or not the list should flip to the opposite side of the trigger if there is not enough space.
+   * Defaults to false.
+   */
+  shouldFlip?: boolean;
+  /**
+   * Whether the popover is non-modal, i.e. elements outside the popover may be interacted with by assistive technologies.
+   * Most popovers should not use this option as it may negatively impact the screen reader experience. Only use with components such as combobox, which are designed to handle this situation carefully.
+   *
+   * Defaults to false.
+   */
+  isNonModal?: boolean;
 };
 /**
  * Internal popover component.
@@ -42,6 +54,8 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       offset = 0,
       crossOffset = 0,
       placement = "bottom",
+      shouldFlip = false,
+      isNonModal = false,
     },
     ref
   ) => {
@@ -55,6 +69,8 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         offset,
         crossOffset,
         placement,
+        shouldFlip,
+        isNonModal,
       },
       state
     );

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -70,6 +70,7 @@ const config = helpers.defineMultiStyleConfig({
       fontSize: "mobile.xs",
       color: mode("darkGrey", "white")(props),
       margin: 0,
+      cursor: "text",
     },
     dateTimeSegment: {
       color: mode(


### PR DESCRIPTION
## Bakgrunn
Mens vi utvikler nytt reisesøk ser vi et par forbedringsområder vi kan tweake på når det kommer til input-felt

## Løsning
- Vise riktig musepeker på div inputfelt
- La konsument definere høyre-padding for loading-spinneren
- Comboboxes burde ikke flippe, siden de er designet til å kun gå nedover.