### PR TITLE
:wheelchair: Ikonstørrelse bør ikke skalere på lokal tekststørrelse

### DIFF
--- a/packages/spor-icon-elm/generate.js
+++ b/packages/spor-icon-elm/generate.js
@@ -248,7 +248,7 @@ sizeToEm size =
         ${sizes
           .map(
             (sizeType) => `Size${sizeType} ->
-            "${sizeType / 16 + "em"}"`
+            "${sizeType / 16 + "rem"}"`
           )
           .join("\n        ")}
     `;


### PR DESCRIPTION
## Bakgrunn
<!-- Liten forklaring på hva som var bakgrunnen for oppgaven, hvorfor det skulle gjøres. -->
Jeg brukte em istedenfor rem med et uhell. Så dersom noe tekst var større så ble ikonene større enn tenkt.

## Løsning
<!-- Kort oppsummering av hva som er gjort -->
Bruker rem.