### PR TITLE
Add minHeight to Accordions

### DIFF
--- a/.changeset/eighty-dodos-relate.md
+++ b/.changeset/eighty-dodos-relate.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Accordion, ExpandableItem: Set the correct minimum height

--- a/packages/spor-react/src/theme/components/accordion.ts
+++ b/packages/spor-react/src/theme/components/accordion.ts
@@ -111,6 +111,7 @@ const config = helpers.defineMultiStyleConfig({
         fontSize: ["mobile.xs", null, "desktop.xs"],
         paddingX: 2,
         paddingY: 1,
+        minHeight: 6,
       },
       panel: {
         fontSize: ["mobile.xs", null, "desktop.xs"],
@@ -122,6 +123,7 @@ const config = helpers.defineMultiStyleConfig({
         fontSize: ["mobile.sm", null, "desktop.sm"],
         paddingX: 3,
         paddingY: 1,
+        minHeight: 7,
       },
       panel: {
         fontSize: ["mobile.sm", null, "desktop.sm"],
@@ -133,6 +135,7 @@ const config = helpers.defineMultiStyleConfig({
         fontSize: ["mobile.sm", null, "desktop.sm"],
         paddingX: 3,
         paddingY: 2,
+        minHeight: 8,
       },
       panel: {
         fontSize: ["mobile.sm", null, "desktop.sm"],


### PR DESCRIPTION
## Background
Accordions are slightly thinner than they should be according to the [component library.](https://www.figma.com/file/Tmr2URVX2vNkyRLqKhNRQA/Vy_komponentbibliotek?node-id=12402%3A185861&mode=dev)

| size |  height before | height in Figma |
|--|--|--|
| sm | 33 (mobile), 36 | 36|
|md |  36 (mobile), 39 | 42 |
| lg | 48 (mobile), 51 | 54 |


## Solution
Added a `minHeight` to ensure that they are as tall as they should be as I couldn't get the math to work to use padding. 