### PR TITLE
Forenkle implementasjonen av CalendarTriggerButton

### DIFF
--- a/.changeset/sharp-parents-attend.md
+++ b/.changeset/sharp-parents-attend.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+DatePicker: Use useButton to simplify the CalendarTriggerButton implementation slightly

--- a/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
+++ b/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
@@ -1,29 +1,25 @@
 import {
+  As,
   Box,
   PopoverAnchor,
-  useMultiStyleConfig,
   forwardRef,
-  As,
+  useMultiStyleConfig,
 } from "@chakra-ui/react";
 import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
-import React, { useEffect } from "react";
-import { AriaButtonProps } from "react-aria";
+import React, { RefObject } from "react";
+import { AriaButtonProps, useButton } from "react-aria";
 import { createTexts, useTranslation } from "..";
 
 type CalendarTriggerButtonProps = AriaButtonProps<"button">;
 export const CalendarTriggerButton = forwardRef<CalendarTriggerButtonProps, As>(
-  ({ ...buttonProps }, ref) => {
+  ({ onClick, ...props }, ref) => {
     const { t } = useTranslation();
     const styles = useMultiStyleConfig("Datepicker", {});
 
-    const { onPress, ...filteredButtonProps } = buttonProps;
-
-    const handleOnPress = (event: KeyboardEvent) => {
-      if (onPress) {
-        if (event.key == "Enter" || event.key == " ")
-        onPress(event as any)
-      }
-    }
+    const { buttonProps } = useButton(
+      props,
+      ref as RefObject<HTMLButtonElement>
+    );
 
     return (
       <PopoverAnchor>
@@ -33,8 +29,7 @@ export const CalendarTriggerButton = forwardRef<CalendarTriggerButtonProps, As>(
           type="button"
           aria-label={t(texts.openCalendar)}
           sx={styles.calendarTriggerButton}
-          {...filteredButtonProps}
-          onKeyUp={handleOnPress}
+          {...buttonProps}
         >
           <CalendarOutline24Icon />
         </Box>


### PR DESCRIPTION
## Bakgrunn
Implementasjonen av CalendarTriggerButton var hakket hvassere enn den kanskje trengte å være. Grunnen var at vi ikke brukte `useButton`, som er den anbefalte måten til React Aria å implementere knapper på. Siden vi har våre egne knapper laget i Chakra, kreves det litt ekstra mikking for å få ting til å fungere i kombinasjon.

## Løsning
Introdusere `useButton`. Fjern også en ekstra `onClick` prop, som blir sendt inn av PopoverTrigger-komponenten. Den trengs ikke i dette tilfellet :) 