### PR TITLE
Global color støtter både light og dark ColorMode

### DIFF
--- a/.changeset/five-teachers-collect.md
+++ b/.changeset/five-teachers-collect.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Global color supports both light and dark ColorMode

--- a/packages/spor-react/src/provider/SporProvider.tsx
+++ b/packages/spor-react/src/provider/SporProvider.tsx
@@ -54,12 +54,6 @@ export const SporProvider = ({
     <LanguageProvider language={language}>
       <ChakraProvider theme={theme} {...props}>
         <Global styles={fontFaces} />
-        <Global
-          styles={`
-          html, body { color: ${theme.colors.darkGrey}; }
-          svg { display: initial; }
-          `}
-        />
         {children}
       </ChakraProvider>
     </LanguageProvider>

--- a/packages/spor-react/src/theme/foundations/index.ts
+++ b/packages/spor-react/src/theme/foundations/index.ts
@@ -12,3 +12,4 @@ export * from "./sizes";
 export * from "./spacing";
 export * from "./textStyles";
 export * from "./zIndices";
+export * from "./styles";

--- a/packages/spor-react/src/theme/foundations/styles.ts
+++ b/packages/spor-react/src/theme/foundations/styles.ts
@@ -1,0 +1,12 @@
+import {StyleFunctionProps, mode} from "@chakra-ui/theme-tools";
+
+export const styles = {
+    global: (props: StyleFunctionProps | Record<string, any>) => ({
+        'html, body': {
+            color: mode("darkGrey", "lightGrey")(props),
+        },
+        svg : {
+            display: "initial"
+        }
+    })
+}


### PR DESCRIPTION
## Background
- Global `color` var satt til darkGrey i **spor-react** provideren. Ettersom flere og flere komponenter skal støtte både light og dark colorMode, bør også global styling gjøre det samme. Color må derfor settes basert på hvilken colorMode som er aktiv. 

## Solution
- Har satt global color til å være **lightGrey** ved dark mode, og beholdt **darkGrey** ved light mode. Det er fargene vi bruker i våre løsninger, siden hvit og svart ofte kan oppleves litt harde, men tar gjerne innspill på hva dere ønsker her👍 
- I samme slengen fjernet jeg den ene `<Global/>` komponenten i SporProvider som satt color + en liten SVG style globalt, og flyttet dette til en egen styles.ts fil under theme/fundamentals i stedet. Dette skal fungere fordi Chakra oppretter global styling basert på det som settes der, ved hjelp av samme type Global komponent som vi hadde brukt ℹ️👇
- Jeg flyttet det til theme fordi jeg synes det er ryddigere å ha det mer samlet med resten av stylingen til Spor, i stedet for å legge det i en egen/ekstra Global komponent. Det gjør det også enklere for andre brukere å nå/overskrive de globale stilene, hvis nødvendig, via sin egen extendTheme implementasjon. Da slipper man for eksempel å måtte legge til enda et nivå med egen global styling som tar presedens over Spor sine. Vi endte nemlig opp med flere nivåer global styling av body som alle prøvde å sette color. En egen for å overskrive manglende darkMode støtte fra Spor sine, den ene fra Spor med color=darkGrey som jeg nå fjerner, og den andre fra Spor/Chakra som kommer med som default(som vi nå overskriver i stedet via theme) 😅Det er jo ikke noe krise med et hierarki der én tar presedens, men kjekt å få ryddet opp litt ☺️
- Jeg har prøvd å følge [dokumentasjonen](https://chakra-ui.com/docs/styled-system/global-styles) til Chakra for oppsett.

> By using ChakraProvider at the root of your application, we automatically render a GlobalStyle component. Here's what GlobalStyle does under the hood:
> - Reads the styles defined in theme.styles.global, this style can be a style object or a function that returns a style object.
>-  Process the styles and pass it to emotion's Global component which is used to handle global style injection.
