### PR TITLE
Use regular instead of tabular font in date and time pickers

### DIFF
--- a/.changeset/tender-sheep-fix.md
+++ b/.changeset/tender-sheep-fix.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Datepicker, Timepicker: Use regular font for numbers"

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -35,14 +35,14 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
         ref={ref}
         style={{
           ...segmentProps.style,
-          fontVariantNumeric: "tabular-nums",
           boxSizing: "content-box",
         }}
         paddingX="1px"
-        textAlign="end"
+        textAlign="center"
         outline="none"
         borderRadius="xs"
         fontSize={["mobile.sm", "desktop.sm"]}
+        minWidth={isPaddable(segment.type) ? "1.3em" : "auto"}
         sx={styles.dateTimeSegment}
         _focus={{
           backgroundColor: "darkTeal",


### PR DESCRIPTION
## Background
We used a wider version of our font to ensure things weren't jumping back and forth when using the spinbuttons in the time and date pickers. We'd rater have the correct font.

## Solution
Solve the jumping around in a slightly different manner, while using the regular font. The downside to this approach is that the placeholders might seem a bit weirdly distributed.

Here is how it looks now:

![2023-09-14 15 20 06](https://github.com/nsbno/spor/assets/1307267/a9f860bf-a5f5-4477-bcc9-eafb659e506a)

![2023-09-14 15 20 26](https://github.com/nsbno/spor/assets/1307267/7c42f27b-9fd0-4772-ade4-a7e5bbbbd2b0)



