### PR TITLE
Make accordion text responsive

### DIFF
--- a/.changeset/perfect-ravens-report.md
+++ b/.changeset/perfect-ravens-report.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Accordion: Make the text size responsive

--- a/packages/spor-react/src/theme/components/accordion.ts
+++ b/packages/spor-react/src/theme/components/accordion.ts
@@ -107,34 +107,34 @@ const config = helpers.defineMultiStyleConfig({
   sizes: {
     sm: {
       button: {
-        fontSize: "desktop.xs",
+        fontSize: ["mobile.xs", "desktop.xs"],
         paddingX: 2,
         paddingY: 1,
       },
       panel: {
-        fontSize: "desktop.xs",
+        fontSize: ["mobile.xs", "desktop.xs"],
         paddingX: 2,
       },
     },
     md: {
       button: {
-        fontSize: "desktop.sm",
+        fontSize: ["mobile.sm", "desktop.sm"],
         paddingX: 3,
         paddingY: 1,
       },
       panel: {
-        fontSize: "desktop.sm",
+        fontSize: ["mobile.sm", "desktop.sm"],
         paddingX: 3,
       },
     },
     lg: {
       button: {
-        fontSize: "desktop.sm",
+        fontSize: ["mobile.sm", "desktop.sm"],
         paddingX: 3,
         paddingY: 2,
       },
       panel: {
-        fontSize: "desktop.sm",
+        fontSize: ["mobile.sm", "desktop.sm"],
         paddingX: 3,
       },
     },


### PR DESCRIPTION
## Bakgrunn
Teksten i tittel og innhold i Accordion-komponenten skulle være responsiv, og ikke alltid i "desktop"-størrelse.

## Løsning
Sett riktig tekststørrelse på riktig breakpoint.