### PR TITLE
Update variants and design for tabs

### DIFF
--- a/.changeset/sharp-spiders-do.md
+++ b/.changeset/sharp-spiders-do.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Tabs: Update variants and design for tabs

--- a/packages/spor-react/src/tab/Tabs.tsx
+++ b/packages/spor-react/src/tab/Tabs.tsx
@@ -11,11 +11,15 @@ export type TabsProps = Exclude<
 > & {
   colorScheme: 
   /** @deprecated dark is deprecated please use accent*/
-  | "dark" 
+  | "dark"
+  /** @deprecated light is deprecated please use default*/
+  | "light"
+  /** @deprecated green is deprecated please use accent*/
+  | "green"   
+  /** @deprecated grey is deprecated please use default*/
+  | "grey"
   | "default" 
-  | "accent" 
-  /** @deprecated dark is deprecated please use default*/
-  | "grey";
+  | "accent" ;
   /** Defaults to `md` */
   size?: "sm" | "md" | "lg" | "xl";
   /** Defaults to `round` */

--- a/packages/spor-react/src/tab/Tabs.tsx
+++ b/packages/spor-react/src/tab/Tabs.tsx
@@ -9,7 +9,7 @@ export type TabsProps = Exclude<
   ChakraTabsProps,
   "colorScheme" | "variant" | "orientation" | "size"
 > & {
-  colorScheme: "dark" | "light" | "green" | "grey";
+  colorScheme: "dark" | "default" | "accent" | "grey";
   /** Defaults to `md` */
   size?: "sm" | "md" | "lg" | "xl";
   /** Defaults to `round` */

--- a/packages/spor-react/src/tab/Tabs.tsx
+++ b/packages/spor-react/src/tab/Tabs.tsx
@@ -9,7 +9,13 @@ export type TabsProps = Exclude<
   ChakraTabsProps,
   "colorScheme" | "variant" | "orientation" | "size"
 > & {
-  colorScheme: "dark" | "default" | "accent" | "grey";
+  colorScheme: 
+  /** @deprecated dark is deprecated please use accent*/
+  | "dark" 
+  | "default" 
+  | "accent" 
+  /** @deprecated dark is deprecated please use default*/
+  | "grey";
   /** Defaults to `md` */
   size?: "sm" | "md" | "lg" | "xl";
   /** Defaults to `round` */

--- a/packages/spor-react/src/theme/components/tabs.ts
+++ b/packages/spor-react/src/theme/components/tabs.ts
@@ -117,6 +117,18 @@ const getTabColorSchemeProps = (props: StyleFunctionProps) => {
       return {
         color: "white",
       };
+    case "light":
+      return {
+        color: "darkGrey",
+      };
+    case "green":
+      return {
+        color: "darkTeal",
+      };
+    case "grey":
+      return {
+        color: "darkGrey",
+      };
     case "default":
       return {
         color: mode("darkGrey", "white")(props),
@@ -124,10 +136,6 @@ const getTabColorSchemeProps = (props: StyleFunctionProps) => {
     case "accent":
       return {
         color: mode("darkTeal", "white")(props),
-      };
-    case "grey":
-      return {
-        color: "darkGrey",
       };
     default:
       return {};
@@ -158,9 +166,35 @@ const getTabColorSchemeSelectedProps = (props: StyleFunctionProps) => {
           color: "darkTeal",
         },
       };
-    default:
+    case "default":
       return {
         backgroundColor: "pine",
+        color: "white",
+        _hover: {
+          backgroundColor: "darkTeal",
+          color: "white",
+        },
+        _active: {
+          backgroundColor: "darkTeal",
+          color: "white",
+        },
+      }
+    case "accent":
+      return {
+        backgroundColor: "pine",
+        color: "white",
+        _hover: {
+          backgroundColor: "darkTeal",
+          color: "white",
+        },
+        _active: {
+          backgroundColor: "darkTeal",
+          color: "white",
+        },
+      }
+    default:
+      return {
+        backgroundColor: "darkTeal",
         color: "white",
         _hover: {
           backgroundColor: "darkTeal",
@@ -180,10 +214,17 @@ const getTabColorSchemeFocusProps = (props: StyleFunctionProps) => {
       return {
         boxShadow: `inset 0 0 0 2px ${props.theme.colors.white}`,
       };
-      
-    default:
+    case "default":
       return {
         boxShadow: `inset 0 0 0 2px ${props.theme.colors.azure}`,
+      } 
+    case "accent":
+      return {
+        boxShadow: `inset 0 0 0 2px ${props.theme.colors.azure}`,
+      } 
+    default:
+      return {
+        boxShadow: `inset 0 0 0 2px ${props.theme.colors.greenHaze}`,
       };
   }
 };
@@ -194,6 +235,18 @@ const getTabColorSchemeHoverProps = (props: StyleFunctionProps) => {
       return {
         backgroundColor: "pine",
       };
+    case "light":
+      return {
+        backgroundColor: "silver",
+      };
+    case "green":
+      return {
+        backgroundColor: "coralGreen",
+      };
+    case "grey":
+      return {
+        backgroundColor: "silver",
+      };
     case "default":
       return {
         boxShadow: mode(`inset 0 0 0 2px ${props.theme.colors.darkGrey}`, `inset 0 0 0 2px ${props.theme.colors.white}`)(props),
@@ -203,10 +256,6 @@ const getTabColorSchemeHoverProps = (props: StyleFunctionProps) => {
       return {
         backgroundColor: mode("seaMist", "whiteAlpha.200")(props),
         color: mode("darkTeal", "white")(props)
-      };
-    case "grey":
-      return {
-        backgroundColor: "silver",
       };
     default:
       return {};
@@ -220,6 +269,21 @@ const getTabColorSchemeActiveProps = (props: StyleFunctionProps) => {
         backgroundColor: "celadon",
         color: "white",
       };
+    case "light":
+      return {
+        backgroundColor: "mint",
+        color: "darkGrey",
+      };
+    case "green":
+      return {
+        backgroundColor: "seaMist",
+        color: "darkTeal",
+      };
+    case "grey":
+      return {
+        backgroundColor: "lightGrey",
+        color: "darkGrey",
+      };
     case "default":
       return {
         backgroundColor: mode("mint", "whiteAlpha.100")(props),
@@ -229,11 +293,6 @@ const getTabColorSchemeActiveProps = (props: StyleFunctionProps) => {
       return {
         backgroundColor: mode("seaMist", "whiteAlpha.100")(props),
         color: mode("darkTeal", "white")(props),
-      };
-    case "grey":
-      return {
-        backgroundColor: "lightGrey",
-        color: "darkGrey",
       };
     default:
       return {};
@@ -246,18 +305,26 @@ const getTabColorSchemeDisabledProps = (props: StyleFunctionProps) => {
       return {
         color: "lightAlpha.200",
       };
-    case "default":
+    case "light":
       return {
-        color: mode("blackAlpha.400", "whiteAlpha.400")(props),
+        color: "silver",
       };
-    case "accent":
+    case "green":
       return {
-        color: mode("blackAlpha.400", "whiteAlpha.400")(props),
+        color: "coralGreen",
       };
     case "grey":
       return {
         color: "steel",
       };
+    case "default":
+    return {
+      color: mode("blackAlpha.400", "whiteAlpha.400")(props),
+    };
+  case "accent":
+    return {
+      color: mode("blackAlpha.400", "whiteAlpha.400")(props),
+    };
     default:
       return {};
   }
@@ -267,6 +334,19 @@ const getTablistColorSchemeProps = (props: StyleFunctionProps) => {
   switch (props.colorScheme) {
     case "dark":
       return { backgroundColor: "darkTeal", color: "white" };
+    case "light":
+      return {
+        backgroundColor: "white",
+        color: "darkGrey",
+        boxShadow: `inset 0 0 0 1px ${props.theme.colors.blackAlpha["400"]}`,
+      };
+    case "green":
+      return { backgroundColor: "mint", color: "darkTeal" };
+    case "grey":
+      return {
+        backgroundColor: "platinum",
+        color: "darkGrey",
+      };
     case "default":
       return {
         backgroundColor: mode("white", "transparent")(props),
@@ -277,11 +357,6 @@ const getTablistColorSchemeProps = (props: StyleFunctionProps) => {
       return { 
         backgroundColor: mode("mint", "whiteAlpha.100")(props), 
         color: "darkTeal" 
-      };
-    case "grey":
-      return {
-        backgroundColor: "platinum",
-        color: "darkGrey",
       };
     default:
       return {};

--- a/packages/spor-react/src/theme/components/tabs.ts
+++ b/packages/spor-react/src/theme/components/tabs.ts
@@ -180,6 +180,7 @@ const getTabColorSchemeFocusProps = (props: StyleFunctionProps) => {
       return {
         boxShadow: `inset 0 0 0 2px ${props.theme.colors.white}`,
       };
+      
     default:
       return {
         boxShadow: `inset 0 0 0 2px ${props.theme.colors.azure}`,

--- a/packages/spor-react/src/theme/components/tabs.ts
+++ b/packages/spor-react/src/theme/components/tabs.ts
@@ -117,11 +117,11 @@ const getTabColorSchemeProps = (props: StyleFunctionProps) => {
       return {
         color: "white",
       };
-    case "light":
+    case "default":
       return {
         color: mode("darkGrey", "white")(props),
       };
-    case "green":
+    case "accent":
       return {
         color: mode("darkTeal", "white")(props),
       };
@@ -193,12 +193,12 @@ const getTabColorSchemeHoverProps = (props: StyleFunctionProps) => {
       return {
         backgroundColor: "pine",
       };
-    case "light":
+    case "default":
       return {
         boxShadow: mode(`inset 0 0 0 2px ${props.theme.colors.darkGrey}`, `inset 0 0 0 2px ${props.theme.colors.white}`)(props),
         color: mode("darkGrey", "white")(props)
       };
-    case "green":
+    case "accent":
       return {
         backgroundColor: mode("seaMist", "whiteAlpha.200")(props),
         color: mode("darkTeal", "white")(props)
@@ -219,12 +219,12 @@ const getTabColorSchemeActiveProps = (props: StyleFunctionProps) => {
         backgroundColor: "celadon",
         color: "white",
       };
-    case "light":
+    case "default":
       return {
         backgroundColor: mode("mint", "whiteAlpha.100")(props),
         color: mode("darkGrey", "white")(props),
       };
-    case "green":
+    case "accent":
       return {
         backgroundColor: mode("seaMist", "whiteAlpha.100")(props),
         color: mode("darkTeal", "white")(props),
@@ -245,11 +245,11 @@ const getTabColorSchemeDisabledProps = (props: StyleFunctionProps) => {
       return {
         color: "lightAlpha.200",
       };
-    case "light":
+    case "default":
       return {
         color: mode("blackAlpha.400", "whiteAlpha.400")(props),
       };
-    case "green":
+    case "accent":
       return {
         color: mode("blackAlpha.400", "whiteAlpha.400")(props),
       };
@@ -266,13 +266,13 @@ const getTablistColorSchemeProps = (props: StyleFunctionProps) => {
   switch (props.colorScheme) {
     case "dark":
       return { backgroundColor: "darkTeal", color: "white" };
-    case "light":
+    case "default":
       return {
-        backgroundColor: mode("white", "whiteAlpha.400")(props),
+        backgroundColor: mode("white", "transparent")(props),
         color: "darkGrey",
-        boxShadow: `inset 0 0 0 1px ${props.theme.colors.blackAlpha["400"]}`,
+        boxShadow: mode(`inset 0 0 0 1px ${props.theme.colors.blackAlpha["400"]}`, `inset 0 0 0 1px ${props.theme.colors.whiteAlpha["400"]}`)(props),
       };
-    case "green":
+    case "accent":
       return { 
         backgroundColor: mode("mint", "whiteAlpha.100")(props), 
         color: "darkTeal" 

--- a/packages/spor-react/src/theme/components/tabs.ts
+++ b/packages/spor-react/src/theme/components/tabs.ts
@@ -1,6 +1,6 @@
 import { tabsAnatomy as parts } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import type { StyleFunctionProps } from "@chakra-ui/theme-tools";
+import { mode, type StyleFunctionProps } from "@chakra-ui/theme-tools";
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
@@ -119,11 +119,11 @@ const getTabColorSchemeProps = (props: StyleFunctionProps) => {
       };
     case "light":
       return {
-        color: "darkGrey",
+        color: mode("darkGrey", "white")(props),
       };
     case "green":
       return {
-        color: "darkTeal",
+        color: mode("darkTeal", "white")(props),
       };
     case "grey":
       return {
@@ -160,7 +160,7 @@ const getTabColorSchemeSelectedProps = (props: StyleFunctionProps) => {
       };
     default:
       return {
-        backgroundColor: "darkTeal",
+        backgroundColor: "pine",
         color: "white",
         _hover: {
           backgroundColor: "darkTeal",
@@ -182,7 +182,7 @@ const getTabColorSchemeFocusProps = (props: StyleFunctionProps) => {
       };
     default:
       return {
-        boxShadow: `inset 0 0 0 2px ${props.theme.colors.greenHaze}`,
+        boxShadow: `inset 0 0 0 2px ${props.theme.colors.azure}`,
       };
   }
 };
@@ -195,11 +195,13 @@ const getTabColorSchemeHoverProps = (props: StyleFunctionProps) => {
       };
     case "light":
       return {
-        backgroundColor: "silver",
+        boxShadow: mode(`inset 0 0 0 2px ${props.theme.colors.darkGrey}`, `inset 0 0 0 2px ${props.theme.colors.white}`)(props),
+        color: mode("darkGrey", "white")(props)
       };
     case "green":
       return {
-        backgroundColor: "coralGreen",
+        backgroundColor: mode("seaMist", "whiteAlpha.200")(props),
+        color: mode("darkTeal", "white")(props)
       };
     case "grey":
       return {
@@ -219,13 +221,13 @@ const getTabColorSchemeActiveProps = (props: StyleFunctionProps) => {
       };
     case "light":
       return {
-        backgroundColor: "mint",
-        color: "darkGrey",
+        backgroundColor: mode("mint", "whiteAlpha.100")(props),
+        color: mode("darkGrey", "white")(props),
       };
     case "green":
       return {
-        backgroundColor: "seaMist",
-        color: "darkTeal",
+        backgroundColor: mode("seaMist", "whiteAlpha.100")(props),
+        color: mode("darkTeal", "white")(props),
       };
     case "grey":
       return {
@@ -245,11 +247,11 @@ const getTabColorSchemeDisabledProps = (props: StyleFunctionProps) => {
       };
     case "light":
       return {
-        color: "silver",
+        color: mode("blackAlpha.400", "whiteAlpha.400")(props),
       };
     case "green":
       return {
-        color: "coralGreen",
+        color: mode("blackAlpha.400", "whiteAlpha.400")(props),
       };
     case "grey":
       return {
@@ -266,12 +268,15 @@ const getTablistColorSchemeProps = (props: StyleFunctionProps) => {
       return { backgroundColor: "darkTeal", color: "white" };
     case "light":
       return {
-        backgroundColor: "white",
+        backgroundColor: mode("white", "whiteAlpha.400")(props),
         color: "darkGrey",
         boxShadow: `inset 0 0 0 1px ${props.theme.colors.blackAlpha["400"]}`,
       };
     case "green":
-      return { backgroundColor: "mint", color: "darkTeal" };
+      return { 
+        backgroundColor: mode("mint", "whiteAlpha.100")(props), 
+        color: "darkTeal" 
+      };
     case "grey":
       return {
         backgroundColor: "platinum",


### PR DESCRIPTION
## Background
need to change variants and design for tabs

## Solution
Dark -> accent
Green -> accent
Grey -> default
Light -> default

dark and grey are still the same, but adviced to use default and accent instead. previously green and light and changed into accent and default
