### PR TITLE
Drop new major

### DIFF
--- a/.changeset/healthy-garlics-think.md
+++ b/.changeset/healthy-garlics-think.md
@@ -1,0 +1,17 @@
+---
+"@vygruppen/spor-react": major
+---
+
+This major version removes a bunch of deprecated properties, and revamps our Datepicker component.
+
+To migrate, please follow the following instructions:
+
+DatePicker, DateRangePicker: `variant="simple"` and `variant="with-trigger"` has been removed (without a deprecation warning – sorry! 🙈). In their place, you'll find "base", "floating" and "ghost".
+
+Button: The deprecated `variant="tertiary" is removed. To migrate, use `variant="secondary"` instead.
+
+TextLink: The deprecated `variant="tertiary" is removed. To migrate, use `variant="secondary"` instead.
+
+FloatingActionButton: The deprecated variants "green", "light" and "dark" are deprecated. To migrate, use "accent" for all three versions.
+
+Tabs: The deprecated color schemes "dark", "light", "green" and "grey" are all removed. For "dark" and "green", please use "accent". For "light" and "grey", please use "default"

--- a/.changeset/wicked-chefs-stare.md
+++ b/.changeset/wicked-chefs-stare.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Add new Portal component

--- a/apps/docs/app/routes/_base.$category.$slug/route.tsx
+++ b/apps/docs/app/routes/_base.$category.$slug/route.tsx
@@ -243,7 +243,7 @@ type ComponentSectionsProps = {
 const ComponentSections = ({ sections }: ComponentSectionsProps) => {
   return (
     <Tabs
-      colorScheme="green"
+      colorScheme="accent"
       variant="square"
       size="md"
       marginTop={4}

--- a/apps/studio/schemas/objects/buttonLink.tsx
+++ b/apps/studio/schemas/objects/buttonLink.tsx
@@ -27,7 +27,6 @@ export const buttonLink = defineType({
         list: [
           { title: "Primary", value: "primary" },
           { title: "Secondary", value: "secondary" },
-          { title: "Tertiary", value: "tertiary" },
           { title: "Additional", value: "additional" },
           { title: "Control", value: "control" },
         ],

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -28,8 +28,6 @@ export type ButtonProps = Exclude<
     | "control"
     | "primary"
     | "secondary"
-    /** @deprecated Use `secondary` instead */
-    | "tertiary"
     | "additional"
     | "ghost"
     | "floating";

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -40,8 +40,7 @@ export type ButtonProps = Exclude<
  * - `control`: This button is used for ticket controls only.
  * - `primary`: This is our main button. It's used for the main actions in a view, like a call to action. There should only be a single primary button in each view.
  * - `secondary`: Used for secondary actions in a view, and when you need to make several actions available at the same time.
- * - `tertiary`: Used for non-essential actions, as well as in combination with the primary button.
- * - `additional`: Used for additional choices, like a less important tertiary action.
+ * - `additional`: Used for additional choices, like a less important secondary action.
  * - `ghost`: Used inside other interactive elements, like date pickers and input fields.
  * - `floating`: Used for floating actions, like a menu button in a menu.
  *
@@ -54,7 +53,7 @@ export type ButtonProps = Exclude<
  * There are also different sizes. You can specify which one you want with the `size` prop. The available sizes are "lg", "md", "sm" and "xs".
  *
  * ```tsx
- * <Button variant="tertiary" size="sm" onClick={cancelOrder}>
+ * <Button variant="secondary" size="sm" onClick={cancelOrder}>
  *   Cancel trip
  * </Button>
  * ```

--- a/packages/spor-react/src/button/ButtonGroup.tsx
+++ b/packages/spor-react/src/button/ButtonGroup.tsx
@@ -13,7 +13,7 @@ export type ButtonGroupProps = ChakraButtonGroupProps;
  *
  * ```tsx
  * <ButtonGroup>
- *   <Button variant="tertiary">Cancel</Button>
+ *   <Button variant="secondary">Cancel</Button>
  *   <Button variant="primary">Save</Button>
  * </ButtonGroup>
  * ```

--- a/packages/spor-react/src/button/FloatingActionButton.tsx
+++ b/packages/spor-react/src/button/FloatingActionButton.tsx
@@ -11,16 +11,7 @@ import React, { useEffect } from "react";
 const MotionBox = motion(Box);
 
 type FloatingActionButtonProps = BoxProps & {
-  variant?:
-   /** @deprecated dark is deprecated please use accent*/ 
-    "green" 
-   /** @deprecated dark is deprecated please use accent*/
-  | "light"
-   /** @deprecated dark is deprecated please use accent*/ 
-  | "dark"
-  | "accent"
-  | "base"
-  | "brand"
+  variant?: "accent" | "base" | "brand";
   placement?: "bottom right" | "bottom left" | "top right" | "top left";
   icon: React.ReactNode;
   children: React.ReactNode;

--- a/packages/spor-react/src/button/FloatingActionButton.tsx
+++ b/packages/spor-react/src/button/FloatingActionButton.tsx
@@ -25,7 +25,7 @@ type FloatingActionButtonProps = BoxProps & {
  *
  * ```tsx
  * <FloatingActionButton
- *  variant="green"
+ *  variant="accent"
  *  icon={<TicketControlFill30Icon />}
  *  placement="bottom right"
  * />

--- a/packages/spor-react/src/button/IconButton.tsx
+++ b/packages/spor-react/src/button/IconButton.tsx
@@ -12,7 +12,6 @@ export type IconButtonProps = Omit<ChakraIconButtonProps, "variant"> & {
     | "control"
     | "primary"
     | "secondary"
-    | "tertiary"
     | "additional"
     | "ghost"
     | "floating";
@@ -27,8 +26,7 @@ export type IconButtonProps = Omit<ChakraIconButtonProps, "variant"> & {
  * - `control`: This button is used for ticket controls only.
  * - `primary`: This is our main button. It's used for the main actions in a view, like a call to action. There should only be a single primary button in each view.
  * - `secondary`: Used for secondary actions in a view, and when you need to make several actions available at the same time.
- * - `tertiary`: Used for non-essential actions, as well as in combination with the primary button.
- * - `additional`: Used for additional choices, like a less important tertiary action.
+ * - `additional`: Used for additional choices, like a less important secondary action.
  * - `ghost`: Used inside other interactive elements, like date pickers and input fields.
  * - `floating`: Used for floating actions, like a menu button in a menu.
  *

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -11,18 +11,13 @@ import {
   PopoverTrigger,
   Portal,
   ResponsiveValue,
-  useBreakpointValue,
   useFormControlContext,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
 import { DateValue } from "@internationalized/date";
 import { useDatePickerState } from "@react-stately/datepicker";
 import React, { forwardRef, useRef } from "react";
-import {
-  AriaDatePickerProps,
-  I18nProvider,
-  useDatePicker,
-} from "react-aria";
+import { AriaDatePickerProps, I18nProvider, useDatePicker } from "react-aria";
 import { FormErrorMessage } from "..";
 import { Calendar } from "./Calendar";
 import { CalendarTriggerButton } from "./CalendarTriggerButton";
@@ -41,10 +36,10 @@ type DatePickerProps = AriaDatePickerProps<DateValue> &
 /**
  * A date picker component.
  *
- * There are two versions of this component – a simple one, and one with a trigger button for showing the calendar. Use whatever fits your design.
+ * There are three different variants – `base`, `floating` and `ghost`.
  *
  * ```tsx
- * <DatePicker label="Dato" variant="simple" />
+ * <DatePicker label="Dato" variant="base" />
  * ```
  */
 
@@ -109,14 +104,19 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
 
     return (
       <I18nProvider locale={locale}>
-        <Box position="relative" display="inline-flex" flexDirection="column" width={width}>
+        <Box
+          position="relative"
+          display="inline-flex"
+          flexDirection="column"
+          width={width}
+        >
           <Popover
             {...dialogProps}
             isOpen={state.isOpen}
             onOpen={state.open}
             onClose={state.close}
           >
-            <InputGroup {...groupProps} display="inline-flex">             
+            <InputGroup {...groupProps} display="inline-flex">
               <PopoverAnchor>
                 <StyledField
                   variant={variant}
@@ -125,7 +125,11 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                   minHeight={minHeight}
                 >
                   <PopoverTrigger>
-                    <CalendarTriggerButton variant={variant} ref={ref} {...buttonProps} />
+                    <CalendarTriggerButton
+                      variant={variant}
+                      ref={ref}
+                      {...buttonProps}
+                    />
                   </PopoverTrigger>
                   <DateField
                     label={props.label}
@@ -136,8 +140,12 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 </StyledField>
               </PopoverAnchor>
             </InputGroup>
-            <FormErrorMessage {...errorMessageProps}>{errorMessage}</FormErrorMessage>
-            {state.isOpen && !props.isDisabled && withPortal && <Portal>{popoverContent}</Portal>}
+            <FormErrorMessage {...errorMessageProps}>
+              {errorMessage}
+            </FormErrorMessage>
+            {state.isOpen && !props.isDisabled && withPortal && (
+              <Portal>{popoverContent}</Portal>
+            )}
             {state.isOpen && !props.isDisabled && !withPortal && popoverContent}
           </Popover>
         </Box>

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -46,10 +46,10 @@ type DateRangePickerProps = AriaDateRangePickerProps<DateValue> &
 /**
  * A date range picker component.
  *
- * There are two versions of this component – a simple one, and one with a trigger button for showing the calendar. Use whatever fits your design.
+ * There are three variants to choose from – `base`, `floating` and `ghost`.
  *
  * ```tsx
- * <DateRangePicker startLabel="From" startName="from" endLabel="To" endName="to" variant="simple" />
+ * <DateRangePicker startLabel="From" startName="from" endLabel="To" endName="to" variant="base" />
  * ```
  */
 export function DateRangePicker({

--- a/packages/spor-react/src/link/TextLink.tsx
+++ b/packages/spor-react/src/link/TextLink.tsx
@@ -12,7 +12,7 @@ type LinkProps = Omit<ChakraLinkProps, "variant"> & {
 };
 /** Link to different sites or parts of site
  *
- * You can specify the `variant` prop to get different link designs. `tertiary` should only be used on dark backgrounds.
+ * You can specify the `variant` prop to get different link designs.
  */
 export const TextLink = forwardRef<LinkProps, "a">(
   ({ children, ...props }, ref) => {

--- a/packages/spor-react/src/link/TextLink.tsx
+++ b/packages/spor-react/src/link/TextLink.tsx
@@ -8,11 +8,7 @@ import React from "react";
 import { createTexts, useTranslation } from "..";
 
 type LinkProps = Omit<ChakraLinkProps, "variant"> & {
-  variant?:
-    | "primary"
-    | "secondary"
-    /** @deprecated Use `secondary` instead */
-    | "tertiary";
+  variant?: "primary" | "secondary";
 };
 /** Link to different sites or parts of site
  *

--- a/packages/spor-react/src/tab/Tabs.tsx
+++ b/packages/spor-react/src/tab/Tabs.tsx
@@ -9,17 +9,7 @@ export type TabsProps = Exclude<
   ChakraTabsProps,
   "colorScheme" | "variant" | "orientation" | "size"
 > & {
-  colorScheme: 
-  /** @deprecated dark is deprecated please use accent*/
-  | "dark"
-  /** @deprecated light is deprecated please use default*/
-  | "light"
-  /** @deprecated green is deprecated please use accent*/
-  | "green"   
-  /** @deprecated grey is deprecated please use default*/
-  | "grey"
-  | "base" 
-  | "accent" ;
+  colorScheme: "base" | "accent";
   /** Defaults to `md` */
   size?: "sm" | "md" | "lg" | "xl";
   /** Defaults to `round` */

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -125,26 +125,6 @@ const config = defineStyleConfig({
         },
       },
     }),
-    /**
-     * @deprecated use `secondary` instead.
-     */
-    tertiary: {
-      backgroundColor: "mint",
-      color: "darkGrey",
-      fontWeight: "normal",
-      ...focusVisible({
-        focus: {
-          boxShadow: `inset 0 0 0 4px ${colors.mint}, inset 0 0 0 4px ${colors.mint}, inset 0 0 0 6px currentColor`,
-        },
-        notFocus: { boxShadow: "none" },
-      }),
-      _hover: {
-        backgroundColor: "seaMist",
-      },
-      _active: {
-        backgroundColor: "lightGrey",
-      },
-    },
     additional: (props) => ({
       backgroundColor: "transparent",
       color: mode("darkGrey", "white")(props),

--- a/packages/spor-react/src/theme/components/link.ts
+++ b/packages/spor-react/src/theme/components/link.ts
@@ -1,7 +1,7 @@
 import { defineStyleConfig } from "@chakra-ui/react";
+import { mode } from "@chakra-ui/theme-tools";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
-import { mode } from "@chakra-ui/theme-tools";
 
 const config = defineStyleConfig({
   baseStyle: {
@@ -55,7 +55,7 @@ const config = defineStyleConfig({
       }),
       _hover: {
         color: mode("darkTeal", "white")(props),
-        backgroundColor: mode("coralGreen", "whiteAlpha.200")(props)
+        backgroundColor: mode("coralGreen", "whiteAlpha.200")(props),
       },
       _active: {
         color: mode("pine", "white")(props),
@@ -67,7 +67,7 @@ const config = defineStyleConfig({
       ...focusVisible({
         focus: {
           backgroundColor: mode("darkGrey", "white")(props),
-          color: mode("white", "darkTeal")(props)
+          color: mode("white", "darkTeal")(props),
         },
         notFocus: {
           boxShadow: "none",
@@ -76,52 +76,11 @@ const config = defineStyleConfig({
       }),
       _hover: {
         backgroundColor: mode("blackAlpha.100", "whiteAlpha.200")(props),
-        color: mode("darkGrey", "white")(props)
+        color: mode("darkGrey", "white")(props),
       },
       _active: {
         backgroundColor: mode("mint", "whiteAlpha.100")(props),
-        color: mode("darkGrey", "white")(props)
-      },
-    }),
-    /**
-     * @deprecated tertiary style will be deprecated in the future.
-     * Please use the secondary style instead.
-     */
-    tertiary: (props) => ({
-      color: "white",
-      ...focusVisible({
-        focus: {
-          color: "pine",
-          backgroundColor: "white",
-          boxShadow: getBoxShadowString({
-            borderColor: "white",
-            borderWidth: 3,
-            isInset: false,
-          }),
-        },
-        notFocus: {
-          color: "white",
-          boxShadow: "none",
-          backgroundColor: "transparent",
-        },
-      }),
-      _hover: {
-        color: "white",
-        backgroundColor: "whiteAlpha.200",
-        boxShadow: getBoxShadowString({
-          borderColor: props.theme.colors.whiteAlpha[200],
-          borderWidth: 3,
-          isInset: false,
-        }),
-      },
-      _active: {
-        color: "white",
-        backgroundColor: "whiteAlpha.400",
-        boxShadow: getBoxShadowString({
-          borderColor: props.theme.colors.whiteAlpha[400],
-          borderWidth: 3,
-          isInset: false,
-        }),
+        color: mode("darkGrey", "white")(props),
       },
     }),
   },

--- a/packages/spor-react/src/util/externals.tsx
+++ b/packages/spor-react/src/util/externals.tsx
@@ -2,6 +2,7 @@
 export {
   DarkMode,
   LightMode,
+  Portal,
   useBreakpointValue,
   useClipboard,
   useColorMode,
@@ -17,6 +18,7 @@ export {
   useToken,
 } from "@chakra-ui/react";
 export type {
+  PortalProps,
   UseClipboardOptions,
   UseDisclosureProps,
   UseOutsideClickProps,


### PR DESCRIPTION
## Background
Turns out we snuck in a breaking change in a previous minor change. Therefore we're dropping the newest major now, so we can make the upgrade path simpler (and adhere to semantic versioning).

## Solution
In addition to the breaking DatePicker and DateRangePicker changes, this major also removes all deprecated props. And it adds a portal!
