### PR TITLE
Override minimum left padding in ComboBox and InfoSelect popovers

### DIFF
--- a/.changeset/afraid-beers-sin.md
+++ b/.changeset/afraid-beers-sin.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-react": patch
 ---
 
-Override minimum left padding ComboBox and InfoSelect popovers
+Override minimum left padding in ComboBox and InfoSelect popovers

--- a/.changeset/afraid-beers-sin.md
+++ b/.changeset/afraid-beers-sin.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Override minimum left padding ComboBox and InfoSelect popovers

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -164,6 +164,9 @@ export function Combobox<T extends object>({
           placement="bottom start"
           shouldFlip={false}
           hasBackdrop={false}
+          // The minimum padding should be 0, because the popover always should be
+          // aligned with the input field regardless of the left padding in the container.
+          containerPadding={0}
         >
           <ListBox
             {...listBoxProps}

--- a/packages/spor-react/src/input/InfoSelect.tsx
+++ b/packages/spor-react/src/input/InfoSelect.tsx
@@ -216,7 +216,13 @@ export function InfoSelect<T extends object>({
       </chakra.button>
 
       {state.isOpen && (
-        <Popover state={state} triggerRef={triggerRef}>
+        <Popover
+          state={state}
+          triggerRef={triggerRef}
+          // The minimum padding should be 0, because the popover always should be
+          // aligned with the input field regardless of the left padding in the container.
+          containerPadding={0}
+        >
           <ListBox
             {...menuProps}
             state={state}

--- a/packages/spor-react/src/input/InfoSelect.tsx
+++ b/packages/spor-react/src/input/InfoSelect.tsx
@@ -220,7 +220,7 @@ export function InfoSelect<T extends object>({
           state={state}
           triggerRef={triggerRef}
           // The minimum padding should be 0, because the popover always should be
-          // aligned with the input field regardless of the left padding in the container.
+          // aligned with the trigger field regardless of the left padding in the container.
           containerPadding={0}
         >
           <ListBox

--- a/packages/spor-react/src/input/Popover.tsx
+++ b/packages/spor-react/src/input/Popover.tsx
@@ -83,7 +83,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         placement,
         shouldFlip,
         isNonModal,
-        containerPadding: containerPadding,
+        containerPadding,
       },
       state
     );

--- a/packages/spor-react/src/input/Popover.tsx
+++ b/packages/spor-react/src/input/Popover.tsx
@@ -44,6 +44,11 @@ type PopoverProps = {
    * Defaults to true
    */
   hasBackdrop?: boolean;
+  /** The minimum padding required between the popover and the surrounding container.
+   * 
+   * Defaults to 12 (the same as React Aria's default)
+   */
+  containerPadding?: number;
 };
 /**
  * Internal popover component.
@@ -62,6 +67,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       shouldFlip = false,
       isNonModal = false,
       hasBackdrop = true,
+      containerPadding = 12,
     },
     ref
   ) => {
@@ -77,6 +83,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         placement,
         shouldFlip,
         isNonModal,
+        containerPadding: containerPadding,
       },
       state
     );
@@ -86,7 +93,6 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         {...popoverProps}
         ref={popoverRef}
         minWidth={triggerRef.current?.clientWidth ?? "auto"}
-        marginLeft={-2}
       >
         <DismissButton onDismiss={state.close} />
         {children}

--- a/packages/spor-react/src/input/Popover.tsx
+++ b/packages/spor-react/src/input/Popover.tsx
@@ -44,7 +44,7 @@ type PopoverProps = {
    * Defaults to true
    */
   hasBackdrop?: boolean;
-  /** The minimum padding required between the popover and the surrounding container.
+  /** The minimum padding required between the popover and the surrounding container
    * 
    * Defaults to 12 (the same as React Aria's default)
    */


### PR DESCRIPTION
## Background

A negative margin was added to the popover due to that the ComboBox popover was displaced some pixels to the right in the app it was used after removing the overlay. The popover will in fact _always_ be displaced to the right relative to the input field when there is less than 12 px padding to the left in the container. This is because the [default minimum container padding is 12 px](https://github.com/adobe/react-spectrum/discussions/5009).

By adding a negative margin, it worked against its purpose for InfoSelect and ComboBox when there is enough left padding, causing the popover to be displaced the opposite way.

## Solution

We can override the minimum padding by passing `containerPadding: 0` to `usePopover`.

