### PR TITLE
Downgrade fraomer-motion because of race condition bug

### DIFF
--- a/.changeset/tall-months-dream.md
+++ b/.changeset/tall-months-dream.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+General: Downgrade framer-motion because of race condition bug

--- a/package-lock.json
+++ b/package-lock.json
@@ -34685,7 +34685,7 @@
     },
     "packages/spor-icon": {
       "name": "@vygruppen/spor-icon",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "bestzip": "^2.2.0"
@@ -34795,7 +34795,7 @@
     },
     "packages/spor-icon-react": {
       "name": "@vygruppen/spor-icon-react",
-      "version": "3.2.3",
+      "version": "3.3.0",
       "license": "MIT",
       "devDependencies": {
         "@svgr/core": "^8.1.0",
@@ -34818,7 +34818,7 @@
     },
     "packages/spor-icon-react-native": {
       "name": "@vygruppen/spor-icon-react-native",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@shopify/restyle": "^2.1.0",
@@ -35451,7 +35451,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.6.1",
@@ -35463,7 +35463,7 @@
         "@vygruppen/spor-icon-react": "*",
         "@vygruppen/spor-loader": "*",
         "awesome-phonenumber": "^5.10.0",
-        "framer-motion": "^10.16.4",
+        "framer-motion": "^9.1.7",
         "lottie-react": "^2.3.1",
         "react-aria": "^3.27.0",
         "react-stately": "^3.25.0",
@@ -35500,9 +35500,9 @@
       "optional": true
     },
     "packages/spor-react/node_modules/framer-motion": {
-      "version": "10.16.4",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.4.tgz",
-      "integrity": "sha512-p9V9nGomS3m6/CALXqv6nFGMuFOxbWsmaOrdmhyQimMIlLl3LC7h7l86wge/Js/8cRu5ktutS/zlzgR7eBOtFA==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-9.1.7.tgz",
+      "integrity": "sha512-nKxBkIO4IPkMEqcBbbATxsVjwPYShKl051yhBv9628iAH6JLeHD0siBHxkL62oQzMC1+GNX73XtPjgP753ufuw==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -35512,14 +35512,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "packages/spor-react/node_modules/pathe": {

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -26,7 +26,7 @@
     "@vygruppen/spor-icon-react": "*",
     "@vygruppen/spor-loader": "*",
     "awesome-phonenumber": "^5.10.0",
-    "framer-motion": "^10.16.4",
+    "framer-motion": "^9.1.7",
     "lottie-react": "^2.3.1",
     "react-aria": "^3.27.0",
     "react-stately": "^3.25.0",


### PR DESCRIPTION
## Background
There is a bug for the Vy.no header where if you triple-click the Vy header, the `Collapse` component doesn't update properly. Similar to [this](https://github.com/chakra-ui/chakra-ui/issues/7775) issue.

## Solution
The issue above says that it works on framer-motion v9, so we have to downgrade it. We don't use any of the v10 features so should not be problem, just annoying to not be up to date 😒 
