### PR TITLE
Bump version of spor-icon-elm in spor-elm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34277,7 +34277,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "3.0.4",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.6.1",

--- a/packages/spor-elm/elm.json
+++ b/packages/spor-elm/elm.json
@@ -19,7 +19,7 @@
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "nsbno/spor-design-tokens-elm": "2.0.0 <= v < 3.0.0",
-        "nsbno/spor-icon-elm": "1.0.0 <= v < 2.0.0",
+        "nsbno/spor-icon-elm": "2.0.2 <= v < 3.0.0",
         "rtfeldman/elm-css": "17.0.0 <= v < 18.0.0"
     },
     "test-dependencies": {}

--- a/packages/spor-elm/src/Spor/LineTag/LineIcon.elm
+++ b/packages/spor-elm/src/Spor/LineTag/LineIcon.elm
@@ -153,7 +153,7 @@ iconColor variant =
 icon : Variant -> Size -> Svg msg
 icon variant size =
     let
-        sizeToIconSize =
+        sizeAsIconSize =
             case size of
                 Sm ->
                     Icon.Size18
@@ -163,47 +163,45 @@ icon variant size =
 
                 Lg ->
                     Icon.Size30
-
-        trainIcon size_ =
-            Icon.icon size_ Icon.Fill Icon.Train
     in
     Icon.toHtml <|
-        case variant of
-            LocalTrain ->
-                trainIcon sizeToIconSize
+        Icon.icon sizeAsIconSize Icon.Fill <|
+            case variant of
+                LocalTrain ->
+                    Icon.Train
 
-            RegionTrain ->
-                trainIcon sizeToIconSize
+                RegionTrain ->
+                    Icon.Train
 
-            RegionExpressTrain ->
-                trainIcon sizeToIconSize
+                RegionExpressTrain ->
+                    Icon.Train
 
-            LongDistanceTrain ->
-                trainIcon sizeToIconSize
+                LongDistanceTrain ->
+                    Icon.Train
 
-            AirportExpressTrain ->
-                trainIcon sizeToIconSize
+                AirportExpressTrain ->
+                    Icon.Train
 
-            VyBus ->
-                Icon.icon sizeToIconSize Icon.Fill Icon.ExpressBus
+                VyBus ->
+                    Icon.ExpressBus
 
-            LocalBus ->
-                Icon.icon sizeToIconSize Icon.Fill Icon.Bus
+                LocalBus ->
+                    Icon.Bus
 
-            Ferry ->
-                Icon.icon sizeToIconSize Icon.Fill Icon.Ferry
+                Ferry ->
+                    Icon.Ferry
 
-            Subway ->
-                Icon.icon sizeToIconSize Icon.Fill Icon.Subway
+                Subway ->
+                    Icon.Subway
 
-            Tram ->
-                Icon.icon sizeToIconSize Icon.Fill Icon.Tram
+                Tram ->
+                    Icon.Tram
 
-            AlternativeTransport ->
-                Icon.icon sizeToIconSize Icon.Fill Icon.AltTransport
+                AlternativeTransport ->
+                    Icon.AltTransport
 
-            Walk ->
-                Icon.icon sizeToIconSize Icon.Fill Icon.Walk
+                Walk ->
+                    Icon.Walk
 
 
 backgroundColor : Variant -> Color

--- a/packages/spor-elm/src/Spor/LineTag/LineIcon.elm
+++ b/packages/spor-elm/src/Spor/LineTag/LineIcon.elm
@@ -24,7 +24,7 @@ import Css exposing (Color, Style)
 import Css.Global
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
-import Spor.Icon.Transportation as Transportation
+import Spor.Icon as Icon
 import Spor.LineTag.Types exposing (Size(..), Variant(..))
 import Spor.Token.Color.Alias as Alias
 import Spor.Token.Color.Linjetag as Linjetag
@@ -152,115 +152,140 @@ iconColor variant =
 
 icon : Variant -> Size -> Svg msg
 icon variant size =
-    Svg.fromUnstyled <|
+    let
+        trainIcon size_ =
+            Icon.icon size_ Icon.Fill Icon.Train
+
+        expressBusIcon size_ =
+            Icon.icon size_ Icon.Fill Icon.ExpressBus
+
+        busIcon size_ =
+            Icon.icon size_ Icon.Fill Icon.Bus
+
+        ferryIcon size_ =
+            Icon.icon size_ Icon.Fill Icon.Ferry
+
+        subwayIcon size_ =
+            Icon.icon size_ Icon.Fill Icon.Subway
+
+        tramIcon size_ =
+            Icon.icon size_ Icon.Fill Icon.Tram
+
+        altTransportIcon size_ =
+            Icon.icon size_ Icon.Fill Icon.AltTransport
+
+        walkIcon size_ =
+            Icon.icon size_ Icon.Fill Icon.Walk
+    in
+    Icon.toHtml <|
         case ( variant, size ) of
             ( LocalTrain, Sm ) ->
-                Transportation.trainFill18X18 []
+                trainIcon Icon.Size18
 
             ( LocalTrain, Md ) ->
-                Transportation.trainFill24X24 []
+                trainIcon Icon.Size24
 
             ( LocalTrain, Lg ) ->
-                Transportation.trainFill30X30 []
+                trainIcon Icon.Size30
 
             ( RegionTrain, Sm ) ->
-                Transportation.trainFill18X18 []
+                trainIcon Icon.Size18
 
             ( RegionTrain, Md ) ->
-                Transportation.trainFill24X24 []
+                trainIcon Icon.Size24
 
             ( RegionTrain, Lg ) ->
-                Transportation.trainFill30X30 []
+                trainIcon Icon.Size30
 
             ( RegionExpressTrain, Sm ) ->
-                Transportation.trainFill18X18 []
+                trainIcon Icon.Size18
 
             ( RegionExpressTrain, Md ) ->
-                Transportation.trainFill24X24 []
+                trainIcon Icon.Size24
 
             ( RegionExpressTrain, Lg ) ->
-                Transportation.trainFill30X30 []
+                trainIcon Icon.Size30
 
             ( LongDistanceTrain, Sm ) ->
-                Transportation.trainFill18X18 []
+                trainIcon Icon.Size18
 
             ( LongDistanceTrain, Md ) ->
-                Transportation.trainFill24X24 []
+                trainIcon Icon.Size24
 
             ( LongDistanceTrain, Lg ) ->
-                Transportation.trainFill30X30 []
+                trainIcon Icon.Size30
 
             ( AirportExpressTrain, Sm ) ->
-                Transportation.trainFill18X18 []
+                trainIcon Icon.Size18
 
             ( AirportExpressTrain, Md ) ->
-                Transportation.trainFill24X24 []
+                trainIcon Icon.Size24
 
             ( AirportExpressTrain, Lg ) ->
-                Transportation.trainFill30X30 []
+                trainIcon Icon.Size30
 
             ( VyBus, Sm ) ->
-                Transportation.expressBusFill18X18 []
+                expressBusIcon Icon.Size18
 
             ( VyBus, Md ) ->
-                Transportation.expressBusFill24X24 []
+                expressBusIcon Icon.Size24
 
             ( VyBus, Lg ) ->
-                Transportation.expressBusFill30X30 []
+                expressBusIcon Icon.Size30
 
             ( LocalBus, Sm ) ->
-                Transportation.busFill18X18 []
+                busIcon Icon.Size18
 
             ( LocalBus, Md ) ->
-                Transportation.busFill24X24 []
+                busIcon Icon.Size24
 
             ( LocalBus, Lg ) ->
-                Transportation.busFill30X30 []
+                busIcon Icon.Size30
 
             ( Ferry, Sm ) ->
-                Transportation.ferryFill18X18 []
+                ferryIcon Icon.Size18
 
             ( Ferry, Md ) ->
-                Transportation.ferryFill24X24 []
+                ferryIcon Icon.Size24
 
             ( Ferry, Lg ) ->
-                Transportation.ferryFill30X30 []
+                ferryIcon Icon.Size30
 
             ( Subway, Sm ) ->
-                Transportation.subwayFill18X18 []
+                subwayIcon Icon.Size18
 
             ( Subway, Md ) ->
-                Transportation.subwayFill24X24 []
+                subwayIcon Icon.Size24
 
             ( Subway, Lg ) ->
-                Transportation.subwayFill30X30 []
+                subwayIcon Icon.Size30
 
             ( Tram, Sm ) ->
-                Transportation.trainFill18X18 []
+                tramIcon Icon.Size18
 
             ( Tram, Md ) ->
-                Transportation.tramFill24X24 []
+                tramIcon Icon.Size24
 
             ( Tram, Lg ) ->
-                Transportation.trainFill30X30 []
+                tramIcon Icon.Size30
 
             ( AlternativeTransport, Sm ) ->
-                Transportation.altTransportFill18X18 []
+                altTransportIcon Icon.Size18
 
             ( AlternativeTransport, Md ) ->
-                Transportation.altTransportFill24X24 []
+                altTransportIcon Icon.Size24
 
             ( AlternativeTransport, Lg ) ->
-                Transportation.altTransportFill30X30 []
+                altTransportIcon Icon.Size30
 
             ( Walk, Sm ) ->
-                Transportation.walkFill18X18 []
+                walkIcon Icon.Size18
 
             ( Walk, Md ) ->
-                Transportation.walkFill24X24 []
+                walkIcon Icon.Size24
 
             ( Walk, Lg ) ->
-                Transportation.walkFill30X30 []
+                walkIcon Icon.Size30
 
 
 backgroundColor : Variant -> Color

--- a/packages/spor-elm/src/Spor/LineTag/LineIcon.elm
+++ b/packages/spor-elm/src/Spor/LineTag/LineIcon.elm
@@ -153,139 +153,57 @@ iconColor variant =
 icon : Variant -> Size -> Svg msg
 icon variant size =
     let
+        sizeToIconSize =
+            case size of
+                Sm ->
+                    Icon.Size18
+
+                Md ->
+                    Icon.Size24
+
+                Lg ->
+                    Icon.Size30
+
         trainIcon size_ =
             Icon.icon size_ Icon.Fill Icon.Train
-
-        expressBusIcon size_ =
-            Icon.icon size_ Icon.Fill Icon.ExpressBus
-
-        busIcon size_ =
-            Icon.icon size_ Icon.Fill Icon.Bus
-
-        ferryIcon size_ =
-            Icon.icon size_ Icon.Fill Icon.Ferry
-
-        subwayIcon size_ =
-            Icon.icon size_ Icon.Fill Icon.Subway
-
-        tramIcon size_ =
-            Icon.icon size_ Icon.Fill Icon.Tram
-
-        altTransportIcon size_ =
-            Icon.icon size_ Icon.Fill Icon.AltTransport
-
-        walkIcon size_ =
-            Icon.icon size_ Icon.Fill Icon.Walk
     in
     Icon.toHtml <|
-        case ( variant, size ) of
-            ( LocalTrain, Sm ) ->
-                trainIcon Icon.Size18
+        case variant of
+            LocalTrain ->
+                trainIcon sizeToIconSize
 
-            ( LocalTrain, Md ) ->
-                trainIcon Icon.Size24
+            RegionTrain ->
+                trainIcon sizeToIconSize
 
-            ( LocalTrain, Lg ) ->
-                trainIcon Icon.Size30
+            RegionExpressTrain ->
+                trainIcon sizeToIconSize
 
-            ( RegionTrain, Sm ) ->
-                trainIcon Icon.Size18
+            LongDistanceTrain ->
+                trainIcon sizeToIconSize
 
-            ( RegionTrain, Md ) ->
-                trainIcon Icon.Size24
+            AirportExpressTrain ->
+                trainIcon sizeToIconSize
 
-            ( RegionTrain, Lg ) ->
-                trainIcon Icon.Size30
+            VyBus ->
+                Icon.icon sizeToIconSize Icon.Fill Icon.ExpressBus
 
-            ( RegionExpressTrain, Sm ) ->
-                trainIcon Icon.Size18
+            LocalBus ->
+                Icon.icon sizeToIconSize Icon.Fill Icon.Bus
 
-            ( RegionExpressTrain, Md ) ->
-                trainIcon Icon.Size24
+            Ferry ->
+                Icon.icon sizeToIconSize Icon.Fill Icon.Ferry
 
-            ( RegionExpressTrain, Lg ) ->
-                trainIcon Icon.Size30
+            Subway ->
+                Icon.icon sizeToIconSize Icon.Fill Icon.Subway
 
-            ( LongDistanceTrain, Sm ) ->
-                trainIcon Icon.Size18
+            Tram ->
+                Icon.icon sizeToIconSize Icon.Fill Icon.Tram
 
-            ( LongDistanceTrain, Md ) ->
-                trainIcon Icon.Size24
+            AlternativeTransport ->
+                Icon.icon sizeToIconSize Icon.Fill Icon.AltTransport
 
-            ( LongDistanceTrain, Lg ) ->
-                trainIcon Icon.Size30
-
-            ( AirportExpressTrain, Sm ) ->
-                trainIcon Icon.Size18
-
-            ( AirportExpressTrain, Md ) ->
-                trainIcon Icon.Size24
-
-            ( AirportExpressTrain, Lg ) ->
-                trainIcon Icon.Size30
-
-            ( VyBus, Sm ) ->
-                expressBusIcon Icon.Size18
-
-            ( VyBus, Md ) ->
-                expressBusIcon Icon.Size24
-
-            ( VyBus, Lg ) ->
-                expressBusIcon Icon.Size30
-
-            ( LocalBus, Sm ) ->
-                busIcon Icon.Size18
-
-            ( LocalBus, Md ) ->
-                busIcon Icon.Size24
-
-            ( LocalBus, Lg ) ->
-                busIcon Icon.Size30
-
-            ( Ferry, Sm ) ->
-                ferryIcon Icon.Size18
-
-            ( Ferry, Md ) ->
-                ferryIcon Icon.Size24
-
-            ( Ferry, Lg ) ->
-                ferryIcon Icon.Size30
-
-            ( Subway, Sm ) ->
-                subwayIcon Icon.Size18
-
-            ( Subway, Md ) ->
-                subwayIcon Icon.Size24
-
-            ( Subway, Lg ) ->
-                subwayIcon Icon.Size30
-
-            ( Tram, Sm ) ->
-                tramIcon Icon.Size18
-
-            ( Tram, Md ) ->
-                tramIcon Icon.Size24
-
-            ( Tram, Lg ) ->
-                tramIcon Icon.Size30
-
-            ( AlternativeTransport, Sm ) ->
-                altTransportIcon Icon.Size18
-
-            ( AlternativeTransport, Md ) ->
-                altTransportIcon Icon.Size24
-
-            ( AlternativeTransport, Lg ) ->
-                altTransportIcon Icon.Size30
-
-            ( Walk, Sm ) ->
-                walkIcon Icon.Size18
-
-            ( Walk, Md ) ->
-                walkIcon Icon.Size24
-
-            ( Walk, Lg ) ->
-                walkIcon Icon.Size30
+            Walk ->
+                Icon.icon sizeToIconSize Icon.Fill Icon.Walk
 
 
 backgroundColor : Variant -> Color

--- a/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
+++ b/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
@@ -274,18 +274,19 @@ deviationIcon maybeDeviationLevel =
             Html.span
                 [ Attributes.css [ deviationStyle deviationLevel ] ]
                 [ Icon.toHtml <|
-                    case deviationLevel of
-                        Critical ->
-                            feedbackIcon Icon.Error
+                    feedbackIcon <|
+                        case deviationLevel of
+                            Critical ->
+                                Icon.Error
 
-                        Major ->
-                            feedbackIcon Icon.Warning
+                            Major ->
+                                Icon.Warning
 
-                        Minor ->
-                            feedbackIcon Icon.Warning
+                            Minor ->
+                                Icon.Warning
 
-                        Info ->
-                            feedbackIcon Icon.Information
+                            Info ->
+                                Icon.Information
                 ]
 
         Nothing ->

--- a/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
+++ b/packages/spor-elm/src/Spor/LineTag/TravelTag.elm
@@ -24,15 +24,13 @@ import Css exposing (Color, Style)
 import Css.Global
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attributes
-import Spor.Icon.Feedback as Feedback
+import Spor.Icon as Icon
 import Spor.LineTag.LineIcon as LineIcon
 import Spor.LineTag.LineText as LineText
 import Spor.LineTag.Types exposing (DeviationLevel(..), Size(..), Variant(..))
 import Spor.Token.Color.Alias as Alias
 import Spor.Token.Color.Linjetag as Linjetag
 import Spor.Token.Size.Spacing as Spacing
-import Svg.Styled as Svg
-import Svg.Styled.Attributes as SvgAttributes
 
 
 {-| A component for displaying travel tags
@@ -267,22 +265,27 @@ backgroundColor variant =
 
 deviationIcon : Maybe DeviationLevel -> Html msg
 deviationIcon maybeDeviationLevel =
+    let
+        feedbackIcon type_ =
+            Icon.icon Icon.Size18 Icon.Fill type_
+    in
     case maybeDeviationLevel of
         Just deviationLevel ->
             Html.span
                 [ Attributes.css [ deviationStyle deviationLevel ] ]
-                [ case deviationLevel of
-                    Critical ->
-                        Svg.fromUnstyled <| Feedback.errorFill18X18 []
+                [ Icon.toHtml <|
+                    case deviationLevel of
+                        Critical ->
+                            feedbackIcon Icon.Error
 
-                    Major ->
-                        warningFill18x18
+                        Major ->
+                            feedbackIcon Icon.Warning
 
-                    Minor ->
-                        warningFill18x18
+                        Minor ->
+                            feedbackIcon Icon.Warning
 
-                    Info ->
-                        Svg.fromUnstyled <| Feedback.informationFill18X18 []
+                        Info ->
+                            feedbackIcon Icon.Information
                 ]
 
         Nothing ->
@@ -332,34 +335,6 @@ deviationStyle deviationLevel =
         , Css.right <| Css.px -8
         , Css.zIndex <| Css.int 1
         , svgStyle
-        ]
-
-
-warningFill18x18 : Html msg
-warningFill18x18 =
-    Svg.svg
-        [ SvgAttributes.width "18"
-        , SvgAttributes.height "18"
-        , SvgAttributes.fill "none"
-        , SvgAttributes.stroke "#fff"
-        , Attributes.attribute "stroke-width" "2"
-        , Attributes.attribute "paint-order" "stroke"
-        ]
-        [ Svg.path
-            [ SvgAttributes.fillRule "evenodd"
-            , SvgAttributes.clipRule "evenodd"
-            , SvgAttributes.d "M7.897 1.506a1.25 1.25 0 0 1 2.206 0l6.75 12.656A1.25 1.25 0 0 1 15.75 16H2.25a1.25 1.25 0 0 1-1.103-1.838l6.75-12.656ZM9 6a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-1 0v-4A.5.5 0 0 1 9 6Zm.625 6.375a.625.625 0 1 1-1.25 0 .625.625 0 0 1 1.25 0Z"
-            , SvgAttributes.fill "#E5A80C"
-            ]
-            []
-        , Svg.path
-            [ SvgAttributes.fillRule "evenodd"
-            , SvgAttributes.clipRule "evenodd"
-            , SvgAttributes.d "M9.5 6.5a.5.5 0 0 0-1 0v4a.5.5 0 0 0 1 0v-4ZM9 13a.625.625 0 1 0 0-1.25A.625.625 0 0 0 9 13Z"
-            , SvgAttributes.fill "#2B2B2C"
-            , SvgAttributes.stroke "none"
-            ]
-            []
         ]
 
 


### PR DESCRIPTION
## Background
Need to bump the version of `spor-icon-elm` in `travel-costumize`, but this has a dependency on `spor-elm `which uses the old version.

## Solution
Bumped to newer version. Changed the files that needed to be altered.  