### PR TITLE
Make value in TimePicker nullable

### DIFF
--- a/.changeset/smart-mice-laugh.md
+++ b/.changeset/smart-mice-laugh.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+TimePicker: Allow for null values (so the time can be reset)

--- a/packages/spor-react/src/datepicker/TimeField.tsx
+++ b/packages/spor-react/src/datepicker/TimeField.tsx
@@ -2,13 +2,13 @@ import { Box, Flex } from "@chakra-ui/react";
 import { CalendarDateTime, Time } from "@internationalized/date";
 import React, { useRef } from "react";
 import { AriaTimeFieldProps, useTimeField } from "react-aria";
-import { DateFieldState } from "react-stately";
+import { TimeFieldState } from "@react-stately/datepicker";
 import { FormLabel } from "..";
 import { DateTimeSegment } from "./DateTimeSegment";
 import { getTimestampFromTime } from "./utils";
 
 type TimeFieldProps = AriaTimeFieldProps<Time> & {
-  state: DateFieldState;
+  state: TimeFieldState;
   label: string;
   name?: string;
 };

--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -19,9 +19,10 @@ type TimePickerProps = Omit<BoxProps, "defaultValue" | "onChange"> & {
   name?: string;
   /** The controlled value, if any.
    *
-   * A `new Time(hours, minutes)` should be passed
+   * A `new Time(hours, minutes)` should be passed.
+   * Or `null` if the time should be unset.
    **/
-  value?: TimeValue;
+  value?: TimeValue | null;
   /** A default value, if any.
    *
    * A `new Time(hours, minutes)` should be passed.


### PR DESCRIPTION
## Background

We want to be able to used a controlled time picker with the ability to unset the time.

## Solution

`react-stately` appears to already support `null` as value in `useTimeField`. We therefore only make the value type of `TimePicker` match `useTimeField`.
