### PR TITLE
Darkmode card select

### DIFF
--- a/.changeset/tidy-lobsters-fail.md
+++ b/.changeset/tidy-lobsters-fail.md
@@ -1,5 +1,5 @@
 ---
-"@vygruppen/spor-react": patch
+"@vygruppen/spor-react": minor
 ---
 
-card-select: added dark mode update and new prop for background
+CardSelect: added dark mode update and new prop for background also changed outline to base and card to float in variants

--- a/.changeset/tidy-lobsters-fail.md
+++ b/.changeset/tidy-lobsters-fail.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+card-select: added dark mode update and new prop for background

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -45,6 +45,8 @@ type CardSelectProps = BoxProps & {
   placement?: AriaPositionProps["placement"];
   /** Whether or not to show the chevron. Defaults to true */
   withChevron?: boolean;
+  /** ColorScheme for different dark mode backgrounds */
+  backgroundScheme?: "dark" | "green"
 };
 
 /**
@@ -64,6 +66,7 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
   (
     {
       variant,
+      backgroundScheme,
       size,
       isOpen: externalIsOpen,
       defaultOpen = false,
@@ -96,7 +99,7 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
 
     const { buttonProps } = useButton(triggerProps, triggerRef);
 
-    const styles = useMultiStyleConfig("CardSelect", { variant, size });
+    const styles = useMultiStyleConfig("CardSelect", { variant, size, backgroundScheme });
     useForceRerender(state.isOpen);
 
     const ChevronIcon =
@@ -129,8 +132,10 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
             offset={size === "sm" ? 6 : 12}
             crossOffset={crossOffset}
             placement={placement}
+            
           >
             <Card
+              backgroundScheme={backgroundScheme}
               colorScheme="white"
               size="lg"
               sx={styles.card}

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -46,7 +46,7 @@ type CardSelectProps = BoxProps & {
   /** Whether or not to show the chevron. Defaults to true */
   withChevron?: boolean;
   /** ColorScheme for different dark mode backgrounds */
-  backgroundScheme?: "dark" | "green"
+  backgroundScheme?: "primary" | "secondary";
 };
 
 /**
@@ -61,6 +61,7 @@ type CardSelectProps = BoxProps & {
  * ```
  *
  * @see https://spor.vy.no/components/card-select
+ *
  */
 export const CardSelect = forwardRef<CardSelectProps, "button">(
   (
@@ -99,7 +100,11 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
 
     const { buttonProps } = useButton(triggerProps, triggerRef);
 
-    const styles = useMultiStyleConfig("CardSelect", { variant, size, backgroundScheme });
+    const styles = useMultiStyleConfig("CardSelect", {
+      variant,
+      size,
+      backgroundScheme,
+    });
     useForceRerender(state.isOpen);
 
     const ChevronIcon =
@@ -132,7 +137,6 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
             offset={size === "sm" ? 6 : 12}
             crossOffset={crossOffset}
             placement={placement}
-            
           >
             <Card
               backgroundScheme={backgroundScheme}

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -45,8 +45,6 @@ type CardSelectProps = BoxProps & {
   placement?: AriaPositionProps["placement"];
   /** Whether or not to show the chevron. Defaults to true */
   withChevron?: boolean;
-  /** ColorScheme for different dark mode backgrounds */
-  backgroundScheme?: "primary" | "secondary";
 };
 
 /**
@@ -67,7 +65,6 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
   (
     {
       variant,
-      backgroundScheme,
       size,
       isOpen: externalIsOpen,
       defaultOpen = false,
@@ -103,7 +100,6 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
     const styles = useMultiStyleConfig("CardSelect", {
       variant,
       size,
-      backgroundScheme,
     });
     useForceRerender(state.isOpen);
 
@@ -139,7 +135,6 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
             placement={placement}
           >
             <Card
-              backgroundScheme={backgroundScheme}
               colorScheme="white"
               size="lg"
               sx={styles.card}

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -3,6 +3,7 @@ import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
 import { StyleFunctionProps, mode } from "@chakra-ui/theme-tools";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
+import { baseBackground, floatingBackground, ghostBackground } from "../utils/background-utils";
 
 const parts = anatomy("card-select").parts("trigger", "card");
 
@@ -54,20 +55,20 @@ const config = helpers.defineMultiStyleConfig({
           }),
         },
         _active: {
-          backgroundColor: mode("mint", "whiteAlpha.200")(props),
+          ...baseBackground("active", props),
           boxShadow: getBoxShadowString({
             borderColor: mode("darkGrey", "whiteAlpha.400")(props),
             borderWidth: 1,
           }),
         },
         _expanded: {
-          backgroundColor: mode("mint", "whiteAlpha.100")(props),
+          ...baseBackground("active", props),
           _hover: {
-            backgroundColor: mode("seaMist", "todo")(props),
+            ...baseBackground("active", props),
             boxShadow: "none",
           },
           _active: {
-            backgroundColor: mode("mint", "todo")(props),
+            ...baseBackground("active", props),
             boxShadow: getBoxShadowString({
               borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
               borderWidth: 1,
@@ -79,23 +80,23 @@ const config = helpers.defineMultiStyleConfig({
     ghost: (props) => ({
       trigger: {
         _hover: {
-          backgroundColor: mode("seaMist", "pine")(props),
+         ...ghostBackground("hover", props),
         },
         _active: {
-          backgroundColor: mode("mint", "whiteAlpha.200")(props),
+          ...ghostBackground("active", props),
         },
         _expanded: {
-          backgroundColor: mode("mint", "whiteAlpha.200")(props),
+          ...ghostBackground("selected", props),
         },
       },
     }),
     floating: (props) => ({
       trigger: {
-        backgroundColor: mode("transparent", "whiteAlpha.100")(props),
+        ...floatingBackground("default", props),
         boxShadow: "sm",
         transition: "all .1s ease-out",
         _hover: {
-          backgroundColor: mode("seaMist", "pine")(props),
+          ...floatingBackground("hover", props),
           boxShadow: getBoxShadowString({
             borderColor: mode("silver", "whiteAlpha.400")(props),
             borderWidth: 1,
@@ -103,7 +104,7 @@ const config = helpers.defineMultiStyleConfig({
           }),
         },
         _active: {
-          backgroundColor: mode("mint", "whiteAlpha.100")(props),
+          ...floatingBackground("active", props),
           boxShadow: getBoxShadowString({
             borderColor: mode("silver", "whiteAlpha.400")(props),
             borderWidth: mode(0, 1)(props),
@@ -111,7 +112,7 @@ const config = helpers.defineMultiStyleConfig({
           }),
         },
         _expanded: {
-          backgroundColor: mode("mint", "whiteAlpha.100")(props),
+          ...floatingBackground("active", props),
           _hover: {
             boxShadow: getBoxShadowString({
               borderColor: "darkGrey",
@@ -119,7 +120,7 @@ const config = helpers.defineMultiStyleConfig({
             }),
           },
           _active: {
-            backgroundColor: mode("mint", "whiteAlpha.200")(props),
+            ...floatingBackground("active", props),
             boxShadow: "none",
           },
         },

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -33,7 +33,7 @@ const config = helpers.defineMultiStyleConfig({
     },
   }),
   variants: {
-    outline: (props) => ({
+    base: (props) => ({
       trigger: {
         boxShadow: getBoxShadowString({
           borderColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
@@ -86,11 +86,11 @@ const config = helpers.defineMultiStyleConfig({
           backgroundColor: mode("mint", "whiteAlpha.200")(props),
         },
         _expanded: {
-          backgroundColor: mode("mint", "whiteAlpha.200")(props)
-        }
+          backgroundColor: mode("mint", "whiteAlpha.200")(props),
+        },
       },
     }),
-    card: (props) => ({
+    floating: (props) => ({
       trigger: {
         backgroundColor: mode("transparent", "whiteAlpha.100")(props),
         boxShadow: "sm",
@@ -112,7 +112,7 @@ const config = helpers.defineMultiStyleConfig({
           }),
         },
         _expanded: {
-          backgroundColor: mode("mint","whiteAlpha.100")(props),
+          backgroundColor: mode("mint", "whiteAlpha.100")(props),
           _hover: {
             boxShadow: getBoxShadowString({
               borderColor: "darkGrey",
@@ -160,13 +160,12 @@ const config = helpers.defineMultiStyleConfig({
 
 export default config;
 
-
 const getBackgroundColor = (props: StyleFunctionProps) => {
   switch (props.backgroundScheme) {
-    case "dark":
-      return mode("white", "darkGrey")(props);;
-    case "green":
-      return mode("white", "night")(props);;
+    case "primary":
+      return mode("white", "darkGrey")(props);
+    case "secondary":
+      return mode("white", "night")(props);
     default:
       return mode("white", "whiteAlpha.100")(props);
   }

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -29,7 +29,6 @@ const config = helpers.defineMultiStyleConfig({
       boxShadow: "md",
       padding: 3,
       color: mode("darkGrey", "white")(props),
-      backgroundColor: getBackgroundColor(props),
     },
   }),
   variants: {
@@ -159,14 +158,3 @@ const config = helpers.defineMultiStyleConfig({
 });
 
 export default config;
-
-const getBackgroundColor = (props: StyleFunctionProps) => {
-  switch (props.backgroundScheme) {
-    case "primary":
-      return mode("white", "darkGrey")(props);
-    case "secondary":
-      return mode("white", "night")(props);
-    default:
-      return mode("white", "whiteAlpha.100")(props);
-  }
-};

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -1,6 +1,6 @@
 import { anatomy } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
-import { mode } from "@chakra-ui/theme-tools";
+import { StyleFunctionProps, mode } from "@chakra-ui/theme-tools";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
 
@@ -28,6 +28,8 @@ const config = helpers.defineMultiStyleConfig({
       borderRadius: "sm",
       boxShadow: "md",
       padding: 3,
+      color: mode("darkGrey", "white")(props),
+      backgroundColor: getBackgroundColor(props),
     },
   }),
   variants: {
@@ -157,3 +159,15 @@ const config = helpers.defineMultiStyleConfig({
 });
 
 export default config;
+
+
+const getBackgroundColor = (props: StyleFunctionProps) => {
+  switch (props.backgroundScheme) {
+    case "dark":
+      return mode("white", "darkGrey")(props);;
+    case "green":
+      return mode("white", "night")(props);;
+    default:
+      return mode("white", "whiteAlpha.100")(props);
+  }
+};

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -3,7 +3,11 @@ import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
 import { StyleFunctionProps, mode } from "@chakra-ui/theme-tools";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
 import { focusVisible } from "../utils/focus-utils";
-import { baseBackground, floatingBackground, ghostBackground } from "../utils/background-utils";
+import {
+  baseBackground,
+  floatingBackground,
+  ghostBackground,
+} from "../utils/background-utils";
 
 const parts = anatomy("card-select").parts("trigger", "card");
 
@@ -80,7 +84,7 @@ const config = helpers.defineMultiStyleConfig({
     ghost: (props) => ({
       trigger: {
         _hover: {
-         ...ghostBackground("hover", props),
+          ...ghostBackground("hover", props),
         },
         _active: {
           ...ghostBackground("active", props),

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -13,9 +13,6 @@ const config = helpers.defineMultiStyleConfig({
       appearance: "none",
       display: "flex",
       alignItems: "center",
-      _expanded: {
-        backgroundColor: mode("mint", "night")(props),
-      },
       ...focusVisible({
         notFocus: {},
         focus: {
@@ -34,16 +31,6 @@ const config = helpers.defineMultiStyleConfig({
     },
   }),
   variants: {
-    ghost: (props) => ({
-      trigger: {
-        _hover: {
-          backgroundColor: mode("seaMist", "pine")(props),
-        },
-        _active: {
-          backgroundColor: mode("mint", "whiteAlpha.200")(props),
-        },
-      },
-    }),
     outline: (props) => ({
       trigger: {
         boxShadow: getBoxShadowString({
@@ -72,8 +59,8 @@ const config = helpers.defineMultiStyleConfig({
             borderWidth: 1,
           }),
         },
-
         _expanded: {
+          backgroundColor: mode("mint", "whiteAlpha.100")(props),
           _hover: {
             backgroundColor: mode("seaMist", "todo")(props),
             boxShadow: "none",
@@ -86,6 +73,19 @@ const config = helpers.defineMultiStyleConfig({
             }),
           },
         },
+      },
+    }),
+    ghost: (props) => ({
+      trigger: {
+        _hover: {
+          backgroundColor: mode("seaMist", "pine")(props),
+        },
+        _active: {
+          backgroundColor: mode("mint", "whiteAlpha.200")(props),
+        },
+        _expanded: {
+          backgroundColor: mode("mint", "whiteAlpha.200")(props)
+        }
       },
     }),
     card: (props) => ({
@@ -110,6 +110,7 @@ const config = helpers.defineMultiStyleConfig({
           }),
         },
         _expanded: {
+          backgroundColor: mode("mint","whiteAlpha.100")(props),
           _hover: {
             boxShadow: getBoxShadowString({
               borderColor: "darkGrey",

--- a/packages/spor-react/src/theme/utils/background-utils.ts
+++ b/packages/spor-react/src/theme/utils/background-utils.ts
@@ -84,27 +84,21 @@ export function floatingBackground(
       return {
         backgroundColor: mode(
           "mint",
-          `color-mix(in srgb, ${
-            props.theme.colors.accent
-          }, ${colors.white} 30%)`,
+          `color-mix(in srgb, ${props.theme.colors.accent}, ${colors.white} 30%)`,
         )(props),
       };
     case "hover":
       return {
         backgroundColor: mode(
           "white",
-          `color-mix(in srgb, ${
-            props.theme.colors.accent
-          }, ${colors.white} 20%)`,
+          `color-mix(in srgb, ${props.theme.colors.accent}, ${colors.white} 20%)`,
         )(props),
       };
     case "focus":
       return {
         backgroundColor: mode(
           "white",
-          `color-mix(in srgb, ${
-            props.theme.colors.accent
-          }, ${colors.white} 40%)`,
+          `color-mix(in srgb, ${props.theme.colors.accent}, ${colors.white} 40%)`,
         )(props),
       };
     case "default":
@@ -112,9 +106,7 @@ export function floatingBackground(
       return {
         backgroundColor: mode(
           "white",
-          `color-mix(in srgb, ${
-            props.theme.colors.accent
-          }, ${colors.white} 10%)`,
+          `color-mix(in srgb, ${props.theme.colors.accent}, ${colors.white} 10%)`,
         )(props),
       };
   }

--- a/packages/spor-react/src/theme/utils/background-utils.ts
+++ b/packages/spor-react/src/theme/utils/background-utils.ts
@@ -17,7 +17,7 @@ export function baseBackground(
       };
     case "selected":
       return {
-        backgroundColor: "pine",
+        backgroundColor: mode("pine", "coralGreen")(props),
       };
     case "disabled":
       return {
@@ -85,7 +85,7 @@ export function floatingBackground(
         backgroundColor: mode(
           "mint",
           `color-mix(in srgb, ${
-            props.theme.darkBackgroundColor ?? colors.darkGrey
+            props.theme.colors.accent
           }, ${colors.white} 30%)`,
         )(props),
       };
@@ -94,7 +94,7 @@ export function floatingBackground(
         backgroundColor: mode(
           "white",
           `color-mix(in srgb, ${
-            props.theme.darkBackgroundColor ?? colors.darkGrey
+            props.theme.colors.accent
           }, ${colors.white} 20%)`,
         )(props),
       };
@@ -103,7 +103,7 @@ export function floatingBackground(
         backgroundColor: mode(
           "white",
           `color-mix(in srgb, ${
-            props.theme.darkBackgroundColor ?? colors.darkGrey
+            props.theme.colors.accent
           }, ${colors.white} 40%)`,
         )(props),
       };
@@ -113,7 +113,7 @@ export function floatingBackground(
         backgroundColor: mode(
           "white",
           `color-mix(in srgb, ${
-            props.theme.darkBackgroundColor ?? colors.darkGrey
+            props.theme.colors.accent
           }, ${colors.white} 10%)`,
         )(props),
       };


### PR DESCRIPTION
## Background
background for card popover was transparent and didnt work on every surface

component lacked som dark mode updates

## Solution
gave the component a less transparent background as default and props for the developer to chose between a solid dark background or green background.

updated dark mode support for the component
