### PR TITLE
adds support for input field sizes and adds sm styling

### DIFF
--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/react";
 import React, { useId } from "react";
 
-export type InputProps = Omit<ChakraInputProps, "variant" | "size"> & {
+export type InputProps = Omit<ChakraInputProps, "variant"> & {
   /** The input's label */
   label: string;
   /** Icon that shows up to the left */
@@ -34,7 +34,7 @@ export type InputProps = Omit<ChakraInputProps, "variant" | "size"> & {
  * ```
  */
 export const Input = forwardRef<InputProps, "input">(
-  ({ label, leftIcon, rightIcon, id, size, ...props }, ref) => {
+  ({ label, leftIcon, rightIcon, id, ...props }, ref) => {
     const formControlProps = useFormControlContext();
     const fallbackId = `input-${useId()}`;
     const inputId = id ?? formControlProps?.id ?? fallbackId;

--- a/packages/spor-react/src/theme/components/input.ts
+++ b/packages/spor-react/src/theme/components/input.ts
@@ -1,12 +1,32 @@
 import { inputAnatomy as parts } from "@chakra-ui/anatomy";
-import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
+import { createMultiStyleConfigHelpers, defineStyle } from "@chakra-ui/react";
+
 import { mode } from "@chakra-ui/theme-tools";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
 
-const helpers = createMultiStyleConfigHelpers(parts.keys);
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(parts.keys);
 
-const config = helpers.defineMultiStyleConfig({
+const sizes = {
+  sm: definePartsStyle({
+    field: defineStyle({
+      height: 6,
+      "+ label": {
+        margin: 0,
+        lineHeight: "2rem", // FIXME: these values are a bit arbitrary, but work for now
+      },
+      ":not(:placeholder-shown)": {
+        paddingTop: 0,
+        "+ label": {
+          display: "none",
+        },
+      },
+    }),
+  }),
+};
+
+const config = defineMultiStyleConfig({
   baseStyle: (props) => ({
     field: {
       appearance: "none",
@@ -101,6 +121,7 @@ const config = helpers.defineMultiStyleConfig({
       height: "100%",
     },
   }),
+  sizes,
 });
 
 export default config;


### PR DESCRIPTION
## Background
Trenger små input-felt i flere flater i Utvikling. Ser at det har blitt gjort litt forskjellige hacks, så her er et forslag på å støtte det "natively". 😊 forhåpentligvis uten å endre defaults/brekke noe. `md` skal være default størrelse for et input-felt.

## Solution
Lagt til `sm` partsStyle. Siden labelen blir litt liten, gikk jeg for en løsning der den fjernes om man har innhold i input-feltet.

Feedback mottas med takk 💯

<img width="939" alt="image" src="https://github.com/nsbno/spor/assets/23121869/88f12e9f-2881-49e1-9777-93e2b51b79bb">
<img width="944" alt="image" src="https://github.com/nsbno/spor/assets/23121869/51c281b7-1af5-4d39-9fc2-d0c845cb1f6b">

