### PR TITLE
Icons and expandables

### DIFF
--- a/.changeset/curly-bugs-sort.md
+++ b/.changeset/curly-bugs-sort.md
@@ -1,0 +1,7 @@
+---
+"@vygruppen/spor-icon-react": patch
+"@vygruppen/spor-react": patch
+---
+
+Icons: Re-add viewBox prop to all icons, making them scalable
+ExpandableAlert: Ensure the text size is equal across title and content

--- a/packages/spor-icon-react/bin/generate.ts
+++ b/packages/spor-icon-react/bin/generate.ts
@@ -113,6 +113,17 @@ async function generateComponent(iconData: IconData) {
         "aria-hidden": "true",
       },
       svgo: true,
+      svgoConfig: {
+        plugins: [{
+          name: 'preset-default',
+          params: {
+            overrides: {
+              removeViewBox: false,
+            }
+          }
+        }]
+      },
+      dimensions: true,
       template: componentTemplate,
       plugins: ["@svgr/plugin-svgo", "@svgr/plugin-jsx"],
       replaceAttrValues: { 

--- a/packages/spor-react/src/alert/ExpandableAlert.tsx
+++ b/packages/spor-react/src/alert/ExpandableAlert.tsx
@@ -53,7 +53,7 @@ export const ExpandableAlert = ({
         flexGrow="1"
       >
         <AccordionItem>
-          <AccordionButton paddingX={3} paddingY={2}>
+          <AccordionButton paddingX={3} paddingY={2} fontSize="inherit">
             <Flex
               justifyContent="space-between"
               alignItems="center"

--- a/packages/spor-react/src/theme/components/accordion.ts
+++ b/packages/spor-react/src/theme/components/accordion.ts
@@ -107,34 +107,34 @@ const config = helpers.defineMultiStyleConfig({
   sizes: {
     sm: {
       button: {
-        fontSize: ["mobile.xs", "desktop.xs"],
+        fontSize: ["mobile.xs", null, "desktop.xs"],
         paddingX: 2,
         paddingY: 1,
       },
       panel: {
-        fontSize: ["mobile.xs", "desktop.xs"],
+        fontSize: ["mobile.xs", null, "desktop.xs"],
         paddingX: 2,
       },
     },
     md: {
       button: {
-        fontSize: ["mobile.sm", "desktop.sm"],
+        fontSize: ["mobile.sm", null, "desktop.sm"],
         paddingX: 3,
         paddingY: 1,
       },
       panel: {
-        fontSize: ["mobile.sm", "desktop.sm"],
+        fontSize: ["mobile.sm", null, "desktop.sm"],
         paddingX: 3,
       },
     },
     lg: {
       button: {
-        fontSize: ["mobile.sm", "desktop.sm"],
+        fontSize: ["mobile.sm", null, "desktop.sm"],
         paddingX: 3,
         paddingY: 2,
       },
       panel: {
-        fontSize: ["mobile.sm", "desktop.sm"],
+        fontSize: ["mobile.sm", null, "desktop.sm"],
         paddingX: 3,
       },
     },


### PR DESCRIPTION
## Background
Two issues in one pull request!

1. After upgrading SVGO, icons had their viewboxes removed. That is an issue for icons that are scaled up or down.
2. The title and content in expandables didn't default to the same size.

## Solution

Two issues requires two solutions!

1. Re-disable the removeViewBox plugin for SVGO
2. Ensure the font size is inherited from the parent of the expandable alert.
