### PR TITLE
Fix closing issues with combobox

### DIFF
--- a/.changeset/few-cycles-know.md
+++ b/.changeset/few-cycles-know.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Combobox: Fix some behavioral issues with opening and closing

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { AriaComboBoxProps, useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
-import { ColorSpinner, Input, InputProps, ListBox, useOutsideClick } from "..";
+import { ColorSpinner, Input, InputProps, ListBox } from "..";
 import { Popover } from "./Popover";
 
 export type ComboboxProps<T> = AriaComboBoxProps<T> & {
@@ -96,12 +96,6 @@ export function Combobox<T extends object>({
     label,
   });
 
-  useOutsideClick({
-    ref: listBoxRef,
-    handler: state.close,
-    enabled: true,
-  });
-
   const {
     inputProps: { size, ...inputProps },
     listBoxProps,
@@ -165,6 +159,7 @@ export function Combobox<T extends object>({
           state={state}
           triggerRef={inputRef as any}
           ref={popoverRef}
+          isNonModal
           placement="bottom start"
           shouldFlip={false}
           hasBackdrop={false}


### PR DESCRIPTION
## Background

When clicking inside the input field, if you do not hit the label, the listbox with suggestions will close. This seems to be due to the `useOutsideClick` (When hitting the label, it does not seem that the useOutsideClick has enough time to trigger, because we click via the label first). The popover already seems to have an outsideClick functionality, and with `useOutsideClick`, the functionality is duplicated and cancels each other out. 

It is also not possible to double click inside the input field while the listbox is open, this should be possible to be able to copy written input. 

## Illustrations 

Illustrated in the first part of this recording.

https://github.com/nsbno/spor/assets/15145686/8e5687a6-8c05-4f5a-b9a6-20ad0241e4b0


## Solution

Remove the `useOutsideClick` hook. 

Add the `isNonModal` prop to the popover to make double clicking inside the input field possible.
