### PR TITLE
Dark mode close_btn

### DIFF
--- a/.changeset/blue-walls-refuse.md
+++ b/.changeset/blue-walls-refuse.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+close-button: added dark mode

--- a/packages/spor-react/src/theme/components/close-button.ts
+++ b/packages/spor-react/src/theme/components/close-button.ts
@@ -11,7 +11,7 @@ const config = defineStyleConfig({
     h: [$size.reference],
     transitionProperty: "common",
     transitionDuration: "normal",
-    borderRadius: "xs",
+    borderRadius: "md",
     backgroundColor: "transparent",
     color: mode("darkGrey", "white")(props),
     fontWeight: "normal",

--- a/packages/spor-react/src/theme/components/close-button.ts
+++ b/packages/spor-react/src/theme/components/close-button.ts
@@ -1,39 +1,40 @@
-import { defineStyleConfig } from "@chakra-ui/react";
-import { cssVar } from "@chakra-ui/theme-tools";
+import { defineStyleConfig, propNames } from "@chakra-ui/react";
+import { cssVar, mode } from "@chakra-ui/theme-tools";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
 
 const $size = cssVar("close-button-size");
 
 const config = defineStyleConfig({
-  baseStyle: {
+  baseStyle: (props) => ({
     w: [$size.reference],
     h: [$size.reference],
     transitionProperty: "common",
     transitionDuration: "normal",
     borderRadius: "xs",
     backgroundColor: "transparent",
-    color: "darkGrey",
+    color: mode("darkGrey", "white")(props),
     fontWeight: "normal",
     ...focusVisible({
       focus: {
-        outline: "none",
-        boxShadow: getBoxShadowString({ borderColor: "greenHaze" }),
+        outline: "transparent solid 2px",
+        boxShadow: getBoxShadowString({ borderColor: mode("greenHaze", "azure")(props) }),
+        outlineOffset: "2px",
       },
       notFocus: {
         boxShadow: "none",
       },
     }),
     _hover: {
-      backgroundColor: "seaMist",
+      backgroundColor: mode("seaMist", "pine")(props),
       _disabled: {
         color: "dimGrey",
       },
     },
     _active: {
-      backgroundColor: "mint",
+      backgroundColor: mode("mint", "whiteAlpha.200")(props),
     },
-  },
+  }),
   sizes: {
     lg: {
       [$size.variable]: "40px",

--- a/packages/spor-react/src/theme/components/close-button.ts
+++ b/packages/spor-react/src/theme/components/close-button.ts
@@ -1,4 +1,4 @@
-import { defineStyleConfig, propNames } from "@chakra-ui/react";
+import { defineStyleConfig } from "@chakra-ui/react";
 import { cssVar, mode } from "@chakra-ui/theme-tools";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";

--- a/packages/spor-react/src/theme/components/close-button.ts
+++ b/packages/spor-react/src/theme/components/close-button.ts
@@ -17,7 +17,6 @@ const config = defineStyleConfig({
     fontWeight: "normal",
     ...focusVisible({
       focus: {
-        outline: "transparent solid 2px",
         boxShadow: getBoxShadowString({ borderColor: mode("greenHaze", "azure")(props) }),
         outlineOffset: "2px",
       },

--- a/packages/spor-react/src/theme/components/close-button.ts
+++ b/packages/spor-react/src/theme/components/close-button.ts
@@ -17,6 +17,7 @@ const config = defineStyleConfig({
     fontWeight: "normal",
     ...focusVisible({
       focus: {
+        outline: "none",
         boxShadow: getBoxShadowString({ borderColor: mode("greenHaze", "azure")(props) }),
         outlineOffset: "2px",
       },


### PR DESCRIPTION
## Background
this close button used in other components as modal and popover did not have dark mode support

![Screenshot 2023-11-06 at 13 12 47](https://github.com/nsbno/spor/assets/69791398/52eb2bb9-b090-4351-8ecd-fb6f93009a23)

## Solution
add dark mode support for close_btn. added ghost for it
