### PR TITLE
Radio cards

### DIFF
--- a/packages/spor-react/src/accordion/Accordion.tsx
+++ b/packages/spor-react/src/accordion/Accordion.tsx
@@ -64,5 +64,5 @@ export const Accordion = forwardRef<AccordionProps, "div">(
         </ChakraAccordion>
       </AccordionProvider>
     );
-  }
+  },
 );

--- a/packages/spor-react/src/input/RadioCard.tsx
+++ b/packages/spor-react/src/input/RadioCard.tsx
@@ -56,12 +56,12 @@ export const RadioCard = forwardRef<RadioCardProps, "input">((props, ref) => {
     onChange: group?.onChange,
   });
 
-  const input = getInputProps();
+  const inputProps = getInputProps();
 
   return (
     <Card
       as="label"
-      colorScheme={input.checked ? "green" : "white"}
+      colorScheme={inputProps.checked ? "green" : "white"}
       padding={3}
       cursor="pointer"
       _focusWithin={{
@@ -72,7 +72,7 @@ export const RadioCard = forwardRef<RadioCardProps, "input">((props, ref) => {
       }}
     >
       <Stack gap={3}>
-        <input {...input} ref={ref} />
+        <input {...inputProps} ref={ref} />
         {props.children}
       </Stack>
     </Card>

--- a/packages/spor-react/src/input/RadioCard.tsx
+++ b/packages/spor-react/src/input/RadioCard.tsx
@@ -10,6 +10,7 @@ import { Card } from "../card";
 import { Text } from "../typography";
 import { TextProps as ChakraTextProps } from "@chakra-ui/layout/dist/text";
 import { Stack } from "../layout";
+import { getBoxShadowString } from "../theme/utils/box-shadow-utils";
 
 export type RadioCardProps = Exclude<
   ChakraRadioProps,
@@ -57,6 +58,12 @@ export const RadioCard = forwardRef<RadioCardProps, "input">((props, ref) => {
       colorScheme={input.checked ? "green" : "white"}
       padding={3}
       cursor="pointer"
+      _focusWithin={{
+        boxShadow: getBoxShadowString({
+          borderColor: "greenHaze",
+          borderWidth: 2,
+        }),
+      }}
     >
       <Stack gap={3}>
         <input {...input} ref={ref} />

--- a/packages/spor-react/src/input/RadioCard.tsx
+++ b/packages/spor-react/src/input/RadioCard.tsx
@@ -1,0 +1,77 @@
+import {
+  Radio as ChakraRadio,
+  RadioProps as ChakraRadioProps,
+  forwardRef,
+  useRadio,
+  useRadioGroupContext,
+} from "@chakra-ui/react";
+import React, { FormEvent } from "react";
+import { Card } from "../card";
+import { Text } from "../typography";
+import { TextProps as ChakraTextProps } from "@chakra-ui/layout/dist/text";
+import { Stack } from "../layout";
+
+export type RadioCardProps = Exclude<
+  ChakraRadioProps,
+  "colorScheme" | "size" | "variant"
+>;
+
+/**
+ * The humble radio button.
+ *
+ * Specify the label as `children` and the value as `value`.
+ *
+ * ```tsx
+ * <Radio value="#f00">Red</Radio>
+ * ```
+ *
+ * You typically want to place Radio components in a group with several other Radio components. You can do that with the `RadioGroup` component.
+ *
+ * ```tsx
+ * <RadioGroup name="ticket">
+ *   <RadioCard value="economy">Economy</Radio>
+ *   <Radio value="business">Business</Radio>
+ *   <Radio value="first-class">First Class</Radio>
+ * </RadioGroup>
+ */
+export const RadioCard = forwardRef<RadioCardProps, "input">((props, ref) => {
+  const group = useRadioGroupContext();
+
+  const isChecked =
+    group?.value !== null &&
+    props.value !== null &&
+    group.value === props.value;
+
+  const { getInputProps } = useRadio({
+    ...props,
+    isChecked,
+    name: group.name,
+    onChange: group.onChange,
+  });
+
+  const input = getInputProps();
+
+  return (
+    <Card
+      as="label"
+      colorScheme={input.checked ? "green" : "white"}
+      padding={3}
+    >
+      <Stack gap={3}>
+        <input {...input} ref={ref} />
+        {props.children}
+      </Stack>
+    </Card>
+  );
+});
+
+export type RadioCardHeaderProps = Omit<ChakraTextProps, "textStyle"> & {
+  /** The size and style of the text.
+   *
+   * Defaults to "sm" */
+  variant?: ChakraTextProps["textStyle"];
+};
+
+export const RadioCardHeader = (props: RadioCardHeaderProps) => {
+  return <Text {...props} />;
+};

--- a/packages/spor-react/src/input/RadioCard.tsx
+++ b/packages/spor-react/src/input/RadioCard.tsx
@@ -46,8 +46,8 @@ export const RadioCard = forwardRef<RadioCardProps, "input">((props, ref) => {
   const { getInputProps } = useRadio({
     ...props,
     isChecked,
-    name: group.name,
-    onChange: group.onChange,
+    name: group?.name,
+    onChange: group?.onChange,
   });
 
   const input = getInputProps();

--- a/packages/spor-react/src/input/RadioCard.tsx
+++ b/packages/spor-react/src/input/RadioCard.tsx
@@ -18,21 +18,27 @@ export type RadioCardProps = Exclude<
 >;
 
 /**
- * The humble radio button.
+ * Radio buttons that look like cards.
  *
- * Specify the label as `children` and the value as `value`.
+ * Specify the label in a `<RadioCardHeader>` and the value as `value`.
  *
  * ```tsx
- * <Radio value="#f00">Red</Radio>
+ * <RadioCard value="#f00"><RadioCardHeader>Red</RadioCardHeader></RadioCard>
  * ```
  *
- * You typically want to place Radio components in a group with several other Radio components. You can do that with the `RadioGroup` component.
+ * You typically want to place RadioCard components in a group with several other RadioCard components. You can do that with the `RadioGroup` component.
  *
  * ```tsx
  * <RadioGroup name="ticket">
- *   <RadioCard value="economy">Economy</Radio>
- *   <Radio value="business">Business</Radio>
- *   <Radio value="first-class">First Class</Radio>
+ *   <RadioCard value="economy">
+ *     <RadioCardHeader>Economy</RadioCardHeader>
+ *   </RadioCard>
+ *   <RadioCard value="business">
+ *     <RadioCardHeader>Business</RadioCardHeader>
+ *   </RadioCard>
+ *   <RadioCard value="first-class">
+ *     <RadioCardHeader>First Class</RadioCardHeader>
+ *   </RadioCard>
  * </RadioGroup>
  */
 export const RadioCard = forwardRef<RadioCardProps, "input">((props, ref) => {

--- a/packages/spor-react/src/input/RadioCard.tsx
+++ b/packages/spor-react/src/input/RadioCard.tsx
@@ -56,6 +56,7 @@ export const RadioCard = forwardRef<RadioCardProps, "input">((props, ref) => {
       as="label"
       colorScheme={input.checked ? "green" : "white"}
       padding={3}
+      cursor="pointer"
     >
       <Stack gap={3}>
         <input {...input} ref={ref} />

--- a/packages/spor-react/src/input/index.tsx
+++ b/packages/spor-react/src/input/index.tsx
@@ -18,6 +18,7 @@ export * from "./NumericStepper";
 export * from "./PasswordInput";
 export * from "./PhoneNumberInput";
 export * from "./Radio";
+export * from "./RadioCard";
 export * from "./RadioGroup";
 export * from "./SearchInput";
 export * from "./Switch";


### PR DESCRIPTION
⚠️ Not ready and not tested properly ⚠️ 

## Background
In forms and in kjøpsløpet, we need cards that work as radio buttons. This PR starts to implement this.

## Solution

Using simple radio cards, the solution in the PR works. That will create cars with the following markup:

```html
<label>
  <input type="radio" />
  <span>Tekst</span>
</label>
```

This won't work for more complex use cases, since only phrasing content is allowed inside the `label` tag ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#technical_summary)).

## Screenshots

| Screenshot |
|----|
| ![image](https://github.com/nsbno/spor/assets/5320566/b6569b7a-08b7-4cdf-b79b-06cddcbdb607) |
| ![image](https://github.com/nsbno/spor/assets/5320566/f19e4165-bd1c-47d6-9109-fc756b4f9228)|
| ![image](https://github.com/nsbno/spor/assets/5320566/ad6b894c-3c93-43ea-9c36-d507b20a5472) |
