### PR TITLE
Correct one alpha color, and add dark mode to floating-button

### DIFF
--- a/.changeset/olive-ligers-jog.md
+++ b/.changeset/olive-ligers-jog.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Adjust active color on Ghost-btn and add dark mode to Floating-btn

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -126,7 +126,7 @@ const config = defineStyleConfig({
           colors.blackAlpha[400],
           colors.whiteAlpha[300]
         )(props)}`,
-        backgroundColor: mode("mint", "whiteAlpha.300")(props),
+        backgroundColor: mode("mint", "whiteAlpha.200")(props),
       },
     }),
     ghost: (props) => ({
@@ -151,30 +151,38 @@ const config = defineStyleConfig({
         },
       },
       _active: {
-        backgroundColor: mode("mint", "whiteAlpha.300")(props),
+        backgroundColor: mode("mint", "whiteAlpha.200")(props),
       },
     }),
-    floating: {
-      backgroundColor: "white",
-      boxShadow: "sm",
+    floating: (props) => ({
+      backgroundColor: mode("white", "whiteAlpha.100")(props),
+      boxShadow: getBoxShadowString({
+        borderColor: mode("grey.200", "whiteAlpha.400")(props),
+        baseShadow: "sm",
+      }),
       _active: {
-        backgroundColor: "mint",
+        backgroundColor: mode("mint", "whiteAlpha.300")(props),
       },
       _hover: {
-        boxShadow: "md",
+        backgroundColor: mode("white", "whiteAlpha.200")(props),
+        boxShadow: getBoxShadowString({
+          borderColor: mode("grey.300", "white")(props),
+          baseShadow: "md",
+          borderWidth: 2,
+        }),
       },
       ...focusVisible({
         focus: {
           boxShadow: getBoxShadowString({
-            borderColor: "greenHaze",
+            borderColor: mode("greenHaze", "azure")(props),
             borderWidth: 2,
             baseShadow: "sm",
           }),
           _hover: {
             boxShadow: getBoxShadowString({
-              borderColor: "greenHaze",
+              borderColor: mode("greenHaze", "azure")(props),
               borderWidth: 2,
-              baseShadow: "md",
+              baseShadow: "md"
             }),
           },
         },
@@ -183,7 +191,7 @@ const config = defineStyleConfig({
           boxShadow: "sm",
         },
       }),
-    },
+    }),
   },
   sizes: {
     lg: {


### PR DESCRIPTION
## Background
Closes #852

## Solution
Adjusts `active` color on Ghost-button. Otherwise, it looks like most was done earlier.
Went through and added dark mode to `Floating`-button.