### PR TITLE
Fix padding issue with breadcrumbs

### DIFF
--- a/.changeset/calm-ligers-jog.md
+++ b/.changeset/calm-ligers-jog.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+BreadcrumbLink: Fix a bug where the current page got a different amount of padding than other breadcrumbs

--- a/packages/spor-react/src/theme/components/breadcrumb.ts
+++ b/packages/spor-react/src/theme/components/breadcrumb.ts
@@ -33,7 +33,7 @@ const baseStyleLink = defineStyle((props) => ({
         }),
       },
       notFocus: {
-        notFocus: { boxShadow: "none" },
+        boxShadow: "none",
       },
     }),
     _active: {

--- a/packages/spor-react/src/theme/components/breadcrumb.ts
+++ b/packages/spor-react/src/theme/components/breadcrumb.ts
@@ -1,7 +1,10 @@
 import { breadcrumbAnatomy as parts } from "@chakra-ui/anatomy";
-import { createMultiStyleConfigHelpers, defineStyle } from "@chakra-ui/styled-system";
-import { getBoxShadowString } from "../utils/box-shadow-utils";
+import {
+  createMultiStyleConfigHelpers,
+  defineStyle,
+} from "@chakra-ui/styled-system";
 import { mode } from "@chakra-ui/theme-tools";
+import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
 
 const { defineMultiStyleConfig, definePartsStyle } =
@@ -15,10 +18,10 @@ const baseStyleLink = defineStyle((props) => ({
   color: "inherit",
   textDecoration: "none",
   textStyle: "xs",
+  paddingX: 0.5,
+  borderRadius: "xs",
   "&:not([aria-current=page])": {
     cursor: "pointer",
-    paddingX: 0.5,
-    borderRadius: "xs",
     _hover: {
       backgroundColor: mode("seaMist", "pine")(props),
     },
@@ -31,7 +34,7 @@ const baseStyleLink = defineStyle((props) => ({
       },
       notFocus: {
         notFocus: { boxShadow: "none" },
-      }
+      },
     }),
     _active: {
       backgroundColor: mode("mint", "whiteAlpha.200")(props),


### PR DESCRIPTION
## Background
Breadcrumbs looked a bit wonky on smaller screens, since the last item in the list (the current page) didn't get any padding.

## Solution
Add both padding and rounding to all items in the list.
Also, fix a weird typo.