### PR TITLE
Add more space for larger numbers in Numeric Stepper

### DIFF
--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -143,7 +143,7 @@ export function NumericStepper({
         <chakra.text
           fontSize="sm"
           fontWeight="bold"
-          width="3ch"
+          width="4ch"
           marginX={1}
           paddingX={1}
           textAlign="center"


### PR DESCRIPTION
## Background
When using the Numeric Stepper, having the `withInput` prop set to false, the space becomes too small when the number becomes greater than 19. This causes the numbers to overlap each other.

## Solution
For now, we just increase the width one notch. Screenshot from Playground:

![Screenshot 2023-08-24 at 13 15 50](https://github.com/nsbno/spor/assets/45205043/e62b8f5e-3dfb-4f1b-8f5f-69e9f0d8411d)


