### PR TITLE
InfoSelect: added dark mode

### DIFF
--- a/.changeset/odd-roses-crash.md
+++ b/.changeset/odd-roses-crash.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+InfoSelect: Added dark mode

--- a/packages/spor-react/src/theme/components/info-select.ts
+++ b/packages/spor-react/src/theme/components/info-select.ts
@@ -1,15 +1,15 @@
 import { anatomy } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import { mode } from "@chakra-ui/theme-tools";
-import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
 import { srOnly } from "../utils/sr-utils";
+import { baseBorder } from "../utils/border-utils";
+import { baseBackground } from "../utils/background-utils";
 
 const parts = anatomy("InfoSelect").parts(
   "container",
   "label",
   "button",
-  "arrowIcon"
+  "arrowIcon",
 );
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
@@ -31,57 +31,44 @@ const config = helpers.defineMultiStyleConfig({
       justifyContent: "space-between",
       alignItems: "center",
       fontSize: "mobile.md",
-      boxShadow: getBoxShadowString({
-        borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
-      }),
+      ...baseBorder("default", props),
       _hover: {
-        boxShadow: getBoxShadowString({
-          borderColor: mode("darkGrey", "whiteAlpha.600")(props),
-          borderWidth: 2,
-        }),
+        ...baseBorder("hover", props),
       },
       ...focusVisible({
         focus: {
-          boxShadow: getBoxShadowString({
-            borderColor: "greenHaze",
-            borderWidth: 2,
-          }),
+          ...baseBorder("focus", props),
           outline: "none",
         },
         notFocus: {
-          boxShadow: getBoxShadowString({
-            borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
-          }),
+          ...baseBorder("default", props),
         },
       }),
       _disabled: {
-        boxShadow: getBoxShadowString({ borderColor: "platinum" }),
-        _hover: { boxShadow: getBoxShadowString({ borderColor: "platinum" }) },
-        _focus: { boxShadow: getBoxShadowString({ borderColor: "platinum" }) },
+        color: "whiteAlpha.400",
+        ...baseBackground("disabled", props),
+        _hover: { ...baseBorder("disabled", props) },
+        _focus: { ...baseBorder("disabled", props) },
+      },
+      _active: {
+        ...baseBackground("active", props),
+        ...baseBorder("focus", props),
+      },
+      _expanded: {
+        ...baseBackground("active", props),
+        ...baseBorder("focus", props),
       },
       _invalid: {
-        boxShadow: getBoxShadowString({
-          borderColor: "brightRed",
-          borderWidth: 2,
-        }),
+        ...baseBorder("invalid", props),
         _hover: {
-          boxShadow: getBoxShadowString({
-            borderColor: "darkGrey",
-            borderWidth: 2,
-          }),
+          ...baseBorder("hover", props),
         },
         ...focusVisible({
           focus: {
-            boxShadow: getBoxShadowString({
-              borderColor: "greenHaze",
-              borderWidth: 2,
-            }),
+            ...baseBorder("focus", props),
           },
           notFocus: {
-            boxShadow: getBoxShadowString({
-              borderColor: "brightRed",
-              borderWidth: 2,
-            }),
+            ...baseBorder("invalid", props),
           },
         }),
       },

--- a/packages/spor-react/src/theme/components/listbox.ts
+++ b/packages/spor-react/src/theme/components/listbox.ts
@@ -1,12 +1,14 @@
 import { anatomy } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
+import { colors } from "../foundations";
+import { baseBackground } from "../utils/background-utils";
 
 const parts = anatomy("ListBox").parts(
   "container",
   "item",
   "label",
-  "description"
+  "description",
 );
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
@@ -14,7 +16,11 @@ const helpers = createMultiStyleConfigHelpers(parts.keys);
 const config = helpers.defineMultiStyleConfig({
   baseStyle: (props) => ({
     container: {
-      background: mode("white", "darkGrey")(props),
+      // avoiding extra div by blending a transparent color into darkGrey for dark mode
+      backgroundColor: mode(
+        "mint",
+        `color-mix(in srgb, ${colors.darkGrey}, ${colors.white} 10%)`,
+      )(props),
       boxShadow: "sm",
       overflowY: "auto",
       maxHeight: "50vh",
@@ -31,20 +37,20 @@ const config = helpers.defineMultiStyleConfig({
       color: mode("darkGrey", "white")(props),
       cursor: "pointer",
       _hover: {
-        backgroundColor: mode("seaMist", "darkTeal")(props),
+        backgroundColor: mode("seaMist", "pine")(props),
         outline: "none",
       },
       _active: {
-        backgroundColor: mode("mint", "darkTeal")(props),
+        backgroundColor: mode("mint", "pine")(props),
         outline: "none",
       },
       _focus: {
         outline: "none",
-        backgroundColor: mode("seaMist", "darkTeal")(props),
+        backgroundColor: mode("seaMist", "pine")(props),
       },
       _selected: {
-        backgroundColor: mode("pine", "pine")(props),
-        color: mode("white", "white")(props),
+        ...baseBackground("selected", props),
+        color: "white",
       },
     },
     label: {},

--- a/packages/spor-react/src/theme/utils/background-utils.ts
+++ b/packages/spor-react/src/theme/utils/background-utils.ts
@@ -1,0 +1,28 @@
+import { mode, StyleFunctionProps } from "@chakra-ui/theme-tools";
+
+type State =
+  | "default"
+  | "hover"
+  | "active"
+  | "focus"
+  | "selected"
+  | "invalid"
+  | "disabled";
+export function baseBackground(state: State, props: StyleFunctionProps) {
+  switch (state) {
+    case "active":
+      return {
+        backgroundColor: mode("mint", "whiteAlpha.100")(props),
+      };
+    case "selected":
+      return {
+        backgroundColor: "pine",
+      };
+    case "disabled":
+      return {
+        backgroundColor: mode("silver", "whiteAlpha.100")(props),
+      };
+    default:
+      return {};
+  }
+}

--- a/packages/spor-react/src/theme/utils/border-utils.ts
+++ b/packages/spor-react/src/theme/utils/border-utils.ts
@@ -1,0 +1,59 @@
+import { mode, StyleFunctionProps } from "@chakra-ui/theme-tools";
+import { getBoxShadowString } from "./box-shadow-utils";
+
+type State =
+  | "default"
+  | "hover"
+  | "active"
+  | "focus"
+  | "selected"
+  | "invalid"
+  | "disabled";
+
+export function baseBorder(state: State, props: StyleFunctionProps) {
+  switch (state) {
+    case "hover":
+      return {
+        boxShadow: getBoxShadowString({
+          borderColor: mode("darkGrey", "white")(props),
+          borderWidth: 2,
+        }),
+      };
+    case "focus": {
+      return {
+        boxShadow: getBoxShadowString({
+          borderColor: mode("greenHaze", "azure")(props),
+          borderWidth: 2,
+        }),
+      };
+    }
+    case "disabled": {
+      return {
+        boxShadow: getBoxShadowString({
+          borderColor: mode("platinum", "whiteAlpha.400")(props),
+        }),
+      };
+    }
+    case "selected":
+      return {
+        boxShadow: getBoxShadowString({
+          borderColor: mode("greenHaze", "azure")(props),
+        }),
+      };
+    case "invalid": {
+      return {
+        boxShadow: getBoxShadowString({
+          borderColor: "brightRed",
+          borderWidth: 2,
+        }),
+      };
+    }
+    case "default":
+    default:
+      return {
+        boxShadow: getBoxShadowString({
+          borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
+        }),
+      };
+  }
+}


### PR DESCRIPTION
## Background
Closes #873 

## Solution
I've added a proposal on how we can be more consistant with our theming by providing a set of utility-functions.
For now, I've used them just in InfoSelect, but if this is accepted, these should be widely adopted. Otherwise, there's no point.

I'd like your feedback on the matter @ithen15  and @selbekk .


Otherwise, here's screenshot and video of interactivity. @perweum Maybe you could take a lot on those?



https://github.com/nsbno/spor/assets/3692249/7e0c3f21-220e-4c88-a0e8-3124e3b71368

![Screenshot 2023-10-16 at 13 06 50](https://github.com/nsbno/spor/assets/3692249/1d2c63d7-3497-46da-a3d3-2f868082f8ce)
![Screenshot 2023-10-16 at 13 06 40](https://github.com/nsbno/spor/assets/3692249/ea27100d-c658-4831-9c63-a76049893e5c)
