### PR TITLE
Darkmode colors for all Input pseudo classes..

### DIFF
--- a/.changeset/poor-bobcats-bow.md
+++ b/.changeset/poor-bobcats-bow.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Input, PasswordInput, SearchInput, InfoSelect, NativeSelect: Tweak disabled state styling.

--- a/packages/spor-react/src/input/PasswordInput.tsx
+++ b/packages/spor-react/src/input/PasswordInput.tsx
@@ -46,6 +46,7 @@ export const PasswordInput = forwardRef<PasswordInputProps, "input">(
             onClick={onToggle}
             borderRadius="sm"
             marginRight={1}
+            isDisabled={props.disabled || props.isDisabled}
           >
             {isShowingPassword ? t(texts.hidePassword) : t(texts.showPassword)}
           </Button>

--- a/packages/spor-react/src/theme/components/input.ts
+++ b/packages/spor-react/src/theme/components/input.ts
@@ -53,7 +53,7 @@ const config = helpers.defineMultiStyleConfig({
         boxShadow: getBoxShadowString({
           borderColor: mode("blackAlpha.200", "whiteAlpha.200")(props)
         }),
-        cursor: "not-allowed"
+        cursor: "not-allowed",
       },
       _invalid: {
         boxShadow: getBoxShadowString({
@@ -81,9 +81,6 @@ const config = helpers.defineMultiStyleConfig({
           },
         }),
       },
-      ":disabled + label": {
-        color: mode("blackAlpha.400", "whiteAlpha.400")(props),
-      },
       " + label": {
         fontSize: ["mobile.sm", "desktop.sm"],
         top: "2px",
@@ -104,6 +101,11 @@ const config = helpers.defineMultiStyleConfig({
     },
     element: {
       height: "100%",
+    },
+    group: {
+      ":has(:disabled)": {
+        color: mode("blackAlpha.400", "whiteAlpha.400")(props),
+      },
     },
   }),
 });

--- a/packages/spor-react/src/theme/components/input.ts
+++ b/packages/spor-react/src/theme/components/input.ts
@@ -45,13 +45,14 @@ const config = helpers.defineMultiStyleConfig({
           }),
         },
         notFocus: {
-          boxShadow: getBoxShadowString({ borderColor: "darkGrey" }),
+          boxShadow: getBoxShadowString({ borderColor: mode("darkGrey", "white")(props) }),
         },
       }),
       _disabled: {
-        boxShadow: getBoxShadowString({ borderColor: "platinum" }),
-        _hover: { boxShadow: getBoxShadowString({ borderColor: "platinum" }) },
-        _focus: { boxShadow: getBoxShadowString({ borderColor: "platinum" }) },
+        backgroundColor: mode("blackAlpha.100", "whiteAlpha.100")(props),
+        boxShadow: getBoxShadowString({
+          borderColor: mode("blackAlpha.200", "whiteAlpha.200")(props)
+        }),
       },
       _invalid: {
         boxShadow: getBoxShadowString({
@@ -60,7 +61,7 @@ const config = helpers.defineMultiStyleConfig({
         }),
         _hover: {
           boxShadow: getBoxShadowString({
-            borderColor: "darkGrey",
+            borderColor: mode("darkGrey", "white")(props),
             borderWidth: 2,
           }),
         },
@@ -78,6 +79,9 @@ const config = helpers.defineMultiStyleConfig({
             }),
           },
         }),
+      },
+      ":disabled + label": {
+        color: mode("blackAlpha.400", "whiteAlpha.400")(props),
       },
       " + label": {
         fontSize: ["mobile.sm", "desktop.sm"],

--- a/packages/spor-react/src/theme/components/input.ts
+++ b/packages/spor-react/src/theme/components/input.ts
@@ -53,6 +53,7 @@ const config = helpers.defineMultiStyleConfig({
         boxShadow: getBoxShadowString({
           borderColor: mode("blackAlpha.200", "whiteAlpha.200")(props)
         }),
+        cursor: "not-allowed"
       },
       _invalid: {
         boxShadow: getBoxShadowString({

--- a/packages/spor-react/src/theme/components/select.ts
+++ b/packages/spor-react/src/theme/components/select.ts
@@ -1,6 +1,7 @@
-import { selectAnatomy } from "@chakra-ui/anatomy";
-import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
-import { default as Input } from "./input";
+import {selectAnatomy} from "@chakra-ui/anatomy";
+import {createMultiStyleConfigHelpers} from "@chakra-ui/react";
+import {default as Input} from "./input";
+import {mode} from "@chakra-ui/theme-tools";
 
 const parts = selectAnatomy.extend("root");
 
@@ -43,7 +44,7 @@ const config = helpers.defineMultiStyleConfig({
       strokeLinecap: "round",
       fontSize: "1.125rem",
       _disabled: {
-        opacity: 0.5,
+        color: mode("blackAlpha.400", "whiteAlpha.400")(props),
       },
     },
   }),


### PR DESCRIPTION
.. and tweak disabled styling to match Figma sketches (in both light and dark mode).

## Background
<!-- Why is this pull request necessary? -->
This closes issue #900 and #903 

1) There were some missing darkMode colors in the Input base styling, specifically for `:disabled` and `:invalid`.
2) The disabled styling deviated from the original Figma sketches. After consulting with @perweum, he confirmed that the sketches were correct and that the spor-react implementation was a bit of. 

## Solution
<!-- Summarize what has been done to solve the challenge. -->
1) Added the remaining darkMode colors for `:disabled` and `:invalid`.
2) Changed the styling to match the sketches, and added "not-allowed" disabled cursor as discussed with Per Øyvind.

Some examples. 
| `:Disabled` Before      | `:Disabled` After |
| ----------- | ----------- |
| ![Screenshot 2023-11-01 at 5 07 45 PM](https://github.com/nsbno/spor/assets/31268781/d76ef2a7-5af9-4d8d-b8ce-2085ec3ff0a9)      | ![Screenshot 2023-11-01 at 5 06 52 PM](https://github.com/nsbno/spor/assets/31268781/937f8d41-2616-49d4-85fc-2839961d8046)       |
| ![Screenshot 2023-11-01 at 5 07 55 PM](https://github.com/nsbno/spor/assets/31268781/290e4a83-8930-424f-b3f4-a3cb85a94324)   | ![Screenshot 2023-11-01 at 5 07 02 PM](https://github.com/nsbno/spor/assets/31268781/a8c0f085-0c0b-4c69-ba0e-34d7929e3de8)        |
|![Screenshot 2023-11-14 at 3 26 03 PM](https://github.com/nsbno/spor/assets/31268781/780e4f40-3397-404a-b0e1-9e4cac27571e)    |![Screenshot 2023-11-14 at 2 51 22 PM](https://github.com/nsbno/spor/assets/31268781/62ef56b9-4d2b-4a05-bf56-589d7fb6835b)     |

From what I can see the inputs affected by the Input base styling are:
- Input
- TextArea
- SearchInput
- PasswordInput
- Combobox
- NativeSelect 

Input that are not affected and needs future addressing (disabled styling is currently either missing or off) : 
- InfoSelect
- PhoneNumberInput
