### PR TITLE
Make buttons break on several lines if required

### DIFF
--- a/.changeset/twenty-bulldogs-compare.md
+++ b/.changeset/twenty-bulldogs-compare.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Button: Make buttons break on several lines if there isn't space

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -126,7 +126,13 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
           />
         </Center>
       )}
-      <Box visibility={isLoading ? "hidden" : "visible"}>{children}</Box>
+      <Box
+        visibility={isLoading ? "hidden" : "visible"}
+        whiteSpace="normal"
+        textAlign="left"
+      >
+        {children}
+      </Box>
     </ChakraButton>
   );
 });

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -11,7 +11,9 @@ const config = defineStyleConfig({
     fontWeight: "bold",
     transitionProperty: "common",
     transitionDuration: "normal",
-    px: 3,
+    textWrap: "wrap",
+    paddingX: 3,
+    paddingY: 1,
     _focus: {
       boxShadow: 0,
       outline: 0,
@@ -36,7 +38,7 @@ const config = defineStyleConfig({
         focus: {
           boxShadow: `inset 0 0 0 4px ${mode(
             colors.darkTeal,
-            colors.seaMist,
+            colors.seaMist
           )(props)}, inset 0 0 0 6px currentColor`,
         },
         notFocus: { boxShadow: "none" },
@@ -57,10 +59,10 @@ const config = defineStyleConfig({
         focus: {
           boxShadow: `inset 0 0 0 2px ${mode(
             colors.greenHaze,
-            colors.azure,
+            colors.azure
           )(props)}, inset 0 0 0 4px ${mode(
             colors.white,
-            colors.darkGrey,
+            colors.darkGrey
           )(props)}`,
         },
         notFocus: { boxShadow: "none" },
@@ -84,18 +86,18 @@ const config = defineStyleConfig({
         focus: {
           boxShadow: `inset 0 0 0 2px ${mode(
             colors.greenHaze,
-            colors.azure,
+            colors.azure
           )(props)}, inset 0 0 0 4px ${mode(
             colors.white,
-            colors.blackAlpha[300],
+            colors.blackAlpha[300]
           )(props)}`,
           _hover: {
             boxShadow: `inset 0 0 0 2px ${mode(
               colors.greenHaze,
-              colors.azure,
+              colors.azure
             )(props)}, inset 0 0 0 4px ${mode(
               colors.white,
-              colors.blackAlpha[500],
+              colors.blackAlpha[500]
             )(props)}`,
           },
         },
@@ -107,18 +109,18 @@ const config = defineStyleConfig({
         backgroundColor: mode("mint", "whiteAlpha.300")(props),
         boxShadow: `inset 0 0 0 2px ${mode(
           colors.greenHaze,
-          colors.azure,
+          colors.azure
         )(props)}, inset 0 0 0 4px ${mode(
           colors.white,
-          colors.blackAlpha[600],
+          colors.blackAlpha[600]
         )(props)}`,
         _hover: {
           boxShadow: `inset 0 0 0 2px ${mode(
             colors.greenHaze,
-            colors.azure,
+            colors.azure
           )(props)}, inset 0 0 0 4px ${mode(
             colors.white,
-            colors.blackAlpha[600],
+            colors.blackAlpha[600]
           )(props)}`,
         },
       },
@@ -149,7 +151,7 @@ const config = defineStyleConfig({
       fontWeight: "normal",
       boxShadow: `inset 0 0 0 1px ${mode(
         colors.blackAlpha[400],
-        colors.whiteAlpha[400],
+        colors.whiteAlpha[400]
       )(props)}`,
       ...focusVisible({
         focus: {
@@ -161,7 +163,7 @@ const config = defineStyleConfig({
         notFocus: {
           boxShadow: `inset 0 0 0 1px ${mode(
             colors.blackAlpha[400],
-            colors.whiteAlpha[400],
+            colors.whiteAlpha[400]
           )(props)}`,
         },
       }),
@@ -171,7 +173,7 @@ const config = defineStyleConfig({
       _active: {
         boxShadow: `inset 0 0 0 1px ${mode(
           colors.blackAlpha[400],
-          colors.whiteAlpha[300],
+          colors.whiteAlpha[300]
         )(props)}`,
         backgroundColor: mode("mint", "whiteAlpha.200")(props),
       },
@@ -260,7 +262,7 @@ const config = defineStyleConfig({
       minHeight: 5,
       minWidth: 5,
       fontSize: "16px",
-      px: 2,
+      paddingX: 2,
     },
   },
   defaultProps: {


### PR DESCRIPTION
## Background
When the button text gets too long to fit in its container, it currently overflows outside of its container. That's not a good look.

## Solution
Make the button text wrap to another line. It's not optimal, but it's better than the alternative. When the text breaks, the text is left-aligned.

<img width="350" alt="image" src="https://github.com/nsbno/spor/assets/1307267/c239818d-429d-4722-8bdd-b130dad6bf1c">
<img width="359" alt="image" src="https://github.com/nsbno/spor/assets/1307267/3ab2a3c2-6baa-496d-bcad-6896b85ed193">
