### PR TITLE
Make font size in DateTime dynamic

### DIFF
--- a/.changeset/nasty-avocados-grab.md
+++ b/.changeset/nasty-avocados-grab.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Make font size in DateTime dynamic.

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -2,7 +2,6 @@ import { Box, useMultiStyleConfig } from "@chakra-ui/react";
 import React, { RefObject, forwardRef, useRef } from "react";
 import { useDateSegment } from "react-aria";
 import { DateFieldState, DateSegment } from "react-stately";
-import { colors } from "../theme/foundations";
 
 type DateTimeSegmentProps = {
   segment: DateSegment;
@@ -43,7 +42,7 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
         textAlign="end"
         outline="none"
         borderRadius="xs"
-        fontSize="mobile.md"
+        fontSize={["mobile.sm", "desktop.sm"]}
         sx={styles.dateTimeSegment}
         _focus={{
           backgroundColor: "darkTeal",


### PR DESCRIPTION
## Background
We want the font size of the TimePicker and DateTime to adapt depending on whether you are on a desktop or mobile.