### PR TITLE
Add fallback fonts

### DIFF
--- a/.changeset/plenty-pumas-taste.md
+++ b/.changeset/plenty-pumas-taste.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add fallback for fonts"

--- a/packages/spor-react/src/theme/foundations/fonts.ts
+++ b/packages/spor-react/src/theme/foundations/fonts.ts
@@ -1,7 +1,7 @@
 import tokens from "@vygruppen/spor-design-tokens";
 
 export const fonts = {
-  body: tokens.font.family.body,
-  heading: tokens.font.family.heading,
-  mono: tokens.font.family.monospace,
+  body: `${tokens.font.family.body}, sans-serif`,
+  heading: `${tokens.font.family.heading}, sans-serif`,
+  mono: `${tokens.font.family.monospace}, monospace`,
 };


### PR DESCRIPTION
## Background
We didn't have any fallback fonts specified

## Solution
Add sans-serif as a fallback for heading and body text, and monospace for code.
