### PR TITLE
Make DatePicker handle null values correctly

### DIFF
--- a/.changeset/polite-eyes-laugh.md
+++ b/.changeset/polite-eyes-laugh.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+DatePicker: Fix bug where field went from uncontrolled to controleld

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -64,7 +64,7 @@ export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
         </Flex>
         <input
           type="hidden"
-          value={state.value?.toString()}
+          value={state.value?.toString() ?? ""}
           name={props.name}
         />
       </Box>


### PR DESCRIPTION
## Background

When passing in `value={null}` or `defaultValue={null}` to a DatePicker component, a warning was printed to the console about the input going from uncontrolled to controlled.

## Solution

The issue came from the hidden input field changing from undefined to a value. This was fixed by falling back to an empty value if the value passed was null.

Fixes #950.