### PR TITLE
Fix bug where display prop was required to not break clickable cards

### DIFF
--- a/.changeset/angry-months-film.md
+++ b/.changeset/angry-months-film.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Card: Fix a bug with clickable cards that had to have the display property set to not break

--- a/packages/spor-react/src/theme/components/card.ts
+++ b/packages/spor-react/src/theme/components/card.ts
@@ -9,6 +9,7 @@ const config = defineStyleConfig({
     border: "none",
     overflow: "hidden",
     fontSize: "inherit",
+    display: "block",
     transitionProperty: "common",
     transitionDuration: "fast",
     borderRadius: "md",


### PR DESCRIPTION
## Bakgrunn
For klikkbare kort så måtte man spesifisere display-propen til block eller flex eksplisitt for at den ikke skulle kræsje

## Løsning
Sett default-verdien til display: block.