### PR TITLE
Darkmode popovers

### DIFF
--- a/.changeset/chatty-taxis-crash.md
+++ b/.changeset/chatty-taxis-crash.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Popover: add dark mode support

--- a/.changeset/chatty-taxis-crash.md
+++ b/.changeset/chatty-taxis-crash.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": patch
----
-
-Popover: add dark mode support

--- a/packages/spor-react/src/theme/components/popover.ts
+++ b/packages/spor-react/src/theme/components/popover.ts
@@ -14,7 +14,7 @@ const config = helpers.defineMultiStyleConfig({
       zIndex: "popover",
     },
     content: {
-      [$popperBg.variable]: mode(`colors.darkTeal`, `colors.seaMist`)(props) ,
+      [$popperBg.variable]: mode(`colors.darkTeal`, `colors.pine`)(props) ,
       backgroundColor: $popperBg.reference,
       [$arrowBg.variable]: $popperBg.reference,
       [$arrowShadowColor.variable]: `colors.blackAlpha.300`,

--- a/packages/spor-react/src/theme/components/popover.ts
+++ b/packages/spor-react/src/theme/components/popover.ts
@@ -14,11 +14,7 @@ const config = helpers.defineMultiStyleConfig({
       zIndex: "popover",
     },
     content: {
-<<<<<<< HEAD
-      [$popperBg.variable]: mode(`colors.darkTeal`, `colors.seaMist`)(props) ,
-=======
-      [$popperBg.variable]: mode(`colors.darkTeal`, `colors.seaMist`)(props) ,
->>>>>>> fd725f86e5d03f02505a5d1c2ac8c9a8b00a013d
+      [$popperBg.variable]: mode(`colors.darkTeal`, `colors.pine`)(props) ,
       backgroundColor: $popperBg.reference,
       [$arrowBg.variable]: $popperBg.reference,
       [$arrowShadowColor.variable]: `colors.blackAlpha.300`,

--- a/packages/spor-react/src/theme/components/popover.ts
+++ b/packages/spor-react/src/theme/components/popover.ts
@@ -1,6 +1,8 @@
 import { popoverAnatomy as parts } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
 import { cssVar, mode } from "@chakra-ui/theme-tools";
+import { getBoxShadowString } from "../utils/box-shadow-utils";
+import { focusVisible } from "../utils/focus-utils";
 
 const $popperBg = cssVar("popper-bg");
 const $arrowBg = cssVar("popper-arrow-bg");
@@ -38,6 +40,18 @@ const config = helpers.defineMultiStyleConfig({
       position: "absolute",
       color: "white",
       hover: "whiteAlpha.100",
+      ...focusVisible({
+        focus: {
+          boxShadow: getBoxShadowString({ borderColor: "azure" }),
+      
+        },
+        notFocus: {
+          boxShadow: "none",
+        },
+      }),
+      _active: {
+        backgroundColor: "whiteAlpha.200",
+      },
       borderRadius: "xs",
       top: 1,
       insetEnd: 1,

--- a/packages/spor-react/src/theme/components/popover.ts
+++ b/packages/spor-react/src/theme/components/popover.ts
@@ -1,6 +1,6 @@
 import { popoverAnatomy as parts } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import { cssVar } from "@chakra-ui/theme-tools";
+import { cssVar, mode } from "@chakra-ui/theme-tools";
 
 const $popperBg = cssVar("popper-bg");
 const $arrowBg = cssVar("popper-arrow-bg");
@@ -9,12 +9,12 @@ const $arrowShadowColor = cssVar("popper-arrow-shadow-color");
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
 const config = helpers.defineMultiStyleConfig({
-  baseStyle: {
+  baseStyle: (props) => ({
     popper: {
       zIndex: "popover",
     },
     content: {
-      [$popperBg.variable]: `colors.darkTeal`,
+      [$popperBg.variable]: mode(`colors.darkTeal`, `colors.seaMist`)(props) ,
       backgroundColor: $popperBg.reference,
       [$arrowBg.variable]: $popperBg.reference,
       [$arrowShadowColor.variable]: `colors.blackAlpha.300`,
@@ -43,7 +43,7 @@ const config = helpers.defineMultiStyleConfig({
       height: 2,
       padding: 1,
     },
-  },
+  }),
   sizes: {
     sm: {
       content: {

--- a/packages/spor-react/src/theme/components/popover.ts
+++ b/packages/spor-react/src/theme/components/popover.ts
@@ -36,6 +36,8 @@ const config = helpers.defineMultiStyleConfig({
     },
     closeButton: {
       position: "absolute",
+      color: "white",
+      hover: "whiteAlpha.100",
       borderRadius: "xs",
       top: 1,
       insetEnd: 1,


### PR DESCRIPTION
## Background
popover did not have dark mode support

the colors for light mode did not correspond with close buttons light mode colors

## Solution
added dark mode support for popover

changed close button to have forced dark mode values for both popovers light mode and dark mode 
