### PR TITLE
Darkmode stepper

### DIFF
--- a/.changeset/selfish-wolves-end.md
+++ b/.changeset/selfish-wolves-end.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+spinner: added darkmode for Darkspinner

--- a/.changeset/warm-schools-attack.md
+++ b/.changeset/warm-schools-attack.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Stepper: added dark mode

--- a/packages/spor-react/src/loader/DarkSpinner.tsx
+++ b/packages/spor-react/src/loader/DarkSpinner.tsx
@@ -1,6 +1,6 @@
-import { spinnerDarkData } from "@vygruppen/spor-loader";
+import { spinnerDarkData, spinnerLightData } from "@vygruppen/spor-loader";
 import React from "react";
-import { Box, BoxProps, Center } from "..";
+import { Box, BoxProps, Center, useColorMode } from "..";
 import { ClientOnly } from "./ClientOnly";
 import Lottie from "./Lottie";
 
@@ -26,11 +26,13 @@ export const DarkSpinner = ({
   maxWidth,
   ...props
 }: DarkSpinnerProps) => {
+  const { colorMode } = useColorMode();
+  const spinnerData = colorMode === "dark" ? spinnerLightData : spinnerDarkData
   return (
     <Center flexDirection="column" {...props}>
       <Box width={width} maxWidth={maxWidth}>
         <ClientOnly>
-          {() => <Lottie animationData={spinnerDarkData} />}
+          {() => <Lottie animationData={spinnerData} />}
         </ClientOnly>
       </Box>
       {children && (

--- a/packages/spor-react/src/stepper/Stepper.tsx
+++ b/packages/spor-react/src/stepper/Stepper.tsx
@@ -17,6 +17,7 @@ type StepperProps = {
   title?: string;
   activeStep: number;
   steps: string[];
+  variant: "base" | "accent";
 };
 /**
  * A stepper is used to show which step of a process a user is currently in.
@@ -38,8 +39,9 @@ export const Stepper = ({
   activeStep: activeStepAsStringOrNumber,
   title,
   colorScheme,
+  variant,
 }: StepperProps) => {
-  const style = useMultiStyleConfig("Stepper", { colorScheme });
+  const style = useMultiStyleConfig("Stepper", { colorScheme, variant });
   const numberOfSteps = steps.length;
   const activeStep = Number(activeStepAsStringOrNumber);
   const { t } = useTranslation();
@@ -49,6 +51,7 @@ export const Stepper = ({
         onClick={onClick}
         activeStep={activeStep}
         colorScheme={colorScheme}
+        variant={variant}
         numberOfSteps={numberOfSteps}
       >
         <Box __css={style.container}>
@@ -74,7 +77,11 @@ export const Stepper = ({
                 borderRadius="xs"
               >
                 {steps.map((step, index) => (
-                  <StepperStep key={step} stepNumber={index + 1}>
+                  <StepperStep
+                    key={step}
+                    stepNumber={index + 1}
+                    variant={variant}
+                  >
                     {step}
                   </StepperStep>
                 ))}
@@ -88,7 +95,7 @@ export const Stepper = ({
           </Box>
           <Flex justifyContent="center" display={["none", "flex"]}>
             {steps.map((step, index) => (
-              <StepperStep key={index} stepNumber={index + 1}>
+              <StepperStep key={index} stepNumber={index + 1} variant={variant}>
                 {step}
               </StepperStep>
             ))}

--- a/packages/spor-react/src/stepper/Stepper.tsx
+++ b/packages/spor-react/src/stepper/Stepper.tsx
@@ -13,7 +13,6 @@ import { StepperProvider } from "./StepperContext";
 
 type StepperProps = {
   onClick: (clickedStep: number) => void;
-  colorScheme: "light" | "dark" | "green";
   title?: string;
   activeStep: number;
   steps: string[];
@@ -38,10 +37,9 @@ export const Stepper = ({
   steps,
   activeStep: activeStepAsStringOrNumber,
   title,
-  colorScheme,
   variant,
 }: StepperProps) => {
-  const style = useMultiStyleConfig("Stepper", { colorScheme, variant });
+  const style = useMultiStyleConfig("Stepper", { variant });
   const numberOfSteps = steps.length;
   const activeStep = Number(activeStepAsStringOrNumber);
   const { t } = useTranslation();
@@ -50,7 +48,6 @@ export const Stepper = ({
       <StepperProvider
         onClick={onClick}
         activeStep={activeStep}
-        colorScheme={colorScheme}
         variant={variant}
         numberOfSteps={numberOfSteps}
       >

--- a/packages/spor-react/src/stepper/StepperContext.tsx
+++ b/packages/spor-react/src/stepper/StepperContext.tsx
@@ -4,11 +4,13 @@ type StepperContextType = {
   activeStep: number;
   numberOfSteps: number;
   colorScheme: ColorScheme;
+  variant: Variant;
   onClick: (clickedIndex: number) => void;
 };
 const StepperContext = React.createContext<StepperContextType | null>(null);
 
 type ColorScheme = "green" | "light" | "dark";
+type Variant = "base" | "accent";
 
 type StepperProviderProps = {
   /** Stepper steps */
@@ -21,6 +23,8 @@ type StepperProviderProps = {
   activeStep: number;
   /** The amount of steps */
   numberOfSteps: number;
+  /** The current variant */
+  variant: Variant;
 };
 /**
  * Internal provider for sharing logic between stepper and stepper steps.
@@ -31,10 +35,11 @@ export const StepperProvider = ({
   onClick,
   colorScheme,
   numberOfSteps,
+  variant,
 }: StepperProviderProps) => {
   return (
     <StepperContext.Provider
-      value={{ activeStep, onClick, colorScheme, numberOfSteps }}
+      value={{ activeStep, onClick, colorScheme, numberOfSteps, variant }}
     >
       {children}
     </StepperContext.Provider>

--- a/packages/spor-react/src/stepper/StepperContext.tsx
+++ b/packages/spor-react/src/stepper/StepperContext.tsx
@@ -3,13 +3,11 @@ import React from "react";
 type StepperContextType = {
   activeStep: number;
   numberOfSteps: number;
-  colorScheme: ColorScheme;
   variant: Variant;
   onClick: (clickedIndex: number) => void;
 };
 const StepperContext = React.createContext<StepperContextType | null>(null);
 
-type ColorScheme = "green" | "light" | "dark";
 type Variant = "base" | "accent";
 
 type StepperProviderProps = {
@@ -17,8 +15,6 @@ type StepperProviderProps = {
   children: React.ReactNode;
   /** Callback whenever a stepper step is clicked */
   onClick: (clickedIndex: number) => void;
-  /** The current color scheme */
-  colorScheme: ColorScheme;
   /** The currently active step */
   activeStep: number;
   /** The amount of steps */
@@ -33,13 +29,12 @@ export const StepperProvider = ({
   activeStep,
   children,
   onClick,
-  colorScheme,
   numberOfSteps,
   variant,
 }: StepperProviderProps) => {
   return (
     <StepperContext.Provider
-      value={{ activeStep, onClick, colorScheme, numberOfSteps, variant }}
+      value={{ activeStep, onClick, numberOfSteps, variant }}
     >
       {children}
     </StepperContext.Provider>

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -22,7 +22,7 @@ export const StepperStep = ({
     colorScheme,
   });
 
-  const adjustedProps = getAdjustedBtnProps(state);
+  const adjustedProps = getButtonStylesForState(state);
 
   return (
     <Box __css={style.stepContainer}>
@@ -48,7 +48,7 @@ export const StepperStep = ({
   );
 };
 
-const getAdjustedBtnProps = (
+const getButtonStylesForState = (
   state: "completed" | "active" | "disabled"
 ): Record<string, any> => {
   switch (state) {
@@ -62,7 +62,7 @@ const getAdjustedBtnProps = (
       };
     case "completed":
       return {
-        boxShadow: "",
+        boxShadow: "none",
       };
     case "disabled":
       return {

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -1,4 +1,4 @@
-import { Flex, useMultiStyleConfig } from "@chakra-ui/react";
+import { useMultiStyleConfig } from "@chakra-ui/react";
 import { DropdownRightFill18Icon } from "@vygruppen/spor-icon-react";
 import React from "react";
 import { Box, Button } from "..";

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -14,12 +14,11 @@ export const StepperStep = ({
   stepNumber,
   variant,
 }: StepperStepProps) => {
-  const { activeStep, onClick, colorScheme } = useStepper();
+  const { activeStep, onClick } = useStepper();
   const state = getState(stepNumber!, activeStep);
   const style = useMultiStyleConfig("Stepper", {
     state,
-    variant,
-    colorScheme,
+    variant
   });
 
   const adjustedProps = getButtonStylesForState(state);

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -15,12 +15,14 @@ export const StepperStep = ({
   variant,
 }: StepperStepProps) => {
   const { activeStep, onClick, colorScheme } = useStepper();
-  const state = getVariant(stepNumber!, activeStep);
+  const state = getState(stepNumber!, activeStep);
   const style = useMultiStyleConfig("Stepper", {
     state,
     variant,
     colorScheme,
   });
+
+  const adjustedProps = getAdjustedBtnProps(state);
 
   return (
     <Box __css={style.stepContainer}>
@@ -30,24 +32,14 @@ export const StepperStep = ({
 
       <Button
         size={"xs"}
-        backgroundColor={state === "active" ? "primaryGreen" : undefined}
         variant={
           state === "active"
             ? "primary"
             : state === "completed"
-            ? "secondary"
-            : "additional"
+            ? "additional"
+            : "ghost"
         }
-        isDisabled={state === "disabled"}
-        {...(state === "active"
-          ? {
-              _hover: {},
-              boxShadow: "none",
-              cursor: "not-allowed",
-              _focus: {},
-              _active: {},
-            }
-          : undefined)}
+        {...adjustedProps}
         onClick={() => onClick(stepNumber)}
       >
         {children}
@@ -56,7 +48,39 @@ export const StepperStep = ({
   );
 };
 
-const getVariant = (stepNumber: number, activeStep: number) => {
+const getAdjustedBtnProps = (
+  state: "completed" | "active" | "disabled"
+): Record<string, any> => {
+  switch (state) {
+    case "active":
+      return {
+        _hover: {},
+        boxShadow: "none",
+        _focus: {},
+        _active: {},
+        cursor: "auto",
+      };
+    case "completed":
+      return {
+        boxShadow: "",
+      };
+    case "disabled":
+      return {
+        _disabled: {},
+        _hover: {},
+        _focus: {},
+        _active: {},
+        color: "dimGrey",
+        cursor: "auto",
+      };
+    default:
+      return {};
+  }
+};
+
+
+
+const getState = (stepNumber: number, activeStep: number) => {
   if (stepNumber < activeStep) {
     return "completed";
   }

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -1,17 +1,23 @@
 import { Flex, useMultiStyleConfig } from "@chakra-ui/react";
 import { DropdownRightFill18Icon } from "@vygruppen/spor-icon-react";
 import React from "react";
-import { Box } from "..";
+import { Box, Button } from "..";
 import { useStepper } from "./StepperContext";
 
 type StepperStepProps = {
   children: React.ReactNode;
   stepNumber: number;
+  variant: "base" | "accent";
 };
-export const StepperStep = ({ children, stepNumber }: StepperStepProps) => {
+export const StepperStep = ({
+  children,
+  stepNumber,
+  variant,
+}: StepperStepProps) => {
   const { activeStep, onClick, colorScheme } = useStepper();
-  const variant = getVariant(stepNumber!, activeStep);
+  const state = getVariant(stepNumber!, activeStep);
   const style = useMultiStyleConfig("Stepper", {
+    state,
     variant,
     colorScheme,
   });
@@ -22,17 +28,30 @@ export const StepperStep = ({ children, stepNumber }: StepperStepProps) => {
         <DropdownRightFill18Icon marginX={5} display={["none", "block"]} />
       )}
 
-      <Flex
-        __css={style.stepButton}
-        alignItems="center"
-        as="button"
-        type="button"
-        disabled={variant === "disabled" || variant === "active"}
+      <Button
+        size={"xs"}
+        backgroundColor={state === "active" ? "primaryGreen" : undefined}
+        variant={
+          state === "active"
+            ? "primary"
+            : state === "completed"
+            ? "secondary"
+            : "additional"
+        }
+        isDisabled={state === "disabled"}
+        {...(state === "active"
+          ? {
+              _hover: {},
+              boxShadow: "none",
+              cursor: "not-allowed",
+              _focus: {},
+              _active: {},
+            }
+          : undefined)}
         onClick={() => onClick(stepNumber)}
       >
-        <Box __css={style.stepNumber}>{stepNumber}</Box>
-        <Box __css={style.stepTitle}>{children}</Box>
-      </Flex>
+        {children}
+      </Button>
     </Box>
   );
 };

--- a/packages/spor-react/src/theme/components/stepper.ts
+++ b/packages/spor-react/src/theme/components/stepper.ts
@@ -56,25 +56,9 @@ const config = helpers.defineMultiStyleConfig({
       ml: 2,
       textAlign: "right",
     },
-    stepCounter: {
-      whiteSpace: "nowrap",
-      textDecoration: "underline",
-    },
     stepContainer: {
       display: "flex",
       alignItems: "center",
-    },
-    stepNumber: {
-      borderRadius: "round",
-      border: "sm",
-      borderColor: "currentColor",
-      width: 4,
-      height: 4,
-      mr: 1,
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      fontSize: ["mobile.xs", "desktop.xs"],
     },
     stepTitle: {
       textStyle: "sm",
@@ -84,19 +68,15 @@ const config = helpers.defineMultiStyleConfig({
   variants: {
     base: (props) => ({
       root: {
-        backgroundColor: "red",
+        backgroundColor: "transparent",
       },
     }),
-
     accent: (props) => ({
       root: {
-        backgroundColor: "red",
+        backgroundColor: mode("seaMist", "pine") (props),
       },
     }),
   },
-  // defaultProps: {
-  //   variant: "base",
-  // },
 });
 
 export default config;
@@ -108,8 +88,9 @@ const getRootBackgroundColor = (props: StyleFunctionProps) => {
     case "dark":
       return "darkTeal";
     case "green":
-    default:
       return "seaMist";
+    default:
+      return "transpare";
   }
 };
 
@@ -125,76 +106,3 @@ const getColor = (props: StyleFunctionProps) => {
   }
 };
 
-const getStepNumberStyles = (props: StyleFunctionProps) => {
-  switch (props.colorScheme) {
-    case "dark":
-      return {
-        backgroundColor: "white",
-        color: "darkTeal",
-      };
-    case "light":
-    case "green":
-    default:
-      return {
-        backgroundColor: mode("darkTeal", "white")(props),
-        color: mode("white", "darkTeal")(props),
-      };
-  }
-};
-
-const getDisabledColor = (props: StyleFunctionProps) => {
-  switch (props.colorScheme) {
-    case "dark":
-      return "whiteAlpha.400";
-    case "green":
-      return "dimGrey";
-    case "light":
-    default:
-      return "osloGrey";
-  }
-};
-
-const getHoverStyles = (props: StyleFunctionProps) => {
-  switch (props.colorScheme) {
-    case "dark":
-      return { backgroundColor: "pine" };
-    case "green":
-      return {
-        backgroundColor: mode("coralGreen", "primaryGreen")(props),
-      };
-    case "light":
-    default:
-      return {
-        backgroundColor: mode("seaMist", "primaryGreen")(props),
-      };
-  }
-};
-
-const getFocusStyles = (props: StyleFunctionProps) => {
-  switch (props.colorScheme) {
-    case "dark":
-      return {
-        outline: "none",
-        boxShadow: `inset 0 0 0 2px ${props.theme.colors.white}`,
-      };
-    case "light":
-    case "green":
-    default:
-      return {
-        outline: "none",
-        boxShadow: `inset 0 0 0 2px ${props.theme.colors.greenHaze}`,
-      };
-  }
-};
-
-const getActiveStyles = (props: StyleFunctionProps) => {
-  switch (props.colorScheme) {
-    case "light":
-      return { backgroundColor: "mint" };
-    case "dark":
-      return { backgroundColor: "celadon" };
-    case "green":
-    default:
-      return { color: "azure", backgroundColor: "transparent" };
-  }
-};

--- a/packages/spor-react/src/theme/components/stepper.ts
+++ b/packages/spor-react/src/theme/components/stepper.ts
@@ -12,7 +12,7 @@ const parts = anatomy("stepper").parts(
   "stepButton",
   "stepNumber",
   "stepTitle",
-  "closeButton"
+  "closeButton",
 );
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
@@ -64,13 +64,6 @@ const config = helpers.defineMultiStyleConfig({
       display: "flex",
       alignItems: "center",
     },
-    stepButton: {
-      color: "inherit",
-      display: "flex",
-      alignItems: "center",
-      padding: 1,
-      borderRadius: "xs",
-    },
     stepNumber: {
       borderRadius: "round",
       border: "sm",
@@ -89,44 +82,21 @@ const config = helpers.defineMultiStyleConfig({
     },
   }),
   variants: {
-    completed: (props) => ({
-      stepContainer: {
-        color: getColor(props),
-      },
-      stepButton: {
-        _hover: getHoverStyles(props),
-        _focus: getFocusStyles(props),
-        "&:focus:not(:focus-visible)": {
-          boxShadow: "none",
-        },
-        _focusVisible: getFocusStyles(props),
-        _active: getActiveStyles(props),
+    base: (props) => ({
+      root: {
+        backgroundColor: "red",
       },
     }),
-    active: (props) => ({
-      stepContainer: {
-        color: getColor(props),
-      },
-      stepButton: {
-        pointerEvents: "none",
-      },
-      stepNumber: getStepNumberStyles(props),
-      stepTitle: {
-        fontWeight: "bold",
-      },
-    }),
-    disabled: (props) => ({
-      stepContainer: {
-        color: getDisabledColor(props),
-      },
-      stepButton: {
-        pointerEvents: "none",
+
+    accent: (props) => ({
+      root: {
+        backgroundColor: "red",
       },
     }),
   },
-  defaultProps: {
-    colorScheme: "green",
-  },
+  // defaultProps: {
+  //   variant: "base",
+  // },
 });
 
 export default config;

--- a/packages/spor-react/src/theme/components/stepper.ts
+++ b/packages/spor-react/src/theme/components/stepper.ts
@@ -20,7 +20,6 @@ const helpers = createMultiStyleConfigHelpers(parts.keys);
 const config = helpers.defineMultiStyleConfig({
   baseStyle: (props) => ({
     root: {
-      backgroundColor: getRootBackgroundColor(props),
       display: "flex",
       alignItems: "center",
       justifyContent: ["space-between", "center"],
@@ -39,7 +38,6 @@ const config = helpers.defineMultiStyleConfig({
       display: ["flex", "none"],
       alignItems: "center",
       justifyContent: "space-between",
-      color: getColor(props),
     },
     backButton: {
       borderRadius: "xs",
@@ -77,32 +75,9 @@ const config = helpers.defineMultiStyleConfig({
       },
     }),
   },
+  defaultProps: {
+    variant: "base"
+  }
 });
 
 export default config;
-
-const getRootBackgroundColor = (props: StyleFunctionProps) => {
-  switch (props.colorScheme) {
-    case "light":
-      return "white";
-    case "dark":
-      return "darkTeal";
-    case "green":
-      return "seaMist";
-    default:
-      return "transparent";
-  }
-};
-
-const getColor = (props: StyleFunctionProps) => {
-  switch (props.colorScheme) {
-    case "light":
-      return mode("darkGrey", "white")(props);
-    case "dark":
-      return "white";
-    case "green":
-    default:
-      return mode("darkTeal", "white")(props);
-  }
-};
-

--- a/packages/spor-react/src/theme/components/stepper.ts
+++ b/packages/spor-react/src/theme/components/stepper.ts
@@ -90,7 +90,7 @@ const getRootBackgroundColor = (props: StyleFunctionProps) => {
     case "green":
       return "seaMist";
     default:
-      return "transpare";
+      return "transparent";
   }
 };
 


### PR DESCRIPTION
## Background
stepper did not have dark mode support and miss used variation

## Solution
changed variation to be used the correct way, made the component more universal by using buttons, and added dark mode support
