### PR TITLE
Fix an issue with the combobox listbox closing on keyUp

### DIFF
--- a/.changeset/twenty-drinks-push.md
+++ b/.changeset/twenty-drinks-push.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix an issue with the listbox closing on keyUp

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -82,7 +82,7 @@ export function Combobox<T extends object>({
 }: ComboboxProps<T>) {
   const { contains } = useFilter({ sensitivity: "base" });
 
-  const inputRef =  useRef(null);
+  const inputRef = useRef(null);
   const listBoxRef = useRef(null);
   const popoverRef = useRef(null);
 

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -82,7 +82,7 @@ export function Combobox<T extends object>({
 }: ComboboxProps<T>) {
   const { contains } = useFilter({ sensitivity: "base" });
 
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef =  useRef(null);
   const listBoxRef = useRef(null);
   const popoverRef = useRef(null);
 


### PR DESCRIPTION
## Background

When clicking inside the input field, if you do not hit the lable, the listbox with suggestions will close. Somehow it seems that an onKeyUp triggers that, but when hitting the lable it seems that the key up does not have enough time to do so because we click via the label first.. or something like that.

## Illustrations 

Illustrated in the first part of this recording.

https://github.com/nsbno/spor/assets/15145686/8e5687a6-8c05-4f5a-b9a6-20ad0241e4b0


## Solution

The reason this happens is somehow that the inputRef specifically has type HTMLInputElement here. I believe that we really do not need to specify the type in this case (and now the listbox stays open when it should).