### PR TITLE
Add dark mode to choice chips

### DIFF
--- a/.changeset/old-readers-flow.md
+++ b/.changeset/old-readers-flow.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Tweaked ChoiceChip colors, and added dark mode

--- a/packages/spor-react/src/input/ChoiceChip.tsx
+++ b/packages/spor-react/src/input/ChoiceChip.tsx
@@ -83,6 +83,8 @@ export const ChoiceChip = forwardRef((props: ChoiceChipProps, ref) => {
         data-checked={dataAttr(state.isChecked)}
         data-hover={dataAttr(state.isHovered)}
         data-focus={dataAttr(state.isFocused)}
+        data-active={dataAttr(state.isActive)}
+        data-disabled={dataAttr(state.isDisabled)}
       >
         {icon && (
           <chakra.span __css={styles.icon}>

--- a/packages/spor-react/src/theme/components/choice-chip.ts
+++ b/packages/spor-react/src/theme/components/choice-chip.ts
@@ -1,6 +1,8 @@
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import { anatomy } from "@chakra-ui/theme-tools";
+import { anatomy, mode } from "@chakra-ui/theme-tools";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
+import { colors } from "../foundations";
+import { focusVisible } from "../utils/focus-utils";
 
 const parts = anatomy("choice-chip").parts("container", "icon", "label");
 
@@ -9,32 +11,43 @@ const helpers = createMultiStyleConfigHelpers(parts.keys);
 const config = helpers.defineMultiStyleConfig({
   baseStyle: (props) => ({
     container: {
-      backgroundColor: "white",
+      backgroundColor: mode("white", "transparent")(props),
       boxShadow: getBoxShadowString({ borderColor: "celadon" }),
-      color: "darkTeal",
+      color: mode("darkTeal", "white")(props),
       display: "inline-flex",
       alignItems: "center",
       fontSize: "16px",
       px: 1,
       _checked: {
-        background: "seaMist",
+        color: "white",
+        background: "pine",
         boxShadow: getBoxShadowString({ borderColor: "celadon" }),
       },
       "input:focus-visible + &": {
-        boxShadow: getBoxShadowString({
-          borderColor: "greenHaze",
-          borderWidth: 2,
-        }),
+        boxShadow: `inset 0 0 0 2px ${mode(
+          colors.greenHaze,
+          colors.azure,
+        )(props)}, inset 0 0 0 4px ${mode(
+          colors.white,
+          colors.darkGrey,
+        )(props)}`,
       },
       "@media (hover:hover)": {
         _hover: {
+          color: mode("darkTeal", "white")(props),
           boxShadow: getBoxShadowString({
             borderColor: "greenHaze",
             borderWidth: 2,
           }),
-          background: "mint",
+          background: mode("coralGreen", "whiteAlpha.200")(props),
           cursor: "pointer",
         },
+      },
+      _active: {
+        backgroundColor: mode("mint", "whiteAlpha.300")(props),
+        boxShadow: getBoxShadowString({
+          borderColor: "pine",
+        }),
       },
     },
     icon: {


### PR DESCRIPTION
## Background
Adds DarkMode support for ChoiceChips, and adds slight color tweaks to align with new design vision.

## Solution



https://github.com/nsbno/spor/assets/3692249/89347bda-9d32-478d-8bca-5baa1e5ffb5f

