### PR TITLE
Fiks heading variants

### DIFF
--- a/.changeset/soft-terms-ring.md
+++ b/.changeset/soft-terms-ring.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Heading: Fix a bug with variants

--- a/packages/spor-react/src/typography/Heading.tsx
+++ b/packages/spor-react/src/typography/Heading.tsx
@@ -1,14 +1,12 @@
 import { HeadingProps as ChakraHeadingProps, Text } from "@chakra-ui/react";
-import type tokens from "@vygruppen/spor-design-tokens";
 import React from "react";
-
-type TextStyles = keyof typeof tokens.font.style;
+import type { textStyles } from "../theme/foundations";
 
 export type HeadingProps = Omit<ChakraHeadingProps, "textStyle" | "as"> & {
   /** The heading level, e.g. h1, h2, h3... **/
   as: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-  /** The size and style of the heading */
-  variant?: TextStyles;
+  /** The size and style of the heading. Defaults to xl-display */
+  variant?: keyof typeof textStyles;
 };
 /**
  * Create your own fancy headings with this component.


### PR DESCRIPTION
## Bakgrunn
`2xl` varianten til heading funket ikke i TypeScript, selv om den funka.

## Løsning
Spesifiser typen basert på riktig objekt.

Fixes #779 