### PR TITLE
Darkmode modal

### DIFF
--- a/packages/spor-react/src/theme/components/modal.ts
+++ b/packages/spor-react/src/theme/components/modal.ts
@@ -1,6 +1,6 @@
 import { modalAnatomy as parts } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import type { PartsStyleObject } from "@chakra-ui/theme-tools";
+import { mode, type PartsStyleObject } from "@chakra-ui/theme-tools";
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
@@ -19,8 +19,8 @@ const config = helpers.defineMultiStyleConfig({
     },
     dialog: {
       borderRadius: "md",
-      background: "white",
-      color: "inherit",
+      background: mode("white", "night")(props),
+      color: mode("inherit", "white")(props),
       my: "3.75rem",
       zIndex: "modal",
       maxHeight:
@@ -36,6 +36,7 @@ const config = helpers.defineMultiStyleConfig({
     },
     closeButton: {
       position: "absolute",
+      color: mode("inherit", "white")(props),
       top: 3,
       insetEnd: 3,
     },

--- a/packages/spor-react/src/theme/components/modal.ts
+++ b/packages/spor-react/src/theme/components/modal.ts
@@ -36,7 +36,7 @@ const config = helpers.defineMultiStyleConfig({
     },
     closeButton: {
       position: "absolute",
-      color: mode("inherit", "white")(props),
+      color: "inherit",
       top: 3,
       insetEnd: 3,
     },


### PR DESCRIPTION
## Background
modal did not work in dark mode

![Screenshot 2023-11-06 at 13 16 20](https://github.com/nsbno/spor/assets/69791398/a280dda1-477c-43e3-9cd7-59a0c4a35d10)

## Solution
did not find an illustration of modal in dark mode, but made an example

![Screenshot 2023-11-06 at 13 22 45](https://github.com/nsbno/spor/assets/69791398/6f3df00e-ae36-4b16-9252-59cb2f348da9)


