### PR TITLE
fix: Expandable title prop

### DIFF
--- a/.changeset/cuddly-shirts-sing.md
+++ b/.changeset/cuddly-shirts-sing.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix Expandable title

--- a/packages/spor-react/src/accordion/Expandable.tsx
+++ b/packages/spor-react/src/accordion/Expandable.tsx
@@ -12,7 +12,7 @@ import { Accordion, AccordionProps } from "./Accordion";
 import { useAccordionContext } from "./AccordionContext";
 
 type HeadingLevel = "h2" | "h3" | "h4" | "h5" | "h6";
-type ExpandableProps = AccordionProps & {
+type ExpandableProps = Omit<AccordionProps, "title"> & {
   /** The hidden content */
   children: React.ReactNode;
   /** The title that's shown inside the toggle button */
@@ -62,7 +62,7 @@ export const Expandable = ({
   );
 };
 
-export type ExpandableItemProps = AccordionItemProps & {
+export type ExpandableItemProps = Omit<AccordionItemProps, "title"> & {
   /** The hidden content */
   children: React.ReactNode;
   /** The title that's shown inside the toggle button */


### PR DESCRIPTION
## Bakgrunn
`AccordionProps` og `AccordionItemProps` drar med seg det native HTML-attributtet `title`, og det blir ikke korrekt overskrevet av `title`-propen i Spor.

## Løsning
Omitter `title` fra `AccordionProps` og `AccordionItemProps`, slik at det er vår `title`-prop som blir brukt.