### PR TITLE
Fix a color bug with cards

### DIFF
--- a/.changeset/perfect-tools-end.md
+++ b/.changeset/perfect-tools-end.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Card: Correct the colors of white cards

--- a/packages/spor-react/src/theme/components/card.ts
+++ b/packages/spor-react/src/theme/components/card.ts
@@ -65,7 +65,7 @@ function getColorSchemeBaseProps({ colorScheme }: CardThemeProps): {
   switch (colorScheme) {
     case "white":
       return {
-        backgroundColor: "lightGrey",
+        backgroundColor: "white",
       };
     case "grey":
       return {


### PR DESCRIPTION
## Background
White cards should be white, not light grey, like the last PR made them

## Solution
Talk to our designer and make the correct design tweaks. In this case, just changing the background color of white cards back to be white.