### PR TITLE
Use smaller left and right icons in Timepicker

### DIFF
--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -2,8 +2,8 @@ import { BoxProps, useFormControlContext } from "@chakra-ui/react";
 import { CalendarDateTime } from "@internationalized/date";
 import { TimeValue } from "@react-types/datepicker";
 import {
-  DropdownLeftFill24Icon,
-  DropdownRightFill24Icon,
+  DropdownLeftFill18Icon,
+  DropdownRightFill18Icon,
 } from "@vygruppen/spor-icon-react";
 import React from "react";
 import { useTimeFieldState } from "react-stately";
@@ -140,7 +140,7 @@ export const TimePicker = ({
         borderRadius="xs"
         aria-label={backwardsLabel}
         title={backwardsLabel}
-        icon={<DropdownLeftFill24Icon />}
+        icon={<DropdownLeftFill18Icon />}
         onClick={handleBackwardsClick}
         isDisabled={isDisabled}
         style={isDisabled ? { backgroundColor: "transparent" } : {}}
@@ -152,7 +152,7 @@ export const TimePicker = ({
         borderRadius="xs"
         aria-label={forwardsLabel}
         title={forwardsLabel}
-        icon={<DropdownRightFill24Icon />}
+        icon={<DropdownRightFill18Icon />}
         onClick={handleForwardClick}
         isDisabled={isDisabled}
         style={isDisabled ? { backgroundColor: "transparent" } : {}}


### PR DESCRIPTION
## Background

https://github.com/nsbno/spor/issues/752

## Solution

| Before    | After |
| -------- | ------- |
| <img width="303" alt="Skjermbilde 2023-08-18 kl  13 10 17" src="https://github.com/nsbno/spor/assets/15145686/de16a09b-787d-4353-8893-d2075703deef"> | <img width="297" alt="Skjermbilde 2023-08-18 kl  13 10 33" src="https://github.com/nsbno/spor/assets/15145686/e64e1713-3010-4add-a937-3d12b528e51c">   |



