### PR TITLE
Make icon and color boxes light grey

### DIFF
--- a/apps/docs/app/routes/_base.ressurser.design-tokens/ColorTokens.tsx
+++ b/apps/docs/app/routes/_base.ressurser.design-tokens/ColorTokens.tsx
@@ -134,7 +134,7 @@ const ColorToken = ({ token, ...rest }: ColorTokenProps) => {
     : colorValue;
 
   return (
-    <Card colorScheme="white" borderRadius="sm" overflow="hidden" {...rest}>
+    <Card colorScheme="grey" borderRadius="sm" overflow="hidden" {...rest}>
       <Box
         height="60px"
         border="1px solid"

--- a/apps/docs/app/routes/_base.ressurser.ikoner/SearchResults.tsx
+++ b/apps/docs/app/routes/_base.ressurser.ikoner/SearchResults.tsx
@@ -160,7 +160,7 @@ function IconBox({ icon }: IconBoxProps) {
   return (
     <Card
       display="flex"
-      colorScheme="white"
+      colorScheme="grey"
       borderRadius="sm"
       flexDirection="column"
       alignItems="center"


### PR DESCRIPTION
## Background
After removing the outline from cards, white cards look invisible on white backgrounds. We've been using white cards on white backgrounds a few places in our docs site, and will have to change those usecases.

## Solution
Change to using the grey version of cards for icons and color tokens.

### Icons:
![image](https://github.com/nsbno/spor/assets/1307267/15c62cf3-17cf-4ac3-971a-bbdaf57f785a)

### Colors
![image](https://github.com/nsbno/spor/assets/1307267/5f5ad40d-bc39-4007-9d06-e7aeb95a4423)

