### PR TITLE
Update the design for non-interactive cards

### DIFF
--- a/.changeset/loud-pants-taste.md
+++ b/.changeset/loud-pants-taste.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Card: Update design for non-interactive cards

--- a/packages/spor-react/src/theme/components/card.ts
+++ b/packages/spor-react/src/theme/components/card.ts
@@ -70,6 +70,11 @@ function getColorSchemeBaseProps({ colorScheme }: CardThemeProps): {
       return {
         backgroundColor: "lightGrey",
       };
+    case "green": {
+      return {
+        backgroundColor: "seaMist",
+      };
+    }
     default:
       return {
         backgroundColor: colors[colorScheme]?.[100] ?? "platinum",

--- a/packages/spor-react/src/theme/components/card.ts
+++ b/packages/spor-react/src/theme/components/card.ts
@@ -60,29 +60,19 @@ type CardThemeProps = {
 
 function getColorSchemeBaseProps({ colorScheme }: CardThemeProps): {
   backgroundColor: string;
-  boxShadow: string;
 } {
   switch (colorScheme) {
     case "white":
       return {
-        backgroundColor: "white",
-        boxShadow: getBoxShadowString({
-          borderColor: "silver",
-        }),
+        backgroundColor: "lightGrey",
       };
     case "grey":
       return {
         backgroundColor: "lightGrey",
-        boxShadow: getBoxShadowString({
-          borderColor: "steel",
-        }),
       };
     default:
       return {
         backgroundColor: colors[colorScheme]?.[100] ?? "platinum",
-        boxShadow: getBoxShadowString({
-          borderColor: colors[colorScheme]?.[200] ?? "silver",
-        }),
       };
   }
 }


### PR DESCRIPTION
## Bakgrunn
See #806

## Løsning
Remove outline for non-interactive cards, and make the white and light grey versions equal.