### PR TITLE
Adds floating label variant on TextArea

### DIFF
--- a/.changeset/small-nails-smile.md
+++ b/.changeset/small-nails-smile.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Adds floating label variant on TextArea

--- a/packages/spor-react/src/input/Textarea.tsx
+++ b/packages/spor-react/src/input/Textarea.tsx
@@ -5,11 +5,13 @@ import {
   Textarea as ChakraTextarea,
   TextareaProps as ChakraTextareaProps,
   useFormControlContext,
+  InputGroup,
 } from "@chakra-ui/react";
 import React, { useId } from "react";
 
 export type TextareaProps = Exclude<ChakraTextareaProps, "variant" | "size"> & {
   label: string;
+  variant?: "default" | "floating";
 };
 /**
  * Text area that works with the `FormControl` component.
@@ -30,12 +32,23 @@ export const Textarea = forwardRef<TextareaProps, "textarea">((props, ref) => {
   const formControlProps = useFormControlContext();
   const fallbackId = `textarea-${useId()}`;
   const inputId = props.id ?? formControlProps?.id ?? fallbackId;
-  return (
-    <Box {...spacingProps}>
-      <FormLabel htmlFor={inputId}>{label}</FormLabel>
-      <ChakraTextarea {...rest} id={inputId} ref={ref} />
-    </Box>
-  );
+
+  switch (props.variant) {
+    case "floating":
+      return (
+        <InputGroup position="relative" {...spacingProps}>
+          <ChakraTextarea {...rest} id={inputId} ref={ref} placeholder=" " />{" "}
+          <FormLabel htmlFor={inputId}>{label}</FormLabel>
+        </InputGroup>
+      );
+    default:
+      return (
+        <Box {...spacingProps}>
+          <FormLabel htmlFor={inputId}>{label}</FormLabel>
+          <ChakraTextarea {...rest} id={inputId} ref={ref} />{" "}
+        </Box>
+      );
+  }
 });
 
 function getSpacingProps<T extends TextareaProps>(props: T) {

--- a/packages/spor-react/src/input/Textarea.tsx
+++ b/packages/spor-react/src/input/Textarea.tsx
@@ -10,13 +10,12 @@ import {
 import React, { useId } from "react";
 
 export type TextareaProps = Exclude<ChakraTextareaProps, "variant" | "size"> & {
-  label: string;
-  variant?: "default" | "floating";
+  label?: string;
 };
 /**
  * Text area that works with the `FormControl` component.
  *
- * Note that it requires you to pass a label.
+ * Providing a label is optional.
  *
  * ```tsx
  * <FormControl>
@@ -33,22 +32,16 @@ export const Textarea = forwardRef<TextareaProps, "textarea">((props, ref) => {
   const fallbackId = `textarea-${useId()}`;
   const inputId = props.id ?? formControlProps?.id ?? fallbackId;
 
-  switch (props.variant) {
-    case "floating":
-      return (
-        <InputGroup position="relative" {...spacingProps}>
-          <ChakraTextarea {...rest} id={inputId} ref={ref} placeholder=" " />{" "}
-          <FormLabel htmlFor={inputId}>{label}</FormLabel>
-        </InputGroup>
-      );
-    default:
-      return (
-        <Box {...spacingProps}>
-          <FormLabel htmlFor={inputId}>{label}</FormLabel>
-          <ChakraTextarea {...rest} id={inputId} ref={ref} />{" "}
-        </Box>
-      );
-  }
+  return (
+    <InputGroup position="relative" {...spacingProps}>
+      <ChakraTextarea {...rest} id={inputId} ref={ref} placeholder=" " />
+      {label && (
+        <FormLabel htmlFor={inputId} id={`label`}>
+          {label}
+        </FormLabel>
+      )}
+    </InputGroup>
+  );
 });
 
 function getSpacingProps<T extends TextareaProps>(props: T) {

--- a/packages/spor-react/src/input/Textarea.tsx
+++ b/packages/spor-react/src/input/Textarea.tsx
@@ -36,7 +36,7 @@ export const Textarea = forwardRef<TextareaProps, "textarea">((props, ref) => {
     <InputGroup position="relative" {...spacingProps}>
       <ChakraTextarea {...rest} id={inputId} ref={ref} placeholder=" " />
       {label && (
-        <FormLabel htmlFor={inputId} id={`label`}>
+        <FormLabel htmlFor={inputId} id={`${inputId}-label`}>
           {label}
         </FormLabel>
       )}

--- a/packages/spor-react/src/theme/components/textarea.ts
+++ b/packages/spor-react/src/theme/components/textarea.ts
@@ -7,10 +7,10 @@ const config = defineStyleConfig({
     minHeight: "5rem",
     verticalAlign: "top",
     appearance: "none",
-    pt: 2,
+    paddingTop: 2,
     "&:not(:placeholder-shown)": {
       "&:has(+ label)": {
-        pt: 4,
+        paddingTop: 4
       },
       "& + label": {
         transform: "scale(0.825) translateY(-10px)",

--- a/packages/spor-react/src/theme/components/textarea.ts
+++ b/packages/spor-react/src/theme/components/textarea.ts
@@ -5,10 +5,26 @@ const config = defineStyleConfig({
   baseStyle: (props) => ({
     ...Input.baseStyle!(props).field,
     minHeight: "5rem",
-    py: 3,
     verticalAlign: "top",
     appearance: "none",
   }),
+  variants: {
+    default: {
+      py: 3,
+    },
+    floating: {
+      pt: 2,
+      "&:not(:placeholder-shown)": {
+        pt: 4,
+        "& + label": {
+          transform: "scale(0.825) translateY(-10px)",
+        },
+      },
+    },
+  },
+  defaultProps: {
+    variant: "default",
+  },
 });
 
 export default config;

--- a/packages/spor-react/src/theme/components/textarea.ts
+++ b/packages/spor-react/src/theme/components/textarea.ts
@@ -7,24 +7,16 @@ const config = defineStyleConfig({
     minHeight: "5rem",
     verticalAlign: "top",
     appearance: "none",
-  }),
-  variants: {
-    default: {
-      py: 3,
-    },
-    floating: {
-      pt: 2,
-      "&:not(:placeholder-shown)": {
+    pt: 2,
+    "&:not(:placeholder-shown)": {
+      "&:has(+ label)": {
         pt: 4,
-        "& + label": {
-          transform: "scale(0.825) translateY(-10px)",
-        },
+      },
+      "& + label": {
+        transform: "scale(0.825) translateY(-10px)",
       },
     },
-  },
-  defaultProps: {
-    variant: "default",
-  },
+  }),
 });
 
 export default config;


### PR DESCRIPTION
## Bakgrunn
Dette er bare et forslag basert på noe jeg kom over. 

I Team Personell trenger vi en `TextArea` med en floating label, slik som `Input`. I tillegg tenkte jeg det er fint at det er litt konsekvent mellom komponentene som er ganske like 😊 
Formen vi trenger det for ser slik ut:

![image](https://github.com/nsbno/spor/assets/23121869/3afe3b1b-a602-4595-abe3-fed8123d607b)

Dersom vi bruker `TextArea` slik den er nå vil det se slik ut: 
![image](https://github.com/nsbno/spor/assets/23121869/ccdf435d-6fbe-4d72-8d79-ea605d9012bc)

Ved siden av hverandre:
![image](https://github.com/nsbno/spor/assets/23121869/f8b45503-3aa1-496a-aa7c-eed5456202ba)
![image](https://github.com/nsbno/spor/assets/23121869/996d5b39-2e07-4f4d-8870-f899f5fdd3ad)


## Løsning
<!-- Kort oppsummering av hva som er gjort -->
Lagt til mulighet for å velge `variant="floating" på en `TextArea`. Legger til variants i theming og i komponenten selv siden den interne strukturen endres med varianten. 

- [ ] Mangler typing på Theme. 