### PR TITLE
Add workaround for click throughs on mobile devices in CalendarCell and ListBox

### DIFF
--- a/.changeset/sweet-plants-live.md
+++ b/.changeset/sweet-plants-live.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-react": patch
 ---
 
-Add workaround for click throughs on mobile devices in Calendar and ListBox
+Add workaround for click throughs on mobile devices in CalendarCell and ListBox

--- a/.changeset/sweet-plants-live.md
+++ b/.changeset/sweet-plants-live.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add workaround for click throughs on mobile devices in Calendar and ListBox

--- a/packages/spor-react/src/datepicker/CalendarCell.tsx
+++ b/packages/spor-react/src/datepicker/CalendarCell.tsx
@@ -42,6 +42,11 @@ export function CalendarCell({ state, date, currentMonth }: CalendarCellProps) {
     stateProps["data-unavailable"] = true;
   }
 
+  /* 
+  Workaround to fix click througs on mobile devices
+  Related to https://github.com/adobe/react-spectrum/issues/4970
+  TODO: Follow up with react-spectrum to see if they can solve on their end
+  */
   useEffect(() => {
     (ref as any)?.current?.addEventListener(
       "touchend",

--- a/packages/spor-react/src/datepicker/CalendarCell.tsx
+++ b/packages/spor-react/src/datepicker/CalendarCell.tsx
@@ -5,7 +5,7 @@ import {
   isSameMonth,
   isToday,
 } from "@internationalized/date";
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { useCalendarCell } from "react-aria";
 import { CalendarState, RangeCalendarState } from "react-stately";
 
@@ -41,7 +41,17 @@ export function CalendarCell({ state, date, currentMonth }: CalendarCellProps) {
   if (isOutsideMonth) {
     stateProps["data-unavailable"] = true;
   }
-  
+
+  useEffect(() => {
+    (ref as any)?.current?.addEventListener(
+      "touchend",
+      (event: TouchEvent) => {
+        event.preventDefault();
+      },
+      { passive: false, once: true }
+    );
+  }, []);
+
   return (
     <Box
       as="td"

--- a/packages/spor-react/src/datepicker/CalendarCell.tsx
+++ b/packages/spor-react/src/datepicker/CalendarCell.tsx
@@ -45,7 +45,7 @@ export function CalendarCell({ state, date, currentMonth }: CalendarCellProps) {
   /* 
   Workaround to fix click througs on mobile devices
   Related to https://github.com/adobe/react-spectrum/issues/4970
-  TODO: Follow up with react-spectrum to see if they can solve on their end
+  TODO: Follow up with react-spectrum to see if they can solve it on their end
   */
   useEffect(() => {
     (ref as any)?.current?.addEventListener(

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -7,7 +7,7 @@ import {
   type BoxProps,
 } from "@chakra-ui/react";
 import type { Node } from "@react-types/shared";
-import React, { useContext, useRef } from "react";
+import React, { useContext, useEffect, useRef } from "react";
 import {
   AriaListBoxProps,
   useListBox,
@@ -151,6 +151,16 @@ function Option({ item, state }: OptionProps) {
   if (isFocused) {
     dataFields["data-focus"] = true;
   }
+
+  useEffect(() => {
+    (ref as any)?.current?.addEventListener(
+      "touchend",
+      (event: TouchEvent) => {
+        event.preventDefault();
+      },
+      { passive: false, once: true }
+    );
+  }, []);
 
   return (
     <OptionContext.Provider value={{ labelProps, descriptionProps }}>

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -155,7 +155,7 @@ function Option({ item, state }: OptionProps) {
   /* 
   Workaround to fix click througs on mobile devices
   Related to https://github.com/adobe/react-spectrum/issues/4970
-  TODO: Follow up with react-spectrum to see if they can solve on their end
+  TODO: Follow up with react-spectrum to see if they can solve it on their end
   */
   useEffect(() => {
     (ref as any)?.current?.addEventListener(

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -152,6 +152,11 @@ function Option({ item, state }: OptionProps) {
     dataFields["data-focus"] = true;
   }
 
+  /* 
+  Workaround to fix click througs on mobile devices
+  Related to https://github.com/adobe/react-spectrum/issues/4970
+  TODO: Follow up with react-spectrum to see if they can solve on their end
+  */
   useEffect(() => {
     (ref as any)?.current?.addEventListener(
       "touchend",


### PR DESCRIPTION
## Background

We experience issues with click throughs in the DatePicker's calendar and in the ComboBox's list box on mobile devices. This was also noticed in React Aria's own examples.

## Solution

The issue was reported to react-spectrum, and they already linked to other related issues that had been reported before. In one of these, a workaround was suggested. 

The workaround is now tested locally in Spor, and seems to work great (and one can still scroll inside the list box). I believe we can release a new version and test this out in our app (otherwise I would have to copy the components to the app and test them there, which is a bit of a hassle, but not impossible, of course).

