### PR TITLE
Fix paddings and text color in DatePicker and TimePicker

### DIFF
--- a/.changeset/bright-panthers-march.md
+++ b/.changeset/bright-panthers-march.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix paddings and text color in DatePicker and TimePicker

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -46,11 +46,13 @@ export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
             {...props.labelProps}
             {...labelProps}
             sx={styles.inputLabel}
+            position="absolute"
+            paddingTop="2px"
           >
             {props.label}
           </FormLabel>
         )}
-        <Flex {...fieldProps}>
+        <Flex {...fieldProps} paddingTop="3" paddingBottom="0.5">
           {state.segments.map((segment, i) => (
             <DateTimeSegment
               ref={i === 0 ? ref : undefined}

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -2,6 +2,7 @@ import { Box, useMultiStyleConfig } from "@chakra-ui/react";
 import React, { RefObject, forwardRef, useRef } from "react";
 import { useDateSegment } from "react-aria";
 import { DateFieldState, DateSegment } from "react-stately";
+import { colors } from "../theme/foundations";
 
 type DateTimeSegmentProps = {
   segment: DateSegment;
@@ -29,7 +30,6 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
       isPlaceholder: segment.isPlaceholder,
       isEditable: segment.isEditable,
     });
-
     return (
       <Box
         {...segmentProps}
@@ -38,6 +38,7 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
           ...segmentProps.style,
           fontVariantNumeric: "tabular-nums",
           boxSizing: "content-box",
+          color: colors.darkGrey,
         }}
         paddingX="1px"
         textAlign="end"

--- a/packages/spor-react/src/datepicker/TimeField.tsx
+++ b/packages/spor-react/src/datepicker/TimeField.tsx
@@ -29,10 +29,12 @@ export const TimeField = ({ state, ...props }: TimeFieldProps) => {
         marginBottom={0}
         fontSize="mobile.xs"
         cursor="text"
+        position="absolute"
+        paddingTop="2px"
       >
         {props.label}
       </FormLabel>
-      <Flex {...fieldProps} ref={ref}>
+      <Flex {...fieldProps} ref={ref} paddingTop="3" paddingBottom="0.5">
         {state.segments.map((segment) => (
           <DateTimeSegment key={segment.type} segment={segment} state={state} />
         ))}


### PR DESCRIPTION
## Background

The paddings for the label and the input in the TimePicker and the DatePicker were a bit off. The color of the punctuation and colon was also dimGrey when it should be darkGrey. 


## Solution

Fix paddings and text color.

## Illustrations

| Before    | After |
| -------- | ------- |
| <img width="374" alt="Skjermbilde 2023-08-21 kl  07 23 57" src="https://github.com/nsbno/spor/assets/15145686/5ba0b9e6-9bd7-452f-b07c-c326b90a16ea">  | <img width="404" alt="Skjermbilde 2023-08-20 kl  21 24 39" src="https://github.com/nsbno/spor/assets/15145686/738c2aa7-d8f1-4952-9161-a6903d640e62">    |
| <img width="339" alt="Skjermbilde 2023-08-21 kl  07 24 21" src="https://github.com/nsbno/spor/assets/15145686/7b415950-7ec0-49c1-bfdc-b70450411c18"> | <img width="335" alt="Skjermbilde 2023-08-20 kl  21 16 42" src="https://github.com/nsbno/spor/assets/15145686/dae84e37-ad4f-47f9-beea-ba2a6fb80504">     |










