### PR TITLE
Accordion design tweaks

### DIFF
--- a/.changeset/dull-shirts-share.md
+++ b/.changeset/dull-shirts-share.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Accordion: Add new prop "spacing" for adding spacing between items.
+Accordion: Do some design tweaks

--- a/packages/spor-react/src/accordion/Accordion.tsx
+++ b/packages/spor-react/src/accordion/Accordion.tsx
@@ -1,10 +1,10 @@
 import {
   Accordion as ChakraAccordion,
   AccordionProps as ChakraAccordionProps,
-  As,
   forwardRef,
 } from "@chakra-ui/react";
 import React from "react";
+import { Stack, StackProps } from "../layout";
 import { AccordionProvider } from "./AccordionContext";
 export {
   AccordionButton,
@@ -28,6 +28,8 @@ export type AccordionProps = Omit<ChakraAccordionProps, "variant" | "size"> & {
    */
   variant?: "list" | "outline" | "card";
   size?: "sm" | "md" | "lg";
+  /** The margin between accordion items */
+  spacing?: StackProps["spacing"];
 };
 /**
  * Wraps a set of ExpandableItem or AccordionItem components.
@@ -45,18 +47,22 @@ export type AccordionProps = Omit<ChakraAccordionProps, "variant" | "size"> & {
  *
  * If you only have one expandable item, you can use the `<Expandable />` component instead.
  */
-export const Accordion = forwardRef<AccordionProps, "div">((props, ref) => {
-  const defaultIndex =
-    typeof props.defaultIndex === "number" && props.allowMultiple
-      ? [props.defaultIndex]
-      : props.defaultIndex;
-  return (
-    <AccordionProvider size={props.size}>
-      <ChakraAccordion
-        {...props}
-        ref={ref}
-        defaultIndex={defaultIndex as number[] | undefined}
-      />
-    </AccordionProvider>
-  );
-});
+export const Accordion = forwardRef<AccordionProps, "div">(
+  ({ children, spacing = 2, ...props }, ref) => {
+    const defaultIndex =
+      typeof props.defaultIndex === "number" && props.allowMultiple
+        ? [props.defaultIndex]
+        : props.defaultIndex;
+    return (
+      <AccordionProvider size={props.size}>
+        <ChakraAccordion
+          {...props}
+          ref={ref}
+          defaultIndex={defaultIndex as number[] | undefined}
+        >
+          <Stack spacing={spacing}>{children}</Stack>
+        </ChakraAccordion>
+      </AccordionProvider>
+    );
+  }
+);

--- a/packages/spor-react/src/accordion/Expandable.tsx
+++ b/packages/spor-react/src/accordion/Expandable.tsx
@@ -106,7 +106,7 @@ export const ExpandableItem = ({
       <Box as={headingLevel}>
         <AccordionButton>
           <Flex alignItems="center">
-            {leftIcon && <Box mr={2}>{leftIcon}</Box>}
+            {leftIcon && <Box marginRight={2}>{leftIcon}</Box>}
             {title}
           </Flex>
           <AccordionIcon />

--- a/packages/spor-react/src/accordion/Expandable.tsx
+++ b/packages/spor-react/src/accordion/Expandable.tsx
@@ -106,7 +106,7 @@ export const ExpandableItem = ({
       <Box as={headingLevel}>
         <AccordionButton>
           <Flex alignItems="center">
-            {leftIcon && <Box marginRight={2}>{leftIcon}</Box>}
+            {leftIcon && <Box marginRight={1}>{leftIcon}</Box>}
             {title}
           </Flex>
           <AccordionIcon />

--- a/packages/spor-react/src/theme/components/accordion.ts
+++ b/packages/spor-react/src/theme/components/accordion.ts
@@ -21,6 +21,7 @@ const config = helpers.defineMultiStyleConfig({
       justifyContent: "space-between",
       color: "darkGrey",
       textAlign: "left",
+      fontWeight: "bold",
       ...focusVisible({
         notFocus: {
           boxShadow: getBoxShadowString({
@@ -40,8 +41,7 @@ const config = helpers.defineMultiStyleConfig({
       },
     },
     panel: {
-      paddingTop: 2,
-      paddingBottom: 5,
+      paddingY: 2,
       borderBottomRadius: "sm",
     },
     icon: {
@@ -57,7 +57,6 @@ const config = helpers.defineMultiStyleConfig({
         },
         _active: {
           backgroundColor: "mint",
-          boxShadow: getBoxShadowString({ borderColor: "darkGrey" }),
         },
       },
     },
@@ -87,7 +86,10 @@ const config = helpers.defineMultiStyleConfig({
     },
     card: {
       container: {
-        boxShadow: "md",
+        boxShadow: getBoxShadowString({
+          baseShadow: "sm",
+          borderColor: "silver",
+        }),
       },
       button: {
         _expanded: {
@@ -110,6 +112,7 @@ const config = helpers.defineMultiStyleConfig({
         paddingY: 1,
       },
       panel: {
+        fontSize: "desktop.xs",
         paddingX: 2,
       },
     },
@@ -120,6 +123,7 @@ const config = helpers.defineMultiStyleConfig({
         paddingY: 1,
       },
       panel: {
+        fontSize: "desktop.sm",
         paddingX: 3,
       },
     },
@@ -130,6 +134,7 @@ const config = helpers.defineMultiStyleConfig({
         paddingY: 2,
       },
       panel: {
+        fontSize: "desktop.sm",
         paddingX: 3,
       },
     },

--- a/packages/spor-react/src/theme/components/accordion.ts
+++ b/packages/spor-react/src/theme/components/accordion.ts
@@ -40,8 +40,8 @@ const config = helpers.defineMultiStyleConfig({
       },
     },
     panel: {
-      pt: 2,
-      pb: 5,
+      paddingTop: 2,
+      paddingBottom: 5,
       borderBottomRadius: "sm",
     },
     icon: {
@@ -106,31 +106,31 @@ const config = helpers.defineMultiStyleConfig({
     sm: {
       button: {
         fontSize: "desktop.xs",
-        px: 2,
-        py: 1,
+        paddingX: 2,
+        paddingY: 1,
       },
       panel: {
-        px: 2,
+        paddingX: 2,
       },
     },
     md: {
       button: {
         fontSize: "desktop.sm",
-        px: 3,
-        py: 1,
+        paddingX: 3,
+        paddingY: 1,
       },
       panel: {
-        px: 3,
+        paddingX: 3,
       },
     },
     lg: {
       button: {
         fontSize: "desktop.sm",
-        px: 3,
-        py: 2,
+        paddingX: 3,
+        paddingY: 2,
       },
       panel: {
-        px: 3,
+        paddingX: 3,
       },
     },
   },


### PR DESCRIPTION
## Bakgrunn
Det var endel småfeil med implementasjonen til Accordion.

## Løsning
Endre endel småting med hvordan accordions ser ut, inkludert
- Mindre avstand mellom ikon og tittel
- Fet tekst i tittel
- Mindre bottom padding i accordion panelet
- Bruke lang-form padding-props
- Fjerne outline på active-staten til list-accordions.