### PR TITLE
Fix some issues with loading states on buttons and icon buttons

### DIFF
--- a/.changeset/tasty-pianos-hear.md
+++ b/.changeset/tasty-pianos-hear.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Button, IconButton: Fix a bug that broke loading states

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -69,6 +69,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
     isDisabled,
     leftIcon,
     rightIcon,
+    ...rest
   } = props;
   const ariaLabel = useCorrectAriaLabel(props);
   const buttonGroup = useButtonGroup();
@@ -83,7 +84,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
     <ChakraButton
       size={finalSize}
       variant={finalVariant}
-      {...props}
+      {...rest}
       ref={ref}
       aria-label={ariaLabel}
       aria-busy={isLoading}
@@ -118,8 +119,9 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
         >
           <ColorInlineLoader
             maxWidth={getLoaderWidth(finalSize)}
-            width="100%"
+            width="80%"
             marginX={2}
+            marginY={2}
           />
         </Center>
       )}

--- a/packages/spor-react/src/button/IconButton.tsx
+++ b/packages/spor-react/src/button/IconButton.tsx
@@ -56,7 +56,9 @@ export const IconButton = forwardRef<IconButtonProps, As>(
     <ChakraIconButton
       title={props["aria-label"]}
       {...props}
-      spinner={<ColorSpinner margin={1} />}
+      spinner={
+        <ColorSpinner width="80%" height="80%" marginX={1} marginTop={1} />
+      }
       ref={ref}
     />
   ),


### PR DESCRIPTION
## Background

The loading state on buttons was a bit borked. It grew in height when you used icons, and the wrong spinner was used.

## Solution

There were a few things wrong.
- All props were forwarded to the underlying button component, instead of removing the correct ones
- The icon button loading spinner was misaligned.

Fixes #945