### PR TITLE
Set textstyle for baseStyleLink

### DIFF
--- a/.changeset/nice-teachers-complain.md
+++ b/.changeset/nice-teachers-complain.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Breadcrumb: Ensure the breadcrumbs scale correctly

--- a/packages/spor-react/src/theme/components/breadcrumb.ts
+++ b/packages/spor-react/src/theme/components/breadcrumb.ts
@@ -15,6 +15,7 @@ const baseStyleLink = defineStyle({
   outline: "none",
   color: "inherit",
   textDecoration: "none",
+  textStyle: "xs",
   "&:not([aria-current=page])": {
     cursor: "pointer",
     paddingX: 0.5,


### PR DESCRIPTION
## Background
The textStyle for the breadcrumbs is not set, so the text does not scale according to screen sizes as defined by Spor.

## Solution
Set the textStyle in the baseStyleLink to be "xs", which was decided by the design for the new web-platform.
