### PR TITLE
Darkmode info tag

### DIFF
--- a/.changeset/tame-terms-admire.md
+++ b/.changeset/tame-terms-admire.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+InfoTag: Add dark mode support

--- a/packages/spor-design-tokens/tokens/color/linjetag.json
+++ b/packages/spor-design-tokens/tokens/color/linjetag.json
@@ -38,7 +38,7 @@
         "value": "#E5F4F1"
       },
       "lokalbuss": {
-        "value": "#2B2B2C"
+        "value": "#606568"
       },
       "lokalbussLight": {
         "value": "#EBEBEC"

--- a/packages/spor-react/src/theme/components/info-tag.ts
+++ b/packages/spor-react/src/theme/components/info-tag.ts
@@ -1,5 +1,5 @@
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import { anatomy } from "@chakra-ui/theme-tools";
+import { StyleFunctionProps, anatomy, mode } from "@chakra-ui/theme-tools";
 import travelTagStyles from "./travel-tag";
 
 const parts = anatomy("info-tag").parts(
@@ -19,6 +19,9 @@ const config = helpers.defineMultiStyleConfig({
     iconContainer: {
       ...travelTagStyles.baseStyle!(props).iconContainer,
       padding: 1,
+    },
+    textContainer: {
+      color: mode("darkGrey", "white")(props),
     },
   }),
   sizes: {
@@ -45,5 +48,34 @@ const config = helpers.defineMultiStyleConfig({
   defaultProps: {
     size: "md",
   },
+  variants: {
+    "local-bus": (props)  => ({
+      iconContainer: {
+        color: "red",
+        boxShadow: mode(
+          `${props.theme.shadows.md}, inset 0 0 0 2px ${props.theme.colors.black}`, 
+          `${props.theme.shadows.md}, inset 0 0 0 2px ${props.theme.colors.whiteAlpha[400]}`
+          )(props),
+      },
+    }),
+    "walk": (props)  => ({
+      container: {
+        backgroundColor: "white",
+      },
+      iconContainer: {
+        backgroundColor: mode("white", "red")(props),
+        color: "white",
+        boxShadow: mode(
+          `${props.theme.shadows.md}, inset 0 0 0 2px ${props.theme.colors.black[200]}`, 
+          `${props.theme.shadows.md}, inset 0 0 0 2px ${props.theme.colors.whiteAlpha[400]}`
+          )(props),
+        img: "red"
+      },
+    }),
+  }
 });
 export default config;
+function getDeviationContainerStyle(props: StyleFunctionProps): any {
+  throw new Error("Function not implemented.");
+}
+

--- a/packages/spor-react/src/theme/components/info-tag.ts
+++ b/packages/spor-react/src/theme/components/info-tag.ts
@@ -48,28 +48,14 @@ const config = helpers.defineMultiStyleConfig({
   defaultProps: {
     size: "md",
   },
-  variants: {
-    "local-bus": (props)  => ({
-      iconContainer: {
-        color: "red",
-        boxShadow: mode(
-          `${props.theme.shadows.md}, inset 0 0 0 2px ${props.theme.colors.black}`, 
-          `${props.theme.shadows.md}, inset 0 0 0 2px ${props.theme.colors.whiteAlpha[400]}`
-          )(props),
-      },
-    }),
+ variants: {
     "walk": (props)  => ({
-      container: {
-        backgroundColor: "white",
-      },
       iconContainer: {
-        backgroundColor: mode("white", "red")(props),
-        color: "white",
+        backgroundColor: mode("white", "transparent")(props),
         boxShadow: mode(
           `${props.theme.shadows.md}, inset 0 0 0 2px ${props.theme.colors.black[200]}`, 
           `${props.theme.shadows.md}, inset 0 0 0 2px ${props.theme.colors.whiteAlpha[400]}`
           )(props),
-        img: "red"
       },
     }),
   }

--- a/packages/spor-react/src/theme/components/line-icon.ts
+++ b/packages/spor-react/src/theme/components/line-icon.ts
@@ -1,5 +1,5 @@
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import { anatomy } from "@chakra-ui/theme-tools";
+import { anatomy, mode } from "@chakra-ui/theme-tools";
 
 const parts = anatomy("line-tag").parts("iconContainer", "icon");
 const helpers = createMultiStyleConfigHelpers(parts.keys);
@@ -78,7 +78,7 @@ const config = helpers.defineMultiStyleConfig({
       },
     },
 
-    walk: {
+    walk: (props)  => ({
       iconContainer: {
         backgroundColor: "white",
         borderWidth: 1,
@@ -86,12 +86,12 @@ const config = helpers.defineMultiStyleConfig({
         borderColor: "blackAlpha.200",
       },
       icon: {
-        color: "darkGrey",
+        color: mode("darkGrey", "white")(props),
         "[aria-disabled=true] &": {
           color: "osloGrey",
         },
       },
-    },
+    }),
   },
   sizes: {
     sm: {


### PR DESCRIPTION
## Background
certain icons did not work visuably in dark mode

## Solution
changed "lokalbuss" default color to be compatible with light & dark mode, and added a dark mode version for "walk"
