### PR TITLE
Legge til utvidet støtte for dark mode i card select 

### DIFF
--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -31,7 +31,7 @@ const config = helpers.defineMultiStyleConfig({
       borderRadius: "sm",
       boxShadow: "md",
       padding: 3,
-      textColor: mode("darkGrey", "lightGrey")(props), 
+      color: mode("darkGrey", "lightGrey")(props), 
       backgroundColor: mode("white", "darkGrey")(props),
     },
   }),

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -31,6 +31,8 @@ const config = helpers.defineMultiStyleConfig({
       borderRadius: "sm",
       boxShadow: "md",
       padding: 3,
+      textColor: mode("darkGrey", "lightGrey")(props), 
+      backgroundColor: mode("white", "darkGrey")(props),
     },
   }),
   variants: {

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -32,7 +32,7 @@ const config = helpers.defineMultiStyleConfig({
       boxShadow: "md",
       padding: 3,
       color: mode("darkGrey", "lightGrey")(props), 
-      backgroundColor: mode("white", "darkGrey")(props),
+      backgroundColor: mode("white", "night")(props),
     },
   }),
   variants: {


### PR DESCRIPTION
## Bakgrunn
Per dags dato er cardet i Card Select alltid hvitt, uavhengig av om mode er light eller dark. (Se bildet) Dersom dette skal endres slik at bakgrunnsfargen støtter dark mode, må også tekstfarge oppdateres for å synes på ny dynamisk bakgrunn. 

<img width="471" alt="CardSelect_DM" src="https://github.com/nsbno/spor/assets/83952671/ff9b910d-fdbf-4693-97a8-40f37f4792a4">

##  Løsning

Jeg har lagt til dynamisk bakgrunnsfarge og da også tekstfarge for card i cardselect. Fant ingen skisser i Figma for darkmode i Card Select enda, så jeg har tatt utgangspunkt i bakgrunnsfargene for fargevalget. 

Det ser da slik ut: 

![CardSelect](https://github.com/nsbno/spor/assets/83952671/405a96f3-2ad0-40ff-98bb-d3476a648a83)

Jeg har prøvd å bruke samme tilnærming som eksisterende komponenter med støtte for darkMode, men si gjerne ifra dersom det er ønskelig å gjøre noe annerledes 😊
