### PR TITLE
Change type of calendar trigger button to "button"

### DIFF
--- a/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
+++ b/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
@@ -6,7 +6,7 @@ import {
   As,
 } from "@chakra-ui/react";
 import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
-import React from "react";
+import React, { useEffect } from "react";
 import { AriaButtonProps } from "react-aria";
 import { createTexts, useTranslation } from "..";
 
@@ -16,14 +16,25 @@ export const CalendarTriggerButton = forwardRef<CalendarTriggerButtonProps, As>(
     const { t } = useTranslation();
     const styles = useMultiStyleConfig("Datepicker", {});
 
+    const { onPress, ...filteredButtonProps } = buttonProps;
+
+    const handleOnPress = (event: KeyboardEvent) => {
+      if (onPress) {
+        if (event.key == "Enter" || event.key == " ")
+        onPress(event as any)
+      }
+    }
+
     return (
       <PopoverAnchor>
         <Box
           ref={ref}
           as="button"
+          type="button"
           aria-label={t(texts.openCalendar)}
           sx={styles.calendarTriggerButton}
-          {...buttonProps}
+          {...filteredButtonProps}
+          onKeyUp={handleOnPress}
         >
           <CalendarOutline24Icon />
         </Box>

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -21,7 +21,6 @@ import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
 import React, { forwardRef, useRef } from "react";
 import {
   AriaDatePickerProps,
-  CalendarProps,
   I18nProvider,
   useDatePicker,
 } from "react-aria";


### PR DESCRIPTION
## Background

When not using type"button" on a button, the default is "submit". Somehow, the button does not like that we use the `onPress` from the `buttonProps`, and Enter or Space buttons do not work if the type is set to "button".

## Solution

Change the type of the button to "button" to make sure it does not submit anything. Also, make sure that the button still can be opened using "Enter" and "Space".
