### PR TITLE
Add missing colors for Input in dark mode

### DIFF
--- a/.changeset/quiet-owls-clap.md
+++ b/.changeset/quiet-owls-clap.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Added missing colors for Input in darkmode

--- a/package-lock.json
+++ b/package-lock.json
@@ -34795,7 +34795,7 @@
     },
     "packages/spor-icon-react": {
       "name": "@vygruppen/spor-icon-react",
-      "version": "3.2.0",
+      "version": "3.2.3",
       "license": "MIT",
       "devDependencies": {
         "@svgr/core": "^8.1.0",
@@ -34818,7 +34818,7 @@
     },
     "packages/spor-icon-react-native": {
       "name": "@vygruppen/spor-icon-react-native",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "devDependencies": {
         "@shopify/restyle": "^2.1.0",
@@ -35443,7 +35443,7 @@
     },
     "packages/spor-loader": {
       "name": "@vygruppen/spor-loader",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^7.2.0"
@@ -35451,7 +35451,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "3.5.0",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.6.1",

--- a/packages/spor-react/src/theme/components/input.ts
+++ b/packages/spor-react/src/theme/components/input.ts
@@ -25,16 +25,22 @@ const config = helpers.defineMultiStyleConfig({
       boxShadow: getBoxShadowString({
         borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
       }),
+      _active: {
+        backgroundColor: mode("blackAlpha.100", "whiteAlpha.100")(props),
+        boxShadow: getBoxShadowString({
+          borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
+        }),
+      },
       _hover: {
         boxShadow: getBoxShadowString({
-          borderColor: mode("darkGrey", "whiteAlpha.600")(props),
+          borderColor: mode("darkGrey", "white")(props),
           borderWidth: 2,
         }),
       },
       ...focusVisible({
         focus: {
           boxShadow: getBoxShadowString({
-            borderColor: "greenHaze",
+            borderColor: mode("greenHaze", "azure")(props),
             borderWidth: 2,
           }),
         },
@@ -61,7 +67,7 @@ const config = helpers.defineMultiStyleConfig({
         ...focusVisible({
           focus: {
             boxShadow: getBoxShadowString({
-              borderColor: "greenHaze",
+              borderColor: mode("greenHaze", "azure")(props),
               borderWidth: 2,
             }),
           },


### PR DESCRIPTION
## Background
Closes #851

## Solution
Adds missing colors for Input in dark mode.
  - `azure` instead of `greenHaze` in dark mode.
  - `white` border for when hovering
  - introduces `active`-state
