### PR TITLE
Dark mode support for Buttons

### DIFF
--- a/.changeset/happy-otters-explain.md
+++ b/.changeset/happy-otters-explain.md
@@ -1,0 +1,7 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Updated buttons to support dark mode with some minor touch ups to the current styles.
+Variant `tertiary`-buttons are now deprecated as we are updating our visual structure
+with a more minimalistic selection; please use `secondary` instead.

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -28,6 +28,7 @@ export type ButtonProps = Exclude<
     | "control"
     | "primary"
     | "secondary"
+    /** @deprecated Use `secondary` instead */
     | "tertiary"
     | "additional"
     | "ghost"

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -29,28 +29,39 @@ const config = defineStyleConfig({
     },
   },
   variants: {
-    control: {
-      backgroundColor: "darkTeal",
-      color: "white",
+    control: (props) => ({
+      backgroundColor: mode("darkTeal", "mint")(props),
+      color: mode("white", "darkTeal")(props),
       ...focusVisible({
         focus: {
-          boxShadow: `inset 0 0 0 4px ${colors.darkTeal}, inset 0 0 0 6px currentColor`,
+          boxShadow: `inset 0 0 0 4px ${mode(
+            colors.darkTeal,
+            colors.seaMist,
+          )(props)}, inset 0 0 0 6px currentColor`,
         },
         notFocus: { boxShadow: "none" },
       }),
       _hover: {
-        backgroundColor: "night",
+        backgroundColor: mode("night", "coralGreen")(props),
       },
       _active: {
-        backgroundColor: "pine",
+        backgroundColor: mode("pine", "white")(props),
       },
-    },
-    primary: {
+    }),
+    primary: (props) => ({
+      // FIXME: Update to use a global defined background color for darkMode whenever it is available.
+      // hardcoded background color as alpha-"hack" below is not feasible for dark mode with solid background color
       backgroundColor: "primaryGreen",
       color: "white",
       ...focusVisible({
         focus: {
-          boxShadow: `inset 0 0 0 4px ${colors.primaryGreen}, inset 0 0 0 4px ${colors.primaryGreen}, inset 0 0 0 6px currentColor`,
+          boxShadow: `inset 0 0 0 2px ${mode(
+            colors.greenHaze,
+            colors.azure,
+          )(props)}, inset 0 0 0 4px ${mode(
+            colors.white,
+            colors.darkGrey,
+          )(props)}`,
         },
         notFocus: { boxShadow: "none" },
       }),
@@ -60,25 +71,61 @@ const config = defineStyleConfig({
       _active: {
         backgroundColor: "azure",
       },
-    },
-    secondary: {
-      backgroundColor: "coralGreen",
-      color: "darkTeal",
+    }),
+    secondary: (props) => ({
+      // FIXME: Update to use global defined background color for darkMode whenever it is available instead of alpha
+      backgroundColor: mode("seaMist", "whiteAlpha.100")(props),
+      color: mode("darkTeal", "white")(props),
+      // order is important here for now while we do not have global defined background color for darkMode
+      _hover: {
+        backgroundColor: mode("coralGreen", "whiteAlpha.200")(props),
+      },
       ...focusVisible({
         focus: {
-          boxShadow: `inset 0 0 0 4px ${colors.coralGreen}, inset 0 0 0 4px ${colors.coralGreen}, inset 0 0 0 6px currentColor`,
+          boxShadow: `inset 0 0 0 2px ${mode(
+            colors.greenHaze,
+            colors.azure,
+          )(props)}, inset 0 0 0 4px ${mode(
+            colors.white,
+            colors.blackAlpha[300],
+          )(props)}`,
+          _hover: {
+            boxShadow: `inset 0 0 0 2px ${mode(
+              colors.greenHaze,
+              colors.azure,
+            )(props)}, inset 0 0 0 4px ${mode(
+              colors.white,
+              colors.blackAlpha[500],
+            )(props)}`,
+          },
         },
         notFocus: {
           boxShadow: "none",
         },
       }),
-      _hover: {
-        backgroundColor: "blueGreen",
-      },
       _active: {
-        backgroundColor: "mint",
+        backgroundColor: mode("mint", "whiteAlpha.300")(props),
+        boxShadow: `inset 0 0 0 2px ${mode(
+          colors.greenHaze,
+          colors.azure,
+        )(props)}, inset 0 0 0 4px ${mode(
+          colors.white,
+          colors.blackAlpha[600],
+        )(props)}`,
+        _hover: {
+          boxShadow: `inset 0 0 0 2px ${mode(
+            colors.greenHaze,
+            colors.azure,
+          )(props)}, inset 0 0 0 4px ${mode(
+            colors.white,
+            colors.blackAlpha[600],
+          )(props)}`,
+        },
       },
-    },
+    }),
+    /**
+     * @deprecated use `secondary` instead.
+     */
     tertiary: {
       backgroundColor: "mint",
       color: "darkGrey",
@@ -102,19 +149,19 @@ const config = defineStyleConfig({
       fontWeight: "normal",
       boxShadow: `inset 0 0 0 1px ${mode(
         colors.blackAlpha[400],
-        colors.whiteAlpha[400]
+        colors.whiteAlpha[400],
       )(props)}`,
       ...focusVisible({
         focus: {
           boxShadow: getBoxShadowString({
-            borderWidth: 3,
+            borderWidth: 2,
             borderColor: "greenHaze",
           }),
         },
         notFocus: {
           boxShadow: `inset 0 0 0 1px ${mode(
             colors.blackAlpha[400],
-            colors.whiteAlpha[400]
+            colors.whiteAlpha[400],
           )(props)}`,
         },
       }),
@@ -124,7 +171,7 @@ const config = defineStyleConfig({
       _active: {
         boxShadow: `inset 0 0 0 1px ${mode(
           colors.blackAlpha[400],
-          colors.whiteAlpha[300]
+          colors.whiteAlpha[300],
         )(props)}`,
         backgroundColor: mode("mint", "whiteAlpha.200")(props),
       },
@@ -182,7 +229,7 @@ const config = defineStyleConfig({
             boxShadow: getBoxShadowString({
               borderColor: mode("greenHaze", "azure")(props),
               borderWidth: 2,
-              baseShadow: "md"
+              baseShadow: "md",
             }),
           },
         },


### PR DESCRIPTION
## Background
Support dark mode

## Solution
Added dark mode to existing button types.
Added `@deprecated` to `tertiary`-variant.
Touched up on current styles to light mode.



https://github.com/nsbno/spor/assets/3692249/79e05d59-4134-4c90-8483-6d48b46a4bda

