### PR TITLE
Datepickers: Gjør dem fokuserbare

### DIFF
--- a/.changeset/ninety-kiwis-deny.md
+++ b/.changeset/ninety-kiwis-deny.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Datepicker: Add ref support

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, FormLabel, useMultiStyleConfig } from "@chakra-ui/react";
 import { DateValue, GregorianCalendar } from "@internationalized/date";
 import { useDateFieldState } from "@react-stately/datepicker";
 import { DOMAttributes, FocusableElement } from "@react-types/shared";
-import React, { useRef } from "react";
+import React, { RefObject, forwardRef, useRef } from "react";
 import { AriaDateFieldProps, useDateField } from "react-aria";
 import { DateTimeSegment } from "./DateTimeSegment";
 import { useCurrentLocale } from "./utils";
@@ -21,31 +21,51 @@ type DateFieldProps = AriaDateFieldProps<DateValue> & {
   labelProps?: DOMAttributes<FocusableElement>;
   name?: string;
 };
-export function DateField(props: DateFieldProps) {
-  const locale = useCurrentLocale();
-  const styles = useMultiStyleConfig("Datepicker", {});
-  const state = useDateFieldState({
-    ...props,
-    locale,
-    createCalendar,
-  });
+export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
+  (props, externalRef) => {
+    const locale = useCurrentLocale();
+    const styles = useMultiStyleConfig("Datepicker", {});
+    const state = useDateFieldState({
+      ...props,
+      locale,
+      createCalendar,
+    });
 
-  const ref = useRef(null);
-  const { fieldProps, labelProps } = useDateField(props, state, ref);
+    const internalRef = useRef(null);
+    const ref = externalRef ?? internalRef;
+    const { fieldProps, labelProps } = useDateField(
+      props,
+      state,
+      ref as RefObject<HTMLDivElement>
+    );
 
-  return (
-    <Box minWidth="6rem" width="100%">
-      {props.label && (
-        <FormLabel {...props.labelProps} {...labelProps} sx={styles.inputLabel}>
-          {props.label}
-        </FormLabel>
-      )}
-      <Flex {...fieldProps} ref={ref}>
-        {state.segments.map((segment, i) => (
-          <DateTimeSegment key={i} segment={segment} state={state} />
-        ))}
-      </Flex>
-      <input type="hidden" value={state.value?.toString()} name={props.name} />
-    </Box>
-  );
-}
+    return (
+      <Box minWidth="6rem" width="100%">
+        {props.label && (
+          <FormLabel
+            {...props.labelProps}
+            {...labelProps}
+            sx={styles.inputLabel}
+          >
+            {props.label}
+          </FormLabel>
+        )}
+        <Flex {...fieldProps}>
+          {state.segments.map((segment, i) => (
+            <DateTimeSegment
+              ref={i === 0 ? ref : undefined}
+              key={i}
+              segment={segment}
+              state={state}
+            />
+          ))}
+        </Flex>
+        <input
+          type="hidden"
+          value={state.value?.toString()}
+          name={props.name}
+        />
+      </Box>
+    );
+  }
+);

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -1,5 +1,5 @@
 import { Box, useMultiStyleConfig } from "@chakra-ui/react";
-import React, { useRef } from "react";
+import React, { RefObject, forwardRef, useRef } from "react";
 import { useDateSegment } from "react-aria";
 import { DateFieldState, DateSegment } from "react-stately";
 
@@ -14,40 +14,49 @@ type DateTimeSegmentProps = {
  *
  * This component should be used with the react-aria library, and is not meant to be used directly.
  * */
-export const DateTimeSegment = ({ segment, state }: DateTimeSegmentProps) => {
-  const ref = useRef(null);
+export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
+  ({ segment, state }, externalRef) => {
+    const internalRef = useRef(null);
+    const ref = externalRef ?? internalRef;
 
-  const { segmentProps } = useDateSegment(segment, state, ref);
+    const { segmentProps } = useDateSegment(
+      segment,
+      state,
+      ref as RefObject<HTMLDivElement>
+    );
 
-  const styles = useMultiStyleConfig("Datepicker", {
-    isPlaceholder: segment.isPlaceholder,
-    isEditable: segment.isEditable,
-  });
+    const styles = useMultiStyleConfig("Datepicker", {
+      isPlaceholder: segment.isPlaceholder,
+      isEditable: segment.isEditable,
+    });
 
-  return (
-    <Box
-      {...segmentProps}
-      ref={ref}
-      style={{
-        ...segmentProps.style,
-        fontVariantNumeric: "tabular-nums",
-        boxSizing: "content-box",
-      }}
-      paddingX="1px"
-      textAlign="end"
-      outline="none"
-      borderRadius="xs"
-      fontSize="mobile.md"
-      sx={styles.dateTimeSegment}
-      _focus={{
-        backgroundColor: "darkTeal",
-        color: "white",
-      }}
-    >
-      {isPaddable(segment.type) ? segment.text.padStart(2, "0") : segment.text}
-    </Box>
-  );
-};
+    return (
+      <Box
+        {...segmentProps}
+        ref={ref}
+        style={{
+          ...segmentProps.style,
+          fontVariantNumeric: "tabular-nums",
+          boxSizing: "content-box",
+        }}
+        paddingX="1px"
+        textAlign="end"
+        outline="none"
+        borderRadius="xs"
+        fontSize="mobile.md"
+        sx={styles.dateTimeSegment}
+        _focus={{
+          backgroundColor: "darkTeal",
+          color: "white",
+        }}
+      >
+        {isPaddable(segment.type)
+          ? segment.text.padStart(2, "0")
+          : segment.text}
+      </Box>
+    );
+  }
+);
 
 const isPaddable = (segmentType: DateSegment["type"]) =>
   segmentType === "month" ||


### PR DESCRIPTION
## Bakgrunn
I forbindelse med nytt reisesøk har vi behov for å fokusere et datofelt. Det var ikke mulig, siden Datepicker ikke godtar refs.

## Løsning
Legg til støtte for å sende inn ref. Den ref-en måtte sendes ned helt ned til hvert date-segment for å faktisk kunne fokusere riktig element.