### PR TITLE
Add stepSize to NumericStepper

### DIFF
--- a/.changeset/rare-parrots-float.md
+++ b/.changeset/rare-parrots-float.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+NumericStepper: Add two new props – `stepSize` (which sets the number to increment at a time) and `showZero` ( which decides whether you should show the digit 0 when the count is 0)

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -83,13 +83,14 @@ export function NumericStepper({
   const textColor = useColorModeValue("darkGrey", "white");
   const backgroundColor = useColorModeValue("white", "darkGrey");
   const focusColor = useColorModeValue("greenHaze", "azure");
+  const clampedStepSize = Math.max(Math.min(stepSize, 10), 1);
 
   return (
     <Flex alignItems="center" {...boxProps}>
       <VerySmallButton
-        icon={<SubtractIcon color="white" />}
-        aria-label={t(texts.decrementButtonAriaLabel(stepSize))}
-        onClick={() => onChange(Math.max(value - stepSize, minValue))}
+        icon={<SubtractIcon color="white" stepLabel={clampedStepSize} />}
+        aria-label={t(texts.decrementButtonAriaLabel(clampedStepSize))}
+        onClick={() => onChange(Math.max(value - clampedStepSize, minValue))}
         visibility={value <= minValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
       />
@@ -104,7 +105,7 @@ export function NumericStepper({
           id={value !== 0 ? formControlProps.id : undefined}
           fontSize="sm"
           fontWeight="bold"
-          width="3ch"
+          width={`${Math.max(value.toString().length + 1, 3)}ch`}
           marginX={1}
           paddingX={1}
           borderRadius="xs"
@@ -159,9 +160,9 @@ export function NumericStepper({
         </chakra.text>
       )}
       <VerySmallButton
-        icon={<AddIcon color="white" />}
-        aria-label={t(texts.incrementButtonAriaLabel(stepSize))}
-        onClick={() => onChange(Math.min(value + stepSize, maxValue))}
+        icon={<AddIcon color="white" stepLabel={clampedStepSize} />}
+        aria-label={t(texts.incrementButtonAriaLabel(clampedStepSize))}
+        onClick={() => onChange(Math.min(value + clampedStepSize, maxValue))}
         visibility={value >= maxValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
         id={value === 0 ? formControlProps.id : undefined}
@@ -204,52 +205,63 @@ const VerySmallButton = (props: VerySmallButtonProps) => {
   );
 };
 
-const SubtractIcon = (props: BoxProps) => (
-  <Box
-    as="svg"
-    viewBox="0 0 30 30"
-    width="24"
-    height="24"
-    stroke="currentColor"
-    {...props}
-  >
-    <line
-      x1="9"
-      y1="15"
-      x2="21"
-      y2="15"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-  </Box>
+const SubtractIcon = (props: BoxProps & { stepLabel: number }) => (
+  <>
+    <Box
+      as="svg"
+      viewBox="0 0 30 30"
+      width="24"
+      height="24"
+      stroke="currentColor"
+      {...props}
+    >
+      <line
+        x1="9"
+        y1="15"
+        x2="21"
+        y2="15"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </Box>
+    {props.stepLabel > 1 && (
+      <chakra.text paddingRight="1">{props.stepLabel.toString()}</chakra.text>
+    )}
+  </>
 );
 
-const AddIcon = (props: BoxProps) => (
-  <Box
-    as="svg"
-    viewBox="0 0 30 30"
-    width="24"
-    height="24"
-    stroke="currentColor"
-    {...props}
-  >
-    <line
-      x1="9"
-      y1="15"
-      x2="21"
-      y2="15"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="15"
-      y1="9"
-      x2="15"
-      y2="21"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-  </Box>
+const AddIcon = (props: BoxProps & { stepLabel: number }) => (
+  <>
+    <Box
+      as="svg"
+      viewBox="0 0 30 30"
+      width="24"
+      height="24"
+      stroke="currentColor"
+      {...props}
+    >
+      <line
+        x1="9"
+        y1="15"
+        x2="21"
+        y2="15"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <line
+        x1="15"
+        y1="9"
+        x2="15"
+        y2="21"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </Box>
+
+    {props.stepLabel > 1 && (
+      <chakra.text paddingRight="1">{props.stepLabel.toString()}</chakra.text>
+    )}
+  </>
 );
 
 const texts = createTexts({

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -35,6 +35,8 @@ type NumericStepperProps = {
   withInput?: boolean;
   /** The amount to increase/decrease when pressing +/- */
   stepSize?: number;
+  /** Whether to show the number input when value is zero  */
+  showZero?: boolean;
 } & Omit<BoxProps, "onChange">;
 /** A simple stepper component for integer values
  *
@@ -71,6 +73,7 @@ export function NumericStepper({
   isDisabled,
   withInput = true,
   stepSize = 1,
+  showZero = false,
   ...boxProps
 }: NumericStepperProps) {
   const { t } = useTranslation();
@@ -93,6 +96,7 @@ export function NumericStepper({
         onClick={() => onChange(Math.max(value - clampedStepSize, minValue))}
         visibility={value <= minValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
+        id={value <= minValue ? undefined : formControlProps.id}
       />
       {withInput ? (
         <chakra.input
@@ -102,7 +106,7 @@ export function NumericStepper({
           name={nameProp}
           value={value}
           {...formControlProps}
-          id={value !== 0 ? formControlProps.id : undefined}
+          id={!showZero && value === 0 ? undefined : formControlProps.id}
           fontSize="sm"
           fontWeight="bold"
           width={`${Math.max(value.toString().length + 1, 3)}ch`}
@@ -113,7 +117,7 @@ export function NumericStepper({
           backgroundColor={backgroundColor}
           color={textColor}
           transition="box-shadow .1s ease-out"
-          visibility={value === 0 ? "hidden" : "visible"}
+          visibility={!showZero && value === 0 ? "hidden" : "visible"}
           aria-live="assertive"
           aria-label={value.toString()}
           _hover={{
@@ -140,7 +144,7 @@ export function NumericStepper({
             if (Number.isNaN(numericInput)) {
               return;
             }
-            onChange(numericInput);
+            onChange(Math.max(Math.min(numericInput, maxValue), minValue));
           }}
         />
       ) : (
@@ -153,7 +157,7 @@ export function NumericStepper({
           textAlign="center"
           color={textColor}
           transition="box-shadow .1s ease-out"
-          visibility={value === 0 ? "hidden" : "visible"}
+          visibility={!showZero && value === 0 ? "hidden" : "visible"}
           aria-label={value.toString()}
         >
           {value}
@@ -165,7 +169,7 @@ export function NumericStepper({
         onClick={() => onChange(Math.min(value + clampedStepSize, maxValue))}
         visibility={value >= maxValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
-        id={value === 0 ? formControlProps.id : undefined}
+        id={value >= maxValue ? undefined : formControlProps.id}
       />
     </Flex>
   );
@@ -225,7 +229,7 @@ const SubtractIcon = (props: BoxProps & { stepLabel: number }) => (
       />
     </Box>
     {props.stepLabel > 1 && (
-      <chakra.text paddingRight="1">{props.stepLabel.toString()}</chakra.text>
+      <chakra.span paddingRight="1">{props.stepLabel.toString()}</chakra.span>
     )}
   </>
 );
@@ -259,7 +263,7 @@ const AddIcon = (props: BoxProps & { stepLabel: number }) => (
     </Box>
 
     {props.stepLabel > 1 && (
-      <chakra.text paddingRight="1">{props.stepLabel.toString()}</chakra.text>
+      <chakra.span paddingRight="1">{props.stepLabel.toString()}</chakra.span>
     )}
   </>
 );

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -88,7 +88,7 @@ export function NumericStepper({
     <Flex alignItems="center" {...boxProps}>
       <VerySmallButton
         icon={<SubtractIcon color="white" />}
-        aria-label={t(texts(stepSize).decrementButtonAriaLabel)}
+        aria-label={t(texts.decrementButtonAriaLabel(stepSize))}
         onClick={() => onChange(Math.max(value - stepSize, minValue))}
         visibility={value <= minValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
@@ -160,7 +160,7 @@ export function NumericStepper({
       )}
       <VerySmallButton
         icon={<AddIcon color="white" />}
-        aria-label={t(texts(stepSize).incrementButtonAriaLabel)}
+        aria-label={t(texts.incrementButtonAriaLabel(stepSize))}
         onClick={() => onChange(Math.min(value + stepSize, maxValue))}
         visibility={value >= maxValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
@@ -252,18 +252,21 @@ const AddIcon = (props: BoxProps) => (
   </Box>
 );
 
-const texts = (stepSize: number) =>
-  createTexts({
-    decrementButtonAriaLabel: {
+const texts = createTexts({
+  decrementButtonAriaLabel(stepSize) {
+    return {
       nb: `Trekk fra ${stepSize}`,
       en: `Subtract ${stepSize}`,
       nn: `Trekk frå ${stepSize}`,
       sv: `Subtrahera ${stepSize}`,
-    },
-    incrementButtonAriaLabel: {
+    };
+  },
+  incrementButtonAriaLabel(stepSize) {
+    return {
       nb: `Legg til ${stepSize}`,
       en: `Add ${stepSize}`,
       nn: `Legg til ${stepSize}`,
       sv: `Lägg till ${stepSize}`,
-    },
-  });
+    };
+  },
+});

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -33,6 +33,8 @@ type NumericStepperProps = {
   isDisabled?: boolean;
   /** Whether to show input field or not */
   withInput?: boolean;
+  /** The amount to increase/decrease when pressing +/- */
+  stepSize?: number;
 } & Omit<BoxProps, "onChange">;
 /** A simple stepper component for integer values
  *
@@ -43,10 +45,10 @@ type NumericStepperProps = {
  * <NumericStepper value={value} onChange={setValue} />
  * ```
  *
- * You can also set a minimum and/or maximum value:
+ * You can also set a minimum and/or maximum value and step size:
  *
  * ```tsx
- * <NumericStepper value={value} onChange={setValue} minValue={1} maxValue={10} />
+ * <NumericStepper value={value} onChange={setValue} minValue={1} maxValue={10} stepSize={3} />
  * ```
  *
  * You can use the NumericStepper inside of a FormControl component to get IDs etc linked up automatically:
@@ -68,6 +70,7 @@ export function NumericStepper({
   maxValue = 99,
   isDisabled,
   withInput = true,
+  stepSize = 1,
   ...boxProps
 }: NumericStepperProps) {
   const { t } = useTranslation();
@@ -85,8 +88,8 @@ export function NumericStepper({
     <Flex alignItems="center" {...boxProps}>
       <VerySmallButton
         icon={<SubtractIcon color="white" />}
-        aria-label={t(texts.decrementButtonAriaLabel)}
-        onClick={() => onChange(value - 1)}
+        aria-label={t(texts(stepSize).decrementButtonAriaLabel)}
+        onClick={() => onChange(Math.max(value - stepSize, minValue))}
         visibility={value <= minValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
       />
@@ -157,8 +160,8 @@ export function NumericStepper({
       )}
       <VerySmallButton
         icon={<AddIcon color="white" />}
-        aria-label={t(texts.incrementButtonAriaLabel)}
-        onClick={() => onChange(value + 1)}
+        aria-label={t(texts(stepSize).incrementButtonAriaLabel)}
+        onClick={() => onChange(Math.min(value + stepSize, maxValue))}
         visibility={value >= maxValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
         id={value === 0 ? formControlProps.id : undefined}
@@ -249,17 +252,18 @@ const AddIcon = (props: BoxProps) => (
   </Box>
 );
 
-const texts = createTexts({
-  decrementButtonAriaLabel: {
-    nb: "Trekk fra 1",
-    en: "Subtract 1",
-    nn: "Trekk frå 1",
-    sv: "Subtrahera 1",
-  },
-  incrementButtonAriaLabel: {
-    nb: "Legg til 1",
-    en: "Add 1",
-    nn: "Legg til 1",
-    sv: "Lägg till 1",
-  },
-});
+const texts = (stepSize: number) =>
+  createTexts({
+    decrementButtonAriaLabel: {
+      nb: `Trekk fra ${stepSize}`,
+      en: `Subtract ${stepSize}`,
+      nn: `Trekk frå ${stepSize}`,
+      sv: `Subtrahera ${stepSize}`,
+    },
+    incrementButtonAriaLabel: {
+      nb: `Legg til ${stepSize}`,
+      en: `Add ${stepSize}`,
+      nn: `Legg til ${stepSize}`,
+      sv: `Lägg till ${stepSize}`,
+    },
+  });


### PR DESCRIPTION
## Background

Dette er ett slags forslag/feature-request.

Ser at det hadde vært nice med mulighet for større steg (+3, +5, osv.) noen steder vi bruker NumericStepper i Drops Dashboard. Prøvde først å hacke det inn via onChange metoden, men aria-labels blir fort misvisende. Det bør nok tas en runde på om det er riktig å utvide komponenten eller lage en egen. Det hadde jo vært nice om +/- knappene kunne vise hvor mye de endrer med for eksempel. Kunne også vært nice å støtte flere stepsizes samtidig.

## Solution
* Har lagt til `stepSize`-variabelen, den defaulter til 1. 
* Har oppdatert change metoden til å respektere `stepSize` og tatt høyde for `maxValue` og `minValue`