### PR TITLE
:arrow_down: Nedgrader elm-css i spor-icon-elm for bedre støtte

### DIFF
--- a/packages/spor-icon-elm/elm.json
+++ b/packages/spor-icon-elm/elm.json
@@ -1,19 +1,17 @@
 {
-    "type": "package",
-    "name": "nsbno/spor-icon-elm",
-    "summary": "Icons used for Elm applications hosted on vy.no",
-    "license": "MIT",
-    "version": "1.0.0",
-    "exposed-modules": [
-        "Spor.Icon"
-    ],
-    "elm-version": "0.19.1 <= v < 0.20.0",
-    "dependencies": {
-        "elm/core": "1.0.0 <= v < 2.0.0",
-        "elm/html": "1.0.0 <= v < 2.0.0",
-        "elm/svg": "1.0.1 <= v < 2.0.0",
-        "elm/virtual-dom": "1.0.3 <= v < 2.0.0",
-        "rtfeldman/elm-css": "18.0.0 <= v < 19.0.0"
-    },
-    "test-dependencies": {}
+  "type": "package",
+  "name": "nsbno/spor-icon-elm",
+  "summary": "Icons used for Elm applications hosted on vy.no",
+  "license": "MIT",
+  "version": "1.0.0",
+  "exposed-modules": ["Spor.Icon"],
+  "elm-version": "0.19.1 <= v < 0.20.0",
+  "dependencies": {
+    "elm/core": "1.0.0 <= v < 2.0.0",
+    "elm/html": "1.0.0 <= v < 2.0.0",
+    "elm/svg": "1.0.1 <= v < 2.0.0",
+    "elm/virtual-dom": "1.0.3 <= v < 2.0.0",
+    "rtfeldman/elm-css": "17.1.1 <= v < 18.0.0"
+  },
+  "test-dependencies": {}
 }


### PR DESCRIPTION
## Bakgrunn
<!-- Liten forklaring på hva som var bakgrunnen for oppgaven, hvorfor det skulle gjøres. -->
#756 la til et nytt API for elm-ikonene. Dessverre så jeg ikke at den krevde nyeste versjon av elm-css, mens alle prosjekter som bruker pakken har én major-versjon under.

## Løsning
<!-- Kort oppsummering av hva som er gjort -->
Nedgraderer til forrige major-versjon