### PR TITLE
Make it possible to pass defaultValue={null}

### DIFF
--- a/.changeset/four-seals-divide.md
+++ b/.changeset/four-seals-divide.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+TimePicker: Make defaultValue=null a valid value

--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -24,9 +24,11 @@ type TimePickerProps = Omit<BoxProps, "defaultValue" | "onChange"> & {
   value?: TimeValue;
   /** A default value, if any.
    *
-   * A `new Time(hours, minutes)` should be passed. Defaults to the current time if not provided.
+   * A `new Time(hours, minutes)` should be passed.
+   * Defaults to the current time if not provided.
+   * Can be set to null if you don't want a time to be selected by default.
    **/
-  defaultValue?: TimeValue;
+  defaultValue?: TimeValue | null;
   /** Callback for when the time changes */
   onChange?: (value: TimeValue) => void;
   /** The maxiumum number of minutes to move when the step buttons are used.


### PR DESCRIPTION
## Background
Some users don't want a default value at all to the TimePicker component.

## Solution
Make it possible to pass defaultValue={null} to disable the default value.
