### PR TITLE
Fix hover effect on icons in input fields

### DIFF
--- a/.changeset/little-poets-matter.md
+++ b/.changeset/little-poets-matter.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Input: Make hover-effect work as expected over icons

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -40,7 +40,9 @@ export const Input = forwardRef<InputProps, "input">(
     const inputId = id ?? formControlProps?.id ?? fallbackId;
     return (
       <InputGroup position="relative">
-        {leftIcon && <InputLeftElement>{leftIcon}</InputLeftElement>}
+        {leftIcon && (
+          <InputLeftElement pointerEvents="none">{leftIcon}</InputLeftElement>
+        )}
         <ChakraInput
           data-attachable
           paddingLeft={leftIcon ? 7 : undefined}
@@ -51,7 +53,11 @@ export const Input = forwardRef<InputProps, "input">(
           placeholder=" " // This is needed to make the label work as expected
         />
         <FormLabel htmlFor={inputId}>{label}</FormLabel>
-        {rightIcon && <InputRightElement>{rightIcon}</InputRightElement>}
+        {rightIcon && (
+          <InputRightElement pointerEvents="none">
+            {rightIcon}
+          </InputRightElement>
+        )}
       </InputGroup>
     );
   }


### PR DESCRIPTION
## Background
We didn't get a hover effect when hovering the icon in an input

## Solution
Add pointer-events: none to the input-element container.