### PR TITLE
Darkmode datepicker

### DIFF
--- a/.changeset/kind-taxis-cough.md
+++ b/.changeset/kind-taxis-cough.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": patch
----
-
-Tabs: changed from default to base

--- a/.changeset/neat-swans-shave.md
+++ b/.changeset/neat-swans-shave.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": patch
----
-
-travelTag: add support for dark mode

--- a/.changeset/neat-swans-shave.md
+++ b/.changeset/neat-swans-shave.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+travelTag: add support for dark mode

--- a/.changeset/nice-panthers-smoke.md
+++ b/.changeset/nice-panthers-smoke.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+DatePicker: add new variations and dark mode

--- a/.changeset/nice-panthers-smoke.md
+++ b/.changeset/nice-panthers-smoke.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-react": patch
 ---
 
-DatePicker: add new variations and dark mode
+DatePicker: add new variations, dark mode and deprecated some old designs

--- a/.changeset/rare-parrots-float.md
+++ b/.changeset/rare-parrots-float.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+NumericStepper: Add two new props – `stepSize` (which sets the number to increment at a time) and `showZero` ( which decides whether you should show the digit 0 when the count is 0)

--- a/.changeset/sharp-spiders-do.md
+++ b/.changeset/sharp-spiders-do.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": patch
----
-
-Tabs: Update variants and design for tabs

--- a/.changeset/silver-items-train.md
+++ b/.changeset/silver-items-train.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": patch
----
-
-Card: Add dark mode support

--- a/.changeset/tame-terms-admire.md
+++ b/.changeset/tame-terms-admire.md
@@ -1,6 +1,0 @@
----
-"@vygruppen/spor-react": patch
-"@vygruppen/spor-design-tokens": patch
----
-Design tokens: Change the color for lokalbuss
-InfoTag: Add dark mode support

--- a/.changeset/tasty-feet-decide.md
+++ b/.changeset/tasty-feet-decide.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": patch
----
-
-Link: Add dark mode support

--- a/.changeset/twenty-bulldogs-compare.md
+++ b/.changeset/twenty-bulldogs-compare.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Button: Make buttons break on several lines if there isn't space

--- a/.changeset/twenty-bulldogs-compare.md
+++ b/.changeset/twenty-bulldogs-compare.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": patch
----
-
-Button: Make buttons break on several lines if there isn't space

--- a/.changeset/wise-worms-complain.md
+++ b/.changeset/wise-worms-complain.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": patch
----
-
-Fab:Add dark mode support

--- a/packages/spor-design-tokens/CHANGELOG.md
+++ b/packages/spor-design-tokens/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.2.1
+
+### Patch Changes
+
+- 4c078f92: Design tokens: Change the color for lokalbuss
+  InfoTag: Add dark mode support
+
 ## 3.2.0
 
 ### Minor Changes

--- a/packages/spor-design-tokens/package.json
+++ b/packages/spor-design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vygruppen/spor-design-tokens",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "All Vy's design tokens",
   "homepage": "https://github.com/nsbno/spor/tree/main/packages/spor-card-react",
   "repository": {

--- a/packages/spor-react/CHANGELOG.md
+++ b/packages/spor-react/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @vygruppen/spor-react
 
+## 3.7.7
+
+### Patch Changes
+
+- 2ffdd3b7: Tabs: changed from default to base
+- d12c315d: travelTag: add support for dark mode
+- b6884fa6: Tabs: Update variants and design for tabs
+- fb6605c6: Card: Add dark mode support
+- 4c078f92: Design tokens: Change the color for lokalbuss
+  InfoTag: Add dark mode support
+- eaf12b4b: Link: Add dark mode support
+- e103af4b: Button: Make buttons break on several lines if there isn't space
+- bc846dd5: Fab:Add dark mode support
+- Updated dependencies [4c078f92]
+  - @vygruppen/spor-design-tokens@3.2.1
+
 ## 3.7.6
 
 ### Patch Changes

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vygruppen/spor-react",
-  "version": "3.7.6",
+  "version": "3.7.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -126,7 +126,13 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
           />
         </Center>
       )}
-      <Box visibility={isLoading ? "hidden" : "visible"}>{children}</Box>
+      <Box
+        visibility={isLoading ? "hidden" : "visible"}
+        whiteSpace="normal"
+        textAlign="left"
+      >
+        {children}
+      </Box>
     </ChakraButton>
   );
 });

--- a/packages/spor-react/src/datepicker/Calendar.tsx
+++ b/packages/spor-react/src/datepicker/Calendar.tsx
@@ -14,9 +14,7 @@ import { createTexts, useTranslation } from "../i18n";
 type CalendarProps = ReactAriaCalendarProps<DateValue> & {
   showYearNavigation?: boolean;
   variant: ResponsiveValue<
-  "simple" 
-  | "with-trigger" 
-  | "base" 
+   "base"
   | "floating"
   | "ghost"
   >;

--- a/packages/spor-react/src/datepicker/Calendar.tsx
+++ b/packages/spor-react/src/datepicker/Calendar.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@chakra-ui/react";
+import { Box, ResponsiveValue } from "@chakra-ui/react";
 import { createCalendar, DateValue } from "@internationalized/date";
 import { useCalendarState } from "@react-stately/calendar";
 import React from "react";
@@ -13,8 +13,15 @@ import { createTexts, useTranslation } from "../i18n";
 
 type CalendarProps = ReactAriaCalendarProps<DateValue> & {
   showYearNavigation?: boolean;
+  variant: ResponsiveValue<
+  "simple" 
+  | "with-trigger" 
+  | "base" 
+  | "floating"
+  | "ghost"
+  >;
 };
-export function Calendar({ showYearNavigation, ...props }: CalendarProps) {
+export function Calendar({ showYearNavigation, variant, ...props }: CalendarProps) {
   const { t } = useTranslation();
   const locale = useCurrentLocale();
   const state = useCalendarState({
@@ -32,7 +39,7 @@ export function Calendar({ showYearNavigation, ...props }: CalendarProps) {
   return (
     <Box {...calendarProps} aria-label={ariaLabel}>
       <CalendarHeader state={state} showYearNavigation={showYearNavigation} />
-      <CalendarGrid state={state} />
+      <CalendarGrid variant={variant} state={state} />
     </Box>
   );
 }

--- a/packages/spor-react/src/datepicker/CalendarCell.tsx
+++ b/packages/spor-react/src/datepicker/CalendarCell.tsx
@@ -11,9 +11,7 @@ import { CalendarState, RangeCalendarState } from "react-stately";
 
 type CalendarCellProps = {
   variant: ResponsiveValue<
-  "simple" 
-  | "with-trigger" 
-  | "base" 
+    "base" 
   | "floating"
   | "ghost"
   >;

--- a/packages/spor-react/src/datepicker/CalendarCell.tsx
+++ b/packages/spor-react/src/datepicker/CalendarCell.tsx
@@ -1,4 +1,4 @@
-import { Box, useMultiStyleConfig } from "@chakra-ui/react";
+import { Box, ResponsiveValue, useMultiStyleConfig } from "@chakra-ui/react";
 import {
   CalendarDate,
   DateValue,
@@ -10,11 +10,18 @@ import { useCalendarCell } from "react-aria";
 import { CalendarState, RangeCalendarState } from "react-stately";
 
 type CalendarCellProps = {
+  variant: ResponsiveValue<
+  "simple" 
+  | "with-trigger" 
+  | "base" 
+  | "floating"
+  | "ghost"
+  >;
   state: CalendarState | RangeCalendarState;
   date: CalendarDate;
   currentMonth: DateValue;
 };
-export function CalendarCell({ state, date, currentMonth }: CalendarCellProps) {
+export function CalendarCell({ state, date, currentMonth, variant }: CalendarCellProps) {
   const ref = useRef(null);
   const {
     cellProps,
@@ -26,7 +33,7 @@ export function CalendarCell({ state, date, currentMonth }: CalendarCellProps) {
   } = useCalendarCell({ date }, state, ref);
 
   const isOutsideMonth = !isSameMonth(currentMonth, date);
-  const styles = useMultiStyleConfig("Datepicker", {});
+  const styles = useMultiStyleConfig("Datepicker", {variant});
 
   const stateProps: Record<string, any> = {};
   if (isSelected) {

--- a/packages/spor-react/src/datepicker/CalendarGrid.tsx
+++ b/packages/spor-react/src/datepicker/CalendarGrid.tsx
@@ -6,7 +6,7 @@ import { Language, useTranslation } from "../i18n";
 import { Text } from "../typography";
 import { CalendarCell } from "./CalendarCell";
 import { useCurrentLocale } from "./utils";
-import { useMultiStyleConfig } from "@chakra-ui/react";
+import { ResponsiveValue, useMultiStyleConfig } from "@chakra-ui/react";
 
 const weekDays: Record<Language, string[]> = {
   nb: ["Ma", "Ti", "On", "To", "Fr", "Lø", "Sø"],
@@ -16,10 +16,17 @@ const weekDays: Record<Language, string[]> = {
 };
 
 type CalendarGridProps = AriaCalendarGridProps & {
+  variant: ResponsiveValue<
+  "simple" 
+  | "with-trigger" 
+  | "base" 
+  | "floating"
+  | "ghost"
+  >;
   state: CalendarState | RangeCalendarState;
   offset?: { months?: number };
 };
-export function CalendarGrid({ state, offset = {} }: CalendarGridProps) {
+export function CalendarGrid({ state, variant ,offset = {} }: CalendarGridProps) {
   const { language } = useTranslation();
   const locale = useCurrentLocale();
   const startDate = state.visibleRange.start.add(offset);
@@ -35,7 +42,7 @@ export function CalendarGrid({ state, offset = {} }: CalendarGridProps) {
   // Get the number of weeks in the month so we can render the proper number of rows.
   const weeksInMonth = getWeeksInMonth(state.visibleRange.start, locale);
   const weeksInMonthRange = new Array(weeksInMonth).fill(0).map((_, i) => i);
-  const styles = useMultiStyleConfig("Datepicker", {});
+  const styles = useMultiStyleConfig("Datepicker", {variant});
 
   return (
     <table {...gridProps}>
@@ -63,6 +70,7 @@ export function CalendarGrid({ state, offset = {} }: CalendarGridProps) {
               .map((date, dayIndex) =>
                 date ? (
                   <CalendarCell
+                    variant={variant}
                     key={dayIndex}
                     state={state}
                     date={date}

--- a/packages/spor-react/src/datepicker/CalendarGrid.tsx
+++ b/packages/spor-react/src/datepicker/CalendarGrid.tsx
@@ -17,9 +17,7 @@ const weekDays: Record<Language, string[]> = {
 
 type CalendarGridProps = AriaCalendarGridProps & {
   variant: ResponsiveValue<
-  "simple" 
-  | "with-trigger" 
-  | "base" 
+   "base" 
   | "floating"
   | "ghost"
   >;

--- a/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
+++ b/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
@@ -13,9 +13,7 @@ import { createTexts, useTranslation } from "..";
 
 type CalendarTriggerButtonProps = AriaButtonProps<"button"> & {
   variant: ResponsiveValue<
-    "simple" 
-    | "with-trigger" 
-    | "base" 
+     "base" 
     | "floating" 
     | "ghost"
   >;

--- a/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
+++ b/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
@@ -4,17 +4,26 @@ import {
   useMultiStyleConfig,
   forwardRef,
   As,
+  ResponsiveValue,
 } from "@chakra-ui/react";
 import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
 import React, { useEffect } from "react";
 import { AriaButtonProps } from "react-aria";
 import { createTexts, useTranslation } from "..";
 
-type CalendarTriggerButtonProps = AriaButtonProps<"button">;
+type CalendarTriggerButtonProps = AriaButtonProps<"button"> & {
+  variant: ResponsiveValue<
+    "simple" 
+    | "with-trigger" 
+    | "base" 
+    | "floating" 
+    | "ghost"
+  >;
+};
 export const CalendarTriggerButton = forwardRef<CalendarTriggerButtonProps, As>(
-  ({ ...buttonProps }, ref) => {
+  ({ variant, ...buttonProps }, ref) => {
     const { t } = useTranslation();
-    const styles = useMultiStyleConfig("Datepicker", {});
+    const styles = useMultiStyleConfig("Datepicker", {variant});
 
     const { onPress, ...filteredButtonProps } = buttonProps;
 

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -38,6 +38,16 @@ type DatePickerProps = AriaDatePickerProps<DateValue> &
     withPortal?: boolean;
   };
 
+/**
+ * A date picker component.
+ *
+ * There are two versions of this component – a simple one, and one with a trigger button for showing the calendar. Use whatever fits your design.
+ *
+ * ```tsx
+ * <DatePicker label="Dato" variant="simple" />
+ * ```
+ */
+
 export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
   (
     {
@@ -78,10 +88,6 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
     const styles = useMultiStyleConfig("Datepicker", { variant });
     const locale = useCurrentLocale();
 
-    // if (variant == "with-trigger" || "simple") {
-      
-    // }
-
     const onFieldClick = () => {
       state.setOpen(true);
     };
@@ -110,8 +116,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             onOpen={state.open}
             onClose={state.close}
           >
-            <InputGroup {...groupProps} display="inline-flex">
-             
+            <InputGroup {...groupProps} display="inline-flex">             
               <PopoverAnchor>
                 <StyledField
                   variant={variant}
@@ -119,11 +124,9 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                   paddingX={3}
                   minHeight={minHeight}
                 >
-                   {variant && (
-                <PopoverTrigger>
-                  <CalendarTriggerButton variant={variant} ref={ref} {...buttonProps} />
-                </PopoverTrigger>
-              )}
+                  <PopoverTrigger>
+                    <CalendarTriggerButton variant={variant} ref={ref} {...buttonProps} />
+                  </PopoverTrigger>
                   <DateField
                     label={props.label}
                     labelProps={labelProps}

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -151,7 +151,6 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                   />
                 </StyledField>
               </PopoverAnchor>
-           
             </InputGroup>
             <FormErrorMessage {...errorMessageProps}>
               {errorMessage}

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -90,13 +90,17 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       ref as React.MutableRefObject<HTMLDivElement>
     );
 
-    const styles = useMultiStyleConfig("Datepicker", {});
+    const styles = useMultiStyleConfig("Datepicker", {variant});
     const locale = useCurrentLocale();
 
     const responsiveVariant =
       useBreakpointValue(typeof variant === "string" ? [variant] : variant) ??
       "simple";
-    const hasTrigger = responsiveVariant === "with-trigger";
+      const hasTrigger = responsiveVariant === "with-trigger" ||
+      responsiveVariant === "base" ||
+      responsiveVariant === "floating" ||
+      responsiveVariant === "ghost";
+    
 
     const onFieldClick = () => {
       if (!hasTrigger) {
@@ -111,6 +115,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
           <FocusLock>
             <Calendar
               {...calendarProps}
+              variant={variant}
               showYearNavigation={showYearNavigation}
             />
           </FocusLock>

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -36,7 +36,7 @@ type DatePickerProps = AriaDatePickerProps<DateValue> &
     variant: ResponsiveValue<
     /** @deprecated simple is deprecated please use base, floating or ghost*/ 
     "simple" 
-    /** @deprecated with-trigger is deprecated please use base, floating or ghost*/ simple" 
+    /** @deprecated with-trigger is deprecated please use base, floating or ghost*/
     | "with-trigger" 
     | "base" 
     | "floating"

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -93,11 +93,13 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
     const styles = useMultiStyleConfig("Datepicker", {variant});
     const locale = useCurrentLocale();
 
+    //deprecated
     const responsiveVariant =
       useBreakpointValue(typeof variant === "string" ? [variant] : variant) ??
       "simple";
-      const hasTrigger = responsiveVariant === "with-trigger" ||
-      responsiveVariant === "base" ||
+      const hasTrigger = responsiveVariant === "with-trigger"
+      //midlertidid løsning for å ikke lage breakingchange
+      const hasNewTrigger = responsiveVariant === "base" ||
       responsiveVariant === "floating" ||
       responsiveVariant === "ghost";
     
@@ -140,7 +142,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             <InputGroup {...groupProps} display="inline-flex">
                  {hasTrigger && (
                 <PopoverTrigger>
-                  <CalendarTriggerButton ref={ref} {...buttonProps} />
+                  <CalendarTriggerButton variant={variant} ref={ref} {...buttonProps} />
                 </PopoverTrigger>
               )}
               <PopoverAnchor>
@@ -150,7 +152,12 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                   paddingX={3}
                   minHeight={minHeight}
                 >
-                  {!hasTrigger && (
+                  {hasNewTrigger && (
+                    <PopoverTrigger>
+                      <CalendarTriggerButton variant={variant} ref={ref} {...buttonProps} />
+                    </PopoverTrigger>
+                  )}
+                  {!hasTrigger && !hasNewTrigger && (
                     <CalendarOutline24Icon marginRight={2} alignSelf="center" />
                   )}
                   <DateField

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -127,6 +127,11 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             onClose={state.close}
           >
             <InputGroup {...groupProps} display="inline-flex">
+            {hasTrigger && (
+                <PopoverTrigger>
+                  <CalendarTriggerButton ref={ref} {...buttonProps} />
+                </PopoverTrigger>
+              )}
               <PopoverAnchor>
                 <StyledField
                   variant={responsiveVariant}
@@ -146,11 +151,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                   />
                 </StyledField>
               </PopoverAnchor>
-              {hasTrigger && (
-                <PopoverTrigger>
-                  <CalendarTriggerButton ref={ref} {...buttonProps} />
-                </PopoverTrigger>
-              )}
+           
             </InputGroup>
             <FormErrorMessage {...errorMessageProps}>
               {errorMessage}

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -33,7 +33,13 @@ import { useCurrentLocale } from "./utils";
 
 type DatePickerProps = AriaDatePickerProps<DateValue> &
   Pick<BoxProps, "minHeight" | "width"> & {
-    variant: ResponsiveValue<"simple" | "with-trigger">;
+    variant: ResponsiveValue<
+    "simple" 
+    | "with-trigger" 
+    | "base" 
+    | "floating"
+    | "ghost"
+    >;
     name?: string;
     showYearNavigation?: boolean;
     withPortal?: boolean;

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -33,24 +33,12 @@ import { useCurrentLocale } from "./utils";
 
 type DatePickerProps = AriaDatePickerProps<DateValue> &
   Pick<BoxProps, "minHeight" | "width"> & {
-    variant: ResponsiveValue<
-     "base" 
-    | "floating"
-    | "ghost"
-    >;
+    variant: ResponsiveValue<"base" | "floating" | "ghost">;
     name?: string;
     showYearNavigation?: boolean;
     withPortal?: boolean;
   };
-/**
- * A date picker component.
- *
- * There are two versions of this component – a simple one, and one with a trigger button for showing the calendar. Use whatever fits your design.
- *
- * ```tsx
- * <DatePicker label="Dato" variant="simple" />
- * ```
- */
+
 export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
   (
     {
@@ -88,24 +76,15 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       ref as React.MutableRefObject<HTMLDivElement>
     );
 
-    const styles = useMultiStyleConfig("Datepicker", {variant});
+    const styles = useMultiStyleConfig("Datepicker", { variant });
     const locale = useCurrentLocale();
 
-    //deprecated
-    const responsiveVariant =
-      useBreakpointValue(typeof variant === "string" ? [variant] : variant) ??
-      "simple";
-      const hasTrigger = responsiveVariant === "with-trigger"
-      //midlertidid løsning for å ikke lage breakingchange
-      const hasNewTrigger = responsiveVariant === "base" ||
-      responsiveVariant === "floating" ||
-      responsiveVariant === "ghost";
-    
+    // if (variant == "with-trigger" || "simple") {
+      
+    // }
 
     const onFieldClick = () => {
-      if (!hasTrigger) {
-        state.setOpen(true);
-      }
+      state.setOpen(true);
     };
 
     const popoverContent = (
@@ -125,12 +104,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
 
     return (
       <I18nProvider locale={locale}>
-        <Box
-          position="relative"
-          display="inline-flex"
-          flexDirection="column"
-          width={width}
-        >
+        <Box position="relative" display="inline-flex" flexDirection="column" width={width}>
           <Popover
             {...dialogProps}
             isOpen={state.isOpen}
@@ -138,42 +112,30 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             onClose={state.close}
           >
             <InputGroup {...groupProps} display="inline-flex">
-                 {hasTrigger && (
-                <PopoverTrigger>
-                  <CalendarTriggerButton variant={variant} ref={ref} {...buttonProps} />
-                </PopoverTrigger>
-              )}
+             
               <PopoverAnchor>
                 <StyledField
-                  variant={responsiveVariant}
+                  variant={variant}
                   onClick={onFieldClick}
                   paddingX={3}
                   minHeight={minHeight}
                 >
-                  {hasNewTrigger && (
-                    <PopoverTrigger>
-                      <CalendarTriggerButton variant={variant} ref={ref} {...buttonProps} />
-                    </PopoverTrigger>
-                  )}
-                  {!hasTrigger && !hasNewTrigger && (
-                    <CalendarOutline24Icon marginRight={2} alignSelf="center" />
-                  )}
+                   {variant && (
+                <PopoverTrigger>
+                  <CalendarTriggerButton variant={variant} ref={ref} {...buttonProps} />
+                </PopoverTrigger>
+              )}
                   <DateField
                     label={props.label}
                     labelProps={labelProps}
                     name={props.name}
-                    ref={hasTrigger ? undefined : ref}
                     {...fieldProps}
                   />
                 </StyledField>
-              </PopoverAnchor> 
+              </PopoverAnchor>
             </InputGroup>
-            <FormErrorMessage {...errorMessageProps}>
-              {errorMessage}
-            </FormErrorMessage>
-            {state.isOpen && !props.isDisabled && withPortal && (
-              <Portal>{popoverContent}</Portal>
-            )}
+            <FormErrorMessage {...errorMessageProps}>{errorMessage}</FormErrorMessage>
+            {state.isOpen && !props.isDisabled && withPortal && <Portal>{popoverContent}</Portal>}
             {state.isOpen && !props.isDisabled && !withPortal && popoverContent}
           </Popover>
         </Box>

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -34,7 +34,9 @@ import { useCurrentLocale } from "./utils";
 type DatePickerProps = AriaDatePickerProps<DateValue> &
   Pick<BoxProps, "minHeight" | "width"> & {
     variant: ResponsiveValue<
+    /** @deprecated simple is deprecated please use base, floating or ghost*/ 
     "simple" 
+    /** @deprecated with-trigger is deprecated please use base, floating or ghost*/ simple" 
     | "with-trigger" 
     | "base" 
     | "floating"

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -17,7 +17,6 @@ import {
 } from "@chakra-ui/react";
 import { DateValue } from "@internationalized/date";
 import { useDatePickerState } from "@react-stately/datepicker";
-import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
 import React, { forwardRef, useRef } from "react";
 import {
   AriaDatePickerProps,

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -34,11 +34,7 @@ import { useCurrentLocale } from "./utils";
 type DatePickerProps = AriaDatePickerProps<DateValue> &
   Pick<BoxProps, "minHeight" | "width"> & {
     variant: ResponsiveValue<
-    /** @deprecated simple is deprecated please use base, floating or ghost*/ 
-    "simple" 
-    /** @deprecated with-trigger is deprecated please use base, floating or ghost*/
-    | "with-trigger" 
-    | "base" 
+     "base" 
     | "floating"
     | "ghost"
     >;

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -127,7 +127,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             onClose={state.close}
           >
             <InputGroup {...groupProps} display="inline-flex">
-            {hasTrigger && (
+                 {hasTrigger && (
                 <PopoverTrigger>
                   <CalendarTriggerButton ref={ref} {...buttonProps} />
                 </PopoverTrigger>
@@ -150,7 +150,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                     {...fieldProps}
                   />
                 </StyledField>
-              </PopoverAnchor>
+              </PopoverAnchor> 
             </InputGroup>
             <FormErrorMessage {...errorMessageProps}>
               {errorMessage}

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -81,6 +81,14 @@ export function DateRangePicker({
   const styles = useMultiStyleConfig("Datepicker", {variant});
   const locale = useCurrentLocale();
 
+  const handleEnterClick = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !state.isOpen && variant === "base") {
+      // Don't submit the form
+      e.stopPropagation();
+      state.setOpen(true);
+    }
+  };
+
   const onFieldClick = () => {
       state.setOpen(true);
   };
@@ -117,6 +125,7 @@ export function DateRangePicker({
                 paddingX={3}
                 variant={variant}
                 onClick={onFieldClick}
+                onKeyPress={handleEnterClick}
                 minHeight={minHeight}
               >
                 {variant && (

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -37,7 +37,13 @@ type DateRangePickerProps = AriaDateRangePickerProps<DateValue> &
     startName?: string;
     endLabel?: string;
     endName?: string;
-    variant: ResponsiveValue<"simple" | "with-trigger">;
+    variant: ResponsiveValue<
+    "simple" 
+    | "with-trigger" 
+    | "base" 
+    | "floating"
+    | "ghost"
+    >;
     withPortal?: boolean;
   };
 /**
@@ -99,6 +105,11 @@ export function DateRangePicker({
   };
 
   const hasTrigger = responsiveVariant === "with-trigger";
+  
+  //midlertidig løsning for å ikke lage breaking change
+  const hasNewTrigger = responsiveVariant === "base" ||
+  responsiveVariant === "floating" ||
+  responsiveVariant === "ghost";
 
   const popoverContent = (
     <PopoverContent sx={styles.calendar} boxShadow="md" maxWidth="none">
@@ -128,7 +139,7 @@ export function DateRangePicker({
           <InputGroup {...groupProps} width="auto" display="inline-flex">
           {hasTrigger && (
               <PopoverTrigger>
-                <CalendarTriggerButton ref={ref} {...buttonProps} />
+                <CalendarTriggerButton variant={variant} ref={ref} {...buttonProps} />
               </PopoverTrigger>
             )}
             <PopoverAnchor>
@@ -140,7 +151,12 @@ export function DateRangePicker({
                 onKeyPress={handleEnterClick}
                 minHeight={minHeight}
               >
-                {!hasTrigger && (
+                 {hasNewTrigger && (
+                  <PopoverTrigger>
+                    <CalendarTriggerButton paddingLeft={1} paddingRight={1} variant={variant} ref={ref} {...buttonProps} />
+                  </PopoverTrigger>
+                )}
+                {!hasTrigger && !hasNewTrigger && (
                   <CalendarOutline24Icon boxSize={8} marginRight={2} alignSelf="center" />
                 )}
                 <DateField

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -151,7 +151,7 @@ export function DateRangePicker({
                   label={props.startLabel}
                   labelProps={labelProps}
                 />
-                 <Box as="span" aria-hidden="true" marginRight="2" marginLeft="-3">
+                 <Box as="span" aria-hidden="true" paddingRight="2">
                   –
                 </Box>
                 <DateField

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -38,11 +38,7 @@ type DateRangePickerProps = AriaDateRangePickerProps<DateValue> &
     endLabel?: string;
     endName?: string;
     variant: ResponsiveValue<
-      /** @deprecated simple is deprecated please use base, floating or ghost*/ 
-    "simple" 
-      /** @deprecated with-trigger is deprecated please use base, floating or ghost*/ 
-    | "with-trigger" 
-    | "base" 
+     "base" 
     | "floating"
     | "ghost"
     >;
@@ -101,13 +97,9 @@ export function DateRangePicker({
   };
 
   const onFieldClick = () => {
-    if (!hasTrigger) {
       state.setOpen(true);
-    }
   };
 
-  const hasTrigger = responsiveVariant === "with-trigger";
-  
   //midlertidig løsning for å ikke lage breaking change
   const hasNewTrigger = responsiveVariant === "base" ||
   responsiveVariant === "floating" ||
@@ -139,36 +131,29 @@ export function DateRangePicker({
           onClose={state.close}
         >
           <InputGroup {...groupProps} width="auto" display="inline-flex">
-          {hasTrigger && (
-              <PopoverTrigger>
-                <CalendarTriggerButton variant={variant} ref={ref} {...buttonProps} />
-              </PopoverTrigger>
-            )}
             <PopoverAnchor>
               <StyledField
                 alignItems="center"
                 paddingX={3}
-                variant={responsiveVariant}
+                variant={variant}
                 onClick={onFieldClick}
                 onKeyPress={handleEnterClick}
                 minHeight={minHeight}
               >
-                 {hasNewTrigger && (
+                {variant && (
                   <PopoverTrigger>
                     <CalendarTriggerButton paddingLeft={1} paddingRight={1} variant={variant} ref={ref} {...buttonProps} />
                   </PopoverTrigger>
-                )}
-                {!hasTrigger && !hasNewTrigger && (
-                  <CalendarOutline24Icon boxSize={8} marginRight={2} alignSelf="center" />
                 )}
                 <DateField
                   {...startFieldProps}
                   name={startName}
                   label={props.startLabel}
-                  ref={hasTrigger ? undefined : ref}
                   labelProps={labelProps}
                 />
-               
+                 <Box as="span" aria-hidden="true" marginRight="2" marginLeft="-3">
+                  –
+                </Box>
                 <DateField
                   {...endFieldProps}
                   name={endName}

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -18,7 +18,6 @@ import {
 } from "@chakra-ui/react";
 import { DateValue } from "@internationalized/date";
 import { useDateRangePickerState } from "@react-stately/datepicker";
-import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
 import React, { useRef } from "react";
 import {
   AriaDateRangePickerProps,
@@ -79,38 +78,19 @@ export function DateRangePicker({
     calendarProps,
   } = useDateRangePicker(props, state, ref);
 
-  const responsiveVariant =
-    useBreakpointValue(typeof variant === "string" ? [variant] : variant) ??
-    "simple";
-
-  const styles = useMultiStyleConfig("Datepicker", {
-    variant: responsiveVariant,
-  });
+  const styles = useMultiStyleConfig("Datepicker", {variant});
   const locale = useCurrentLocale();
-
-  const handleEnterClick = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !state.isOpen && responsiveVariant === "simple") {
-      // Don't submit the form
-      e.stopPropagation();
-      state.setOpen(true);
-    }
-  };
 
   const onFieldClick = () => {
       state.setOpen(true);
   };
-
-  //midlertidig løsning for å ikke lage breaking change
-  const hasNewTrigger = responsiveVariant === "base" ||
-  responsiveVariant === "floating" ||
-  responsiveVariant === "ghost";
 
   const popoverContent = (
     <PopoverContent sx={styles.calendar} boxShadow="md" maxWidth="none">
       <PopoverArrow sx={styles.arrow} />
       <PopoverBody>
         <FocusLock>
-          <RangeCalendar {...calendarProps} />
+          <RangeCalendar variant={"base"} {...calendarProps} />
         </FocusLock>
       </PopoverBody>
     </PopoverContent>
@@ -137,7 +117,6 @@ export function DateRangePicker({
                 paddingX={3}
                 variant={variant}
                 onClick={onFieldClick}
-                onKeyPress={handleEnterClick}
                 minHeight={minHeight}
               >
                 {variant && (

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -38,7 +38,9 @@ type DateRangePickerProps = AriaDateRangePickerProps<DateValue> &
     endLabel?: string;
     endName?: string;
     variant: ResponsiveValue<
+      /** @deprecated simple is deprecated please use base, floating or ghost*/ 
     "simple" 
+      /** @deprecated with-trigger is deprecated please use base, floating or ghost*/ 
     | "with-trigger" 
     | "base" 
     | "floating"

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -126,6 +126,11 @@ export function DateRangePicker({
           onClose={state.close}
         >
           <InputGroup {...groupProps} width="auto" display="inline-flex">
+          {hasTrigger && (
+              <PopoverTrigger>
+                <CalendarTriggerButton ref={ref} {...buttonProps} />
+              </PopoverTrigger>
+            )}
             <PopoverAnchor>
               <StyledField
                 alignItems="center"
@@ -156,11 +161,6 @@ export function DateRangePicker({
                 />
               </StyledField>
             </PopoverAnchor>
-            {hasTrigger && (
-              <PopoverTrigger>
-                <CalendarTriggerButton ref={ref} {...buttonProps} />
-              </PopoverTrigger>
-            )}
           </InputGroup>
           {state.isOpen && withPortal && <Portal>{popoverContent}</Portal>}
           {state.isOpen && !withPortal && popoverContent}

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -150,16 +150,7 @@ export function DateRangePicker({
                   ref={hasTrigger ? undefined : ref}
                   labelProps={labelProps}
                 />
-                {!hasTrigger && (
-                  <Box as="span" aria-hidden="true" marginLeft={-3} paddingX="2">
-                    –
-                  </Box>
-                )}
-                {hasTrigger && (
-                  <Box as="span" aria-hidden="true" paddingX="2">
-                    –
-                  </Box>
-                )}
+               
                 <DateField
                   {...endFieldProps}
                   name={endName}

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -141,7 +141,7 @@ export function DateRangePicker({
                 minHeight={minHeight}
               >
                 {!hasTrigger && (
-                  <CalendarOutline24Icon marginRight={2} alignSelf="center" />
+                  <CalendarOutline24Icon boxSize={8} marginRight={2} alignSelf="center" />
                 )}
                 <DateField
                   {...startFieldProps}
@@ -150,9 +150,16 @@ export function DateRangePicker({
                   ref={hasTrigger ? undefined : ref}
                   labelProps={labelProps}
                 />
-                <Box as="span" aria-hidden="true" paddingX="2">
-                  –
-                </Box>
+                {!hasTrigger && (
+                  <Box as="span" aria-hidden="true" marginLeft={-3} paddingX="2">
+                    –
+                  </Box>
+                )}
+                {hasTrigger && (
+                  <Box as="span" aria-hidden="true" paddingX="2">
+                    –
+                  </Box>
+                )}
                 <DateField
                   {...endFieldProps}
                   name={endName}

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -24,8 +24,6 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
       state,
       ref as RefObject<HTMLDivElement>
     );
-    
-    const segmented = segment.type === "year" ? segment.text.slice(-2) : segment.text;
 
     const styles = useMultiStyleConfig("Datepicker", {
       isPlaceholder: segment.isPlaceholder,
@@ -50,8 +48,8 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
         }}
       >
         {isPaddable(segment.type)
-          ? segmented.padStart(2, "0")
-          : segmented}
+          ? segment.text.padStart(2, "0")
+          : segment.text}
       </Box>
     );
   }

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -24,6 +24,8 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
       state,
       ref as RefObject<HTMLDivElement>
     );
+    
+    const segmented = segment.type === "year" ? segment.text.slice(-2) : segment.text;
 
     const styles = useMultiStyleConfig("Datepicker", {
       isPlaceholder: segment.isPlaceholder,
@@ -37,12 +39,10 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
           ...segmentProps.style,
           boxSizing: "content-box",
         }}
-        paddingX="1px"
         textAlign="center"
         outline="none"
         borderRadius="xs"
         fontSize={["mobile.sm", "desktop.sm"]}
-        minWidth={isPaddable(segment.type) ? "1.3em" : "auto"}
         sx={styles.dateTimeSegment}
         _focus={{
           backgroundColor: "darkTeal",
@@ -50,8 +50,8 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
         }}
       >
         {isPaddable(segment.type)
-          ? segment.text.padStart(2, "0")
-          : segment.text}
+          ? segmented.padStart(2, "0")
+          : segmented}
       </Box>
     );
   }

--- a/packages/spor-react/src/datepicker/RangeCalendar.tsx
+++ b/packages/spor-react/src/datepicker/RangeCalendar.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@chakra-ui/react";
+import { Box, ResponsiveValue, useMultiStyleConfig } from "@chakra-ui/react";
 import { createCalendar, DateValue } from "@internationalized/date";
 import { useRangeCalendarState } from "@react-stately/calendar";
 import React, { useRef } from "react";
@@ -10,7 +10,10 @@ import { CalendarGrid } from "./CalendarGrid";
 import { CalendarHeader } from "./CalendarHeader";
 import { useCurrentLocale } from "./utils";
 
-type RangeCalendarProps = ReactAriaRangeCalendarProps<DateValue>;
+type RangeCalendarProps = ReactAriaRangeCalendarProps<DateValue> & {
+  variant: ResponsiveValue<"base" | "floating" | "ghost">;
+};
+
 export function RangeCalendar(props: RangeCalendarProps) {
   const locale = useCurrentLocale();
   const state = useRangeCalendarState({
@@ -23,12 +26,13 @@ export function RangeCalendar(props: RangeCalendarProps) {
   const ref = useRef(null);
   const { calendarProps, title } = useRangeCalendar(props, state, ref);
 
+
   return (
     <Box {...calendarProps} ref={ref}>
       <CalendarHeader state={state} title={title} />
       <Box display="flex" gap="8">
-        <CalendarGrid state={state} />
-        <CalendarGrid state={state} offset={{ months: 1 }} />
+        <CalendarGrid variant={props.variant} state={state} />
+        <CalendarGrid variant={props.variant} state={state} offset={{ months: 1 }} />
       </Box>
     </Box>
   );

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -9,7 +9,7 @@ import {
 import React from "react";
 
 type StyledFieldProps = BoxProps & {
-  variant: "simple" | "with-trigger";
+  variant: "simple" | "with-trigger" | "base" | "floating" | "ghost";
 };
 export const StyledField = forwardRef<StyledFieldProps, As>(
   ({ children, variant, ...otherProps }, ref) => {

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -2,6 +2,7 @@ import {
   As,
   Box,
   BoxProps,
+  ResponsiveValue,
   forwardRef,
   useFormControlContext,
   useMultiStyleConfig,
@@ -9,7 +10,11 @@ import {
 import React from "react";
 
 type StyledFieldProps = BoxProps & {
-  variant: "simple" | "with-trigger" | "base" | "floating" | "ghost";
+  variant: ResponsiveValue< 
+  "base" 
+  | "floating" 
+  | "ghost" 
+>;
 };
 export const StyledField = forwardRef<StyledFieldProps, As>(
   ({ children, variant, ...otherProps }, ref) => {

--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -121,7 +121,7 @@ export const TimePicker = ({
   )}`;
   return (
     <StyledField
-      variant="simple"
+      variant="base"
       width="fit-content"
       paddingX={2}
       alignItems="center"

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -11,7 +11,9 @@ const config = defineStyleConfig({
     fontWeight: "bold",
     transitionProperty: "common",
     transitionDuration: "normal",
-    px: 3,
+    textWrap: "wrap",
+    paddingX: 3,
+    paddingY: 1,
     _focus: {
       boxShadow: 0,
       outline: 0,
@@ -36,7 +38,7 @@ const config = defineStyleConfig({
         focus: {
           boxShadow: `inset 0 0 0 4px ${mode(
             colors.darkTeal,
-            colors.seaMist,
+            colors.seaMist
           )(props)}, inset 0 0 0 6px currentColor`,
         },
         notFocus: { boxShadow: "none" },
@@ -57,10 +59,10 @@ const config = defineStyleConfig({
         focus: {
           boxShadow: `inset 0 0 0 2px ${mode(
             colors.greenHaze,
-            colors.azure,
+            colors.azure
           )(props)}, inset 0 0 0 4px ${mode(
             colors.white,
-            colors.darkGrey,
+            colors.darkGrey
           )(props)}`,
         },
         notFocus: { boxShadow: "none" },
@@ -84,18 +86,18 @@ const config = defineStyleConfig({
         focus: {
           boxShadow: `inset 0 0 0 2px ${mode(
             colors.greenHaze,
-            colors.azure,
+            colors.azure
           )(props)}, inset 0 0 0 4px ${mode(
             colors.white,
-            colors.blackAlpha[300],
+            colors.blackAlpha[300]
           )(props)}`,
           _hover: {
             boxShadow: `inset 0 0 0 2px ${mode(
               colors.greenHaze,
-              colors.azure,
+              colors.azure
             )(props)}, inset 0 0 0 4px ${mode(
               colors.white,
-              colors.blackAlpha[500],
+              colors.blackAlpha[500]
             )(props)}`,
           },
         },
@@ -107,18 +109,18 @@ const config = defineStyleConfig({
         backgroundColor: mode("mint", "whiteAlpha.300")(props),
         boxShadow: `inset 0 0 0 2px ${mode(
           colors.greenHaze,
-          colors.azure,
+          colors.azure
         )(props)}, inset 0 0 0 4px ${mode(
           colors.white,
-          colors.blackAlpha[600],
+          colors.blackAlpha[600]
         )(props)}`,
         _hover: {
           boxShadow: `inset 0 0 0 2px ${mode(
             colors.greenHaze,
-            colors.azure,
+            colors.azure
           )(props)}, inset 0 0 0 4px ${mode(
             colors.white,
-            colors.blackAlpha[600],
+            colors.blackAlpha[600]
           )(props)}`,
         },
       },
@@ -149,7 +151,7 @@ const config = defineStyleConfig({
       fontWeight: "normal",
       boxShadow: `inset 0 0 0 1px ${mode(
         colors.blackAlpha[400],
-        colors.whiteAlpha[400],
+        colors.whiteAlpha[400]
       )(props)}`,
       ...focusVisible({
         focus: {
@@ -161,7 +163,7 @@ const config = defineStyleConfig({
         notFocus: {
           boxShadow: `inset 0 0 0 1px ${mode(
             colors.blackAlpha[400],
-            colors.whiteAlpha[400],
+            colors.whiteAlpha[400]
           )(props)}`,
         },
       }),
@@ -171,7 +173,7 @@ const config = defineStyleConfig({
       _active: {
         boxShadow: `inset 0 0 0 1px ${mode(
           colors.blackAlpha[400],
-          colors.whiteAlpha[300],
+          colors.whiteAlpha[300]
         )(props)}`,
         backgroundColor: mode("mint", "whiteAlpha.200")(props),
       },
@@ -260,7 +262,7 @@ const config = defineStyleConfig({
       minHeight: 5,
       minWidth: 5,
       fontSize: "16px",
-      px: 2,
+      paddingX: 2,
     },
   },
   defaultProps: {

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -241,6 +241,10 @@ const config = helpers.defineMultiStyleConfig({
         calendar: {
           backgroundColor: mode("white", "night")(props),
           color: mode("darkGrey", "white")(props),
+          boxShadow: getBoxShadowString({
+            borderColor: mode("grey.200", "whiteAlpha.400")(props),
+            baseShadow: "sm",
+          }),
         },
       dateCell: {
         color: mode("darkGrey", "white")(props),

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -19,7 +19,6 @@ const parts = anatomy("datepicker").parts(
 const $arrowBackground = cssVar("popper-arrow-bg");
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
-
 const config = helpers.defineMultiStyleConfig({
   baseStyle: (props) => ({
     wrapper: {
@@ -124,9 +123,9 @@ const config = helpers.defineMultiStyleConfig({
         }),
       },
     },
-    arrow: {
+    arrow: {  
       [$arrowBackground.variable]: mode("white", colors.night)(props),
-    },
+    },    
     calendar: {
       backgroundColor: mode("white", "night")(props),
       color: mode("darkGrey", "white")(props),
@@ -135,7 +134,7 @@ const config = helpers.defineMultiStyleConfig({
       color: mode("darkGrey", "white")(props),
     },
     weekend: {
-      color: mode("greenHaze", "azure")(props),
+      color: mode("darkTeal", "seaMist")(props),
     },
     dateCell: {
       backgroundColor: mode("white", "night")(props),
@@ -212,6 +211,66 @@ const config = helpers.defineMultiStyleConfig({
     },
   }),
   variants: {
+    base: (props) => ({
+      calendar: {
+        backgroundColor: mode("white", "night")(props),
+        color: mode("darkGrey", "white")(props),
+        boxShadow: getBoxShadowString({
+          borderWidth: 2,
+          borderColor: mode("blackAlpha.200", "whiteAlpha.200")(props),
+        }),
+      },
+      dateCell: {
+        color: mode("darkGrey", "white")(props),
+        _hover: {
+          backgroundColor: mode("seaMist", "pine")(props),
+        },
+        "&[data-today]": {
+          boxShadow: getBoxShadowString({
+            borderWidth: 1,
+            borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
+          }),
+        },
+      },
+    }),
+    floating: (props) => ({
+      calendar: {
+        backgroundColor: mode("white", "night")(props),
+        color: mode("darkGrey", "white")(props),
+      },
+      dateCell: {
+        color: mode("darkGrey", "white")(props),
+        _hover: {
+          backgroundColor: mode("", "")(props),
+        },
+        "&[data-today]": {
+          boxShadow: getBoxShadowString({
+            borderWidth: 1,
+            borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
+          }),
+        },
+      },
+    }),
+    ghost: (props) => ({
+      calendar: {
+        backgroundColor: mode("white", "night")(props),
+        color: mode("darkGrey", "white")(props),
+        boxShadow: getBoxShadowString({
+          borderWidth: 2,
+          borderColor: mode("", "")(props),
+        }),
+      },
+      dateCell: {
+        color: mode("darkGrey", "white")(props),
+        _hover: {
+          backgroundColor: mode("seaMist", "pine")(props),
+        },
+        _selected: {
+          backgroundColor: mode("", "primaryGreen")(props),
+          color: "darkGrey"
+        },
+      },
+    }),
     simple: {
       wrapper: {
         borderRadius: "sm",
@@ -223,6 +282,9 @@ const config = helpers.defineMultiStyleConfig({
       },
     },
   },
+  defaultProps: {
+    variant: "floating",
+  }
 });
 
 export default config;

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -28,6 +28,7 @@ const config = helpers.defineMultiStyleConfig({
       }),
       transitionProperty: "box-shadow",
       transitionDuration: "fast",
+      borderRadius: "sm",
       display: "flex",
       flex: 1,
       paddingY: 0.5,
@@ -79,9 +80,7 @@ const config = helpers.defineMultiStyleConfig({
     },
     calendarTriggerButton: {
       backgroundColor: mode("white", "night")(props),
-      boxShadow: `${getBoxShadowString({
-        borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
-      })}, inset 1px 0 0 1px ${mode("white", colors.night)(props)}`, // to make the shadow colors not multiply
+      boxShadow: "none",
       width: 8,
       display: "flex",
       alignItems: "center",
@@ -90,16 +89,17 @@ const config = helpers.defineMultiStyleConfig({
       transitionProperty: "box-shadow, background-color",
       transitionSpeed: "fast",
       position: "relative",
-      right: "-1px", // To make the box-shadows overlap
+      paddingTop: 1,
+      paddingBottom: 1,
+      borderRadius: "sm",
+      right: "9px",
 
       _hover: {
-        boxShadow: `${getBoxShadowString({
-          borderColor: mode("darkGrey", "white")(props),
-          borderWidth: 2,
-        })}, inset 2px 0 0 2px ${mode("white", colors.night)(props)}`,
+        boxShadow: "none",
+        backgroundColor: mode("seaMist", "pine")(props),
       },
       _active: {
-        backgroundColor: mode("mint", "azure")(props),
+        backgroundColor: mode("mint", "whiteAlpha.200")(props),
       },
       ...focusVisible({
         focus: {
@@ -129,6 +129,10 @@ const config = helpers.defineMultiStyleConfig({
     calendar: {
       backgroundColor: mode("white", "night")(props),
       color: mode("darkGrey", "white")(props),
+      boxShadow: getBoxShadowString({
+        borderWidth: 2,
+        borderColor: mode("blackAlpha.200", "whiteAlpha.200")(props),
+      }),
     },
     weekdays: {
       color: mode("darkGrey", "white")(props),
@@ -194,7 +198,7 @@ const config = helpers.defineMultiStyleConfig({
       "&[data-today]": {
         boxShadow: getBoxShadowString({
           borderWidth: 1,
-          borderColor: mode("osloGrey", "dimGrey")(props),
+          borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
         }),
         _focus: {
           outline: "none",
@@ -232,45 +236,6 @@ const config = helpers.defineMultiStyleConfig({
           }),
         },
       },
-      calendarTriggerButton: {
-        boxShadow: ``,
-        paddingTop: 1,
-        paddingBottom: 1,
-        borderRadius: "sm",
-        right: "9px",
-  
-        _hover: {
-        boxShadow: "",
-         backgroundColor: mode("seaMist", "pine")(props),
-        },
-        _active: {
-          backgroundColor: mode("mint", "whiteAlpha.200")(props),
-        },
-        ...focusVisible({
-          focus: {
-            outline: "none",
-            boxShadow: getBoxShadowString({
-              borderColor: mode("greenHaze", "azure")(props),
-              borderWidth: 2,
-            }),
-          },
-          notFocus: {
-            boxShadow: getBoxShadowString({
-              borderColor: mode("darkGrey", "white")(props),
-              borderWidth: 1,
-            }),
-          },
-        }),
-        _invalid: {
-          boxShadow: getBoxShadowString({
-            borderColor: "brightRed",
-            borderWidth: 2,
-          }),
-        },
-      },
-      wrapper: {
-        borderRadius: "sm",
-      },
     }),
     floating: (props) => ({
         calendar: {
@@ -282,45 +247,6 @@ const config = helpers.defineMultiStyleConfig({
         _hover: {
           backgroundColor: mode("", "")(props),
         },
-      },
-      calendarTriggerButton: {
-        boxShadow: ``,
-        paddingTop: 1,
-        paddingBottom: 1,
-        borderRadius: "sm",
-        right: "9px",
-  
-        _hover: {
-        boxShadow: "",
-         backgroundColor: mode("seaMist", "pine")(props),
-        },
-        _active: {
-          backgroundColor: mode("mint", "whiteAlpha.200")(props),
-        },
-        ...focusVisible({
-          focus: {
-            outline: "none",
-            boxShadow: getBoxShadowString({
-              borderColor: mode("greenHaze", "azure")(props),
-              borderWidth: 2,
-            }),
-          },
-          notFocus: {
-            boxShadow: getBoxShadowString({
-              borderColor: mode("darkGrey", "white")(props),
-              borderWidth: 1,
-            }),
-          },
-        }),
-        _invalid: {
-          boxShadow: getBoxShadowString({
-            borderColor: "brightRed",
-            borderWidth: 2,
-          }),
-        },
-      },
-      wrapper: {
-        borderRadius: "sm",
       },
     }),
     ghost: (props) => ({
@@ -342,56 +268,7 @@ const config = helpers.defineMultiStyleConfig({
           color: "darkGrey"
         },
       },
-      calendarTriggerButton: {
-        boxShadow: ``,
-        paddingTop: 1,
-        paddingBottom: 1,
-        borderRadius: "sm",
-        right: "9px",
-  
-        _hover: {
-        boxShadow: "",
-         backgroundColor: mode("seaMist", "pine")(props),
-        },
-        _active: {
-          backgroundColor: mode("mint", "whiteAlpha.200")(props),
-        },
-        ...focusVisible({
-          focus: {
-            outline: "none",
-            boxShadow: getBoxShadowString({
-              borderColor: mode("greenHaze", "azure")(props),
-              borderWidth: 2,
-            }),
-          },
-          notFocus: {
-            boxShadow: getBoxShadowString({
-              borderColor: mode("darkGrey", "white")(props),
-              borderWidth: 1,
-            }),
-          },
-        }),
-        _invalid: {
-          boxShadow: getBoxShadowString({
-            borderColor: "brightRed",
-            borderWidth: 2,
-          }),
-        },
-      },
-      wrapper: {
-        borderRadius: "sm",
-      },
     }),
-    simple: {
-      wrapper: {
-        borderRadius: "sm",
-      },
-    },
-    "with-trigger": {
-      wrapper: {
-        borderRightRadius: "sm",
-      },
-    },
   },
 });
 

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -235,7 +235,7 @@ const config = helpers.defineMultiStyleConfig({
     }),
     floating: (props) => ({
         calendar: {
-          backgroundColor: mode("red", "night")(props),
+          backgroundColor: mode("white", "night")(props),
           color: mode("darkGrey", "white")(props),
         },
       dateCell: {
@@ -245,7 +245,7 @@ const config = helpers.defineMultiStyleConfig({
         },
       },
       wrapper: {
-        borderRadius: "sm",
+        borderRightRadius: "sm",
       },
     }),
     ghost: (props) => ({
@@ -282,9 +282,6 @@ const config = helpers.defineMultiStyleConfig({
       },
     },
   },
-  // defaultProps: {
-  //   variant: "floating",
-  // }
 });
 
 export default config;

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -87,11 +87,11 @@ const config = helpers.defineMultiStyleConfig({
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
-      borderRightRadius: "sm",
+      borderLeftRadius: "sm",
       transitionProperty: "box-shadow, background-color",
       transitionSpeed: "fast",
       position: "relative",
-      left: "-1px", // To make the box-shadows overlap
+      right: "-1px", // To make the box-shadows overlap
 
       _hover: {
         boxShadow: `${getBoxShadowString({
@@ -219,7 +219,7 @@ const config = helpers.defineMultiStyleConfig({
     },
     "with-trigger": {
       wrapper: {
-        borderLeftRadius: "sm",
+        borderRightRadius: "sm",
       },
     },
   },

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -232,6 +232,45 @@ const config = helpers.defineMultiStyleConfig({
           }),
         },
       },
+      calendarTriggerButton: {
+        boxShadow: ``,
+        paddingTop: 1,
+        paddingBottom: 1,
+        borderRadius: "sm",
+        right: "9px",
+  
+        _hover: {
+        boxShadow: "",
+         backgroundColor: mode("seaMist", "pine")(props),
+        },
+        _active: {
+          backgroundColor: mode("mint", "whiteAlpha.200")(props),
+        },
+        ...focusVisible({
+          focus: {
+            outline: "none",
+            boxShadow: getBoxShadowString({
+              borderColor: mode("greenHaze", "azure")(props),
+              borderWidth: 2,
+            }),
+          },
+          notFocus: {
+            boxShadow: getBoxShadowString({
+              borderColor: mode("darkGrey", "white")(props),
+              borderWidth: 1,
+            }),
+          },
+        }),
+        _invalid: {
+          boxShadow: getBoxShadowString({
+            borderColor: "brightRed",
+            borderWidth: 2,
+          }),
+        },
+      },
+      wrapper: {
+        borderRadius: "sm",
+      },
     }),
     floating: (props) => ({
         calendar: {
@@ -244,8 +283,44 @@ const config = helpers.defineMultiStyleConfig({
           backgroundColor: mode("", "")(props),
         },
       },
+      calendarTriggerButton: {
+        boxShadow: ``,
+        paddingTop: 1,
+        paddingBottom: 1,
+        borderRadius: "sm",
+        right: "9px",
+  
+        _hover: {
+        boxShadow: "",
+         backgroundColor: mode("seaMist", "pine")(props),
+        },
+        _active: {
+          backgroundColor: mode("mint", "whiteAlpha.200")(props),
+        },
+        ...focusVisible({
+          focus: {
+            outline: "none",
+            boxShadow: getBoxShadowString({
+              borderColor: mode("greenHaze", "azure")(props),
+              borderWidth: 2,
+            }),
+          },
+          notFocus: {
+            boxShadow: getBoxShadowString({
+              borderColor: mode("darkGrey", "white")(props),
+              borderWidth: 1,
+            }),
+          },
+        }),
+        _invalid: {
+          boxShadow: getBoxShadowString({
+            borderColor: "brightRed",
+            borderWidth: 2,
+          }),
+        },
+      },
       wrapper: {
-        borderRightRadius: "sm",
+        borderRadius: "sm",
       },
     }),
     ghost: (props) => ({
@@ -267,8 +342,44 @@ const config = helpers.defineMultiStyleConfig({
           color: "darkGrey"
         },
       },
+      calendarTriggerButton: {
+        boxShadow: ``,
+        paddingTop: 1,
+        paddingBottom: 1,
+        borderRadius: "sm",
+        right: "9px",
+  
+        _hover: {
+        boxShadow: "",
+         backgroundColor: mode("seaMist", "pine")(props),
+        },
+        _active: {
+          backgroundColor: mode("mint", "whiteAlpha.200")(props),
+        },
+        ...focusVisible({
+          focus: {
+            outline: "none",
+            boxShadow: getBoxShadowString({
+              borderColor: mode("greenHaze", "azure")(props),
+              borderWidth: 2,
+            }),
+          },
+          notFocus: {
+            boxShadow: getBoxShadowString({
+              borderColor: mode("darkGrey", "white")(props),
+              borderWidth: 1,
+            }),
+          },
+        }),
+        _invalid: {
+          boxShadow: getBoxShadowString({
+            borderColor: "brightRed",
+            borderWidth: 2,
+          }),
+        },
+      },
       wrapper: {
-        borderRightRadius: "sm",
+        borderRadius: "sm",
       },
     }),
     simple: {

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -234,21 +234,18 @@ const config = helpers.defineMultiStyleConfig({
       },
     }),
     floating: (props) => ({
-      calendar: {
-        backgroundColor: mode("white", "night")(props),
-        color: mode("darkGrey", "white")(props),
-      },
+        calendar: {
+          backgroundColor: mode("red", "night")(props),
+          color: mode("darkGrey", "white")(props),
+        },
       dateCell: {
         color: mode("darkGrey", "white")(props),
         _hover: {
           backgroundColor: mode("", "")(props),
         },
-        "&[data-today]": {
-          boxShadow: getBoxShadowString({
-            borderWidth: 1,
-            borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
-          }),
-        },
+      },
+      wrapper: {
+        borderRadius: "sm",
       },
     }),
     ghost: (props) => ({
@@ -270,6 +267,9 @@ const config = helpers.defineMultiStyleConfig({
           color: "darkGrey"
         },
       },
+      wrapper: {
+        borderRightRadius: "sm",
+      },
     }),
     simple: {
       wrapper: {
@@ -282,9 +282,9 @@ const config = helpers.defineMultiStyleConfig({
       },
     },
   },
-  defaultProps: {
-    variant: "floating",
-  }
+  // defaultProps: {
+  //   variant: "floating",
+  // }
 });
 
 export default config;

--- a/packages/spor-react/src/theme/components/line-icon.ts
+++ b/packages/spor-react/src/theme/components/line-icon.ts
@@ -77,8 +77,9 @@ const config = helpers.defineMultiStyleConfig({
         },
       },
     },
+    
+    walk: (props) => ({
 
-    walk: (props)  => ({
       iconContainer: {
         backgroundColor: "white",
         borderWidth: 1,

--- a/packages/spor-react/src/theme/components/travel-tag.ts
+++ b/packages/spor-react/src/theme/components/travel-tag.ts
@@ -1,6 +1,6 @@
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
 import type { StyleFunctionProps } from "@chakra-ui/theme-tools";
-import { anatomy } from "@chakra-ui/theme-tools";
+import { anatomy, mode } from "@chakra-ui/theme-tools";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
 
@@ -138,9 +138,9 @@ const config = helpers.defineMultiStyleConfig({
         backgroundColor: "linjetag.altTransportLight",
       },
     },
-    walk: {
+    walk: (props) => ({
       container: {
-        backgroundColor: "white",
+        backgroundColor: mode("white", "transparent")(props),
         _disabled: {
           backgroundColor: "white",
         },
@@ -149,6 +149,7 @@ const config = helpers.defineMultiStyleConfig({
         border: "none",
         position: "relative",
         left: -1,
+        backgroundColor: mode("white", "transparent")(props),
         "[aria-disabled=true] &": {
           backgroundColor: "transparent",
           color: "osloGrey",
@@ -165,11 +166,12 @@ const config = helpers.defineMultiStyleConfig({
       title: {
         fontSize: "mobile.xs",
         fontWeight: "normal",
+        color: mode("black", "white")(props)
       },
       description: {
         display: "none",
       },
-    },
+    }),
   },
   sizes: {
     sm: {


### PR DESCRIPTION
## Background

We need to implement darkmode version of the time/date/calendar. We also need to add the new variants of calendar and make some minor adjustement to the design of both light and darkmode version

## Solution

1. Change the position of the calendar button from right side to left side of the datepicker.
2. Changed the design of the calendar-button. It is now the same as the arrow-buttons in timepicker.
3. changed the spacing between the date numbers in the datepicker
4. Calendar button is now a Ghost-button
5. Changed focusorder
6. Added Base, Ghost and floating version of Calendar to both light and dark mode.
7. Added the darkmode versions for the new variants components

