### PR TITLE
Create custom structure to add filters

### DIFF
--- a/apps/studio/desk/structure.ts
+++ b/apps/studio/desk/structure.ts
@@ -1,0 +1,49 @@
+import {
+  MdArticle,
+  MdBackupTable,
+  MdBrush,
+  MdCategory,
+  MdMenu,
+  MdSettings,
+} from "react-icons/md";
+import { StructureResolver } from "sanity/desk";
+
+export const structure: StructureResolver = (S) =>
+  S.list()
+    .id("root")
+    .title("Content")
+    .items([
+      S.listItem()
+        .title("Articles")
+        .icon(MdArticle)
+        .child(
+          S.documentTypeList("category")
+            .title("Articles by Category")
+            .child((categoryId) =>
+              S.documentList()
+                .title("Categories")
+                .filter('_type == "article" && $categoryId == category._ref')
+                .params({ categoryId })
+            )
+        ),
+      S.listItem()
+        .title("Categories")
+        .icon(MdCategory)
+        .child(S.documentTypeList("category")),
+      S.listItem()
+        .title("Components")
+        .icon(MdBackupTable)
+        .child(S.documentTypeList("component")),
+      S.listItem()
+        .title("Illustrations")
+        .icon(MdBrush)
+        .child(S.documentTypeList("illustration")),
+      S.listItem()
+        .title("Menus")
+        .icon(MdMenu)
+        .child(S.documentTypeList("menu")),
+      S.listItem()
+        .title("Site Settings")
+        .icon(MdSettings)
+        .child(S.documentTypeList("siteSettings")),
+    ]);

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -3,6 +3,7 @@ import { visionTool } from "@sanity/vision";
 import { defineConfig } from "sanity";
 import { deskTool } from "sanity/desk";
 import VyLogo from "./components/VyLogo";
+import { structure } from "./desk/structure";
 import { schemaTypes } from "./schemas";
 
 export default defineConfig({
@@ -10,7 +11,7 @@ export default defineConfig({
   title: "Spor",
   projectId: "tbpd14t4",
   dataset: "production",
-  plugins: [deskTool(), visionTool(), codeInput()],
+  plugins: [deskTool({ structure: structure }), visionTool(), codeInput()],
   studio: {
     components: {
       logo: VyLogo,


### PR DESCRIPTION
## Background
We wanted to be able to structure our content in the Studio a bit clearer, with separate folders for each category of articles.

## Solution
Create a custom structure resolver! Recreated the original structure with their icons and added a filter for categories so that you get unique lists per category for articles. Much easier to navigate like this!

![Screenshot 2023-11-27 at 12 52 28](https://github.com/nsbno/spor/assets/47326965/8b7ac159-0d93-4b1a-b4d0-5b3b5f27e26f)
