### PR TITLE
Fix expandable alert padding

### DIFF
--- a/.changeset/sixty-carpets-shake.md
+++ b/.changeset/sixty-carpets-shake.md
@@ -1,0 +1,10 @@
+---
+"@vygruppen/spor-icon-react": patch
+"@vygruppen/spor-react": patch
+---
+
+ExpandableAlert: Fix double padding bug
+Other:
+
+- Set the document-level line height to a valid value
+- Fix a bug with icon generation

--- a/packages/spor-icon-react/bin/generate.ts
+++ b/packages/spor-icon-react/bin/generate.ts
@@ -114,7 +114,8 @@ async function generateComponent(iconData: IconData) {
       },
       svgo: true,
       template: componentTemplate,
-      replaceAttrValues: {
+      plugins: ["@svgr/plugin-svgo", "@svgr/plugin-jsx"],
+      replaceAttrValues: { 
         "#2B2B2C": "currentColor",
       },
     },

--- a/packages/spor-react/src/alert/BaseAlert.tsx
+++ b/packages/spor-react/src/alert/BaseAlert.tsx
@@ -14,7 +14,7 @@ export type BaseAlertProps = BoxProps & {
 export const BaseAlert = ({ variant, children, ...boxProps }: BaseAlertProps) => {
   const styles = useMultiStyleConfig("Alert", { variant });
   return (
-    <Box sx={styles.container} {...boxProps}>
+    <Box __css={styles.container} {...boxProps}>
       {children}
     </Box>
   );

--- a/packages/spor-react/src/alert/ExpandableAlert.tsx
+++ b/packages/spor-react/src/alert/ExpandableAlert.tsx
@@ -45,7 +45,7 @@ export const ExpandableAlert = ({
   ...boxProps
 }: ExpandableAlertProps) => {
   return (
-    <BaseAlert variant={variant} paddingX={0} paddingY={0} padding={0} {...boxProps}>
+    <BaseAlert variant={variant} {...boxProps} paddingX={0} paddingY={0}>
       <Accordion
         onChange={(expandedIndex) => onToggle(expandedIndex === 0)}
         defaultIndex={defaultOpen ? 0 : -1}
@@ -59,7 +59,7 @@ export const ExpandableAlert = ({
               alignItems="center"
               flexGrow="1"
             >
-              <Flex as={headingLevel}>
+              <Flex as={headingLevel} alignItems="center">
                 <AlertIcon variant={variant} />
                 <Box
                   as="span"

--- a/packages/spor-react/src/theme/foundations/lineHeights.ts
+++ b/packages/spor-react/src/theme/foundations/lineHeights.ts
@@ -1,5 +1,6 @@
 import tokens from "@vygruppen/spor-design-tokens";
 
 export const lineHeights = {
+  base: tokens.font.style.lg["line-height"],
   normal: tokens.font.style.lg["line-height"],
 };


### PR DESCRIPTION
## Background
There was a bug where the expandable alert component got a double padding.

In addition, there was another bug with icon generation, due to the last upgrade PR.

## Solution
Fix all the issues.

Turns out, when you specify the `sx` prop, it overrides any regular styling props you pass in. By using the `__css` prop, you avoid this.
