### PR TITLE
New major version: Change button variant naming

### DIFF
--- a/.changeset/witty-mayflies-nail.md
+++ b/.changeset/witty-mayflies-nail.md
@@ -1,0 +1,11 @@
+---
+"@vygruppen/spor-react": major
+---
+
+Breaking: Rename <Button variant="additional" /> to <Button variant="tertiary" />
+
+Due to a… minor screwup on ~our~ @selbekk's side, we deprecated the wrong name earlier on.
+
+To mitigate my screwup, please search through your code base for "additional", and replace it with "tertiary". It should be a simple enough upgrade. Make sure to do this with all Button and IconButton components.
+
+Sorry. - @selbekk.

--- a/apps/docs/app/features/portable-text/code-block/CodeBlock.tsx
+++ b/apps/docs/app/features/portable-text/code-block/CodeBlock.tsx
@@ -109,7 +109,7 @@ export const CopyCodeButton = forwardRef<CopyCodeButtonProps, "button">(
     return (
       <DarkMode>
         <Button
-          variant="additional"
+          variant="tertiary"
           color="white"
           backgroundColor="darkGrey"
           boxShadow="inset 0 0 0 1px white, 0 0 10px 0.25rem rgba(0,0,0,0.7)"

--- a/apps/docs/app/features/portable-text/interactive-code/LivePreview.tsx
+++ b/apps/docs/app/features/portable-text/interactive-code/LivePreview.tsx
@@ -23,7 +23,7 @@ export const LivePreview = (props: BoxProps) => {
         <Box position="absolute" top={2} right={2} zIndex="popover">
           <IconButton
             size="sm"
-            variant="additional"
+            variant="tertiary"
             onClick={() => setDarkMode((d) => !d)}
             icon={isDarkMode ? <SummerFill24Icon /> : <NightFill24Icon />}
             aria-label={isDarkMode ? "Dark mode" : "Light mode"}

--- a/apps/docs/app/routes/_base.$category.$slug/route.tsx
+++ b/apps/docs/app/routes/_base.$category.$slug/route.tsx
@@ -174,7 +174,7 @@ export default function ArticlePage() {
               key={link.url}
               as="a"
               href={link.url}
-              variant="additional"
+              variant="tertiary"
               size="sm"
               leftIcon={mapLinkToIcon(link.linkType)}
             >

--- a/apps/studio/schemas/objects/buttonLink.tsx
+++ b/apps/studio/schemas/objects/buttonLink.tsx
@@ -27,7 +27,7 @@ export const buttonLink = defineType({
         list: [
           { title: "Primary", value: "primary" },
           { title: "Secondary", value: "secondary" },
-          { title: "Additional", value: "additional" },
+          { title: "Tertiary", value: "tertiary" },
           { title: "Control", value: "control" },
         ],
       },

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -28,7 +28,7 @@ export type ButtonProps = Exclude<
     | "control"
     | "primary"
     | "secondary"
-    | "additional"
+    | "tertiary"
     | "ghost"
     | "floating";
 };
@@ -40,7 +40,7 @@ export type ButtonProps = Exclude<
  * - `control`: This button is used for ticket controls only.
  * - `primary`: This is our main button. It's used for the main actions in a view, like a call to action. There should only be a single primary button in each view.
  * - `secondary`: Used for secondary actions in a view, and when you need to make several actions available at the same time.
- * - `additional`: Used for additional choices, like a less important secondary action.
+ * - `tertiary`: Used for additional choices, like a less important secondary action.
  * - `ghost`: Used inside other interactive elements, like date pickers and input fields.
  * - `floating`: Used for floating actions, like a menu button in a menu.
  *

--- a/packages/spor-react/src/button/IconButton.tsx
+++ b/packages/spor-react/src/button/IconButton.tsx
@@ -12,7 +12,7 @@ export type IconButtonProps = Omit<ChakraIconButtonProps, "variant"> & {
     | "control"
     | "primary"
     | "secondary"
-    | "additional"
+    | "tertiary"
     | "ghost"
     | "floating";
 };
@@ -26,7 +26,7 @@ export type IconButtonProps = Omit<ChakraIconButtonProps, "variant"> & {
  * - `control`: This button is used for ticket controls only.
  * - `primary`: This is our main button. It's used for the main actions in a view, like a call to action. There should only be a single primary button in each view.
  * - `secondary`: Used for secondary actions in a view, and when you need to make several actions available at the same time.
- * - `additional`: Used for additional choices, like a less important secondary action.
+ * - `tertiary`: Used for additional choices, like a less important secondary action.
  * - `ghost`: Used inside other interactive elements, like date pickers and input fields.
  * - `floating`: Used for floating actions, like a menu button in a menu.
  *

--- a/packages/spor-react/src/popover/PopoverWizardBody.tsx
+++ b/packages/spor-react/src/popover/PopoverWizardBody.tsx
@@ -64,7 +64,7 @@ const NextStepButton = ({ isLastStep, onNext }: NextStepButtonProps) => {
   const { t } = useTranslation();
   return (
     <Button
-      variant="additional"
+      variant="tertiary"
       size="sm"
       color="white"
       leftIcon={isLastStep ? undefined : <ArrowRightFill18Icon />}

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -35,7 +35,7 @@ export const StepperStep = ({
           state === "active"
             ? "primary"
             : state === "completed"
-            ? "additional"
+            ? "tertiary"
             : "ghost"
         }
         {...adjustedProps}

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -106,7 +106,7 @@ const config = defineStyleConfig({
         },
       },
     }),
-    tertiary: (props) => ({
+    additional: (props) => ({
       backgroundColor: "transparent",
       color: mode("darkGrey", "white")(props),
       fontWeight: "normal",

--- a/packages/spor-react/src/toast/ActionToast.tsx
+++ b/packages/spor-react/src/toast/ActionToast.tsx
@@ -20,7 +20,7 @@ export const ActionToast = ({
       <Box marginRight={2} flexGrow="1">
         {children}
       </Box>
-      <Button variant="additional" size="sm" onClick={onClick}>
+      <Button variant="tertiary" size="sm" onClick={onClick}>
         {buttonText}
       </Button>
     </BaseToast>


### PR DESCRIPTION
## Background
Looks like we've miscommunicated a bit. It was the Button's `additional` variant that was supposed to be deprecated and removed, not the tertiary variant.

## Solution

This PR renames the additional variant of both Button and IconButton to tertiary. It's a breaking change, but a simple one to go through.
