### PR TITLE
[spor-react] Add null as possible type on Date and Time picker components

### DIFF
--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -25,7 +25,7 @@ import { DateField } from "./DateField";
 import { StyledField } from "./StyledField";
 import { useCurrentLocale } from "./utils";
 
-type DatePickerProps = AriaDatePickerProps<DateValue> &
+type DatePickerProps = AriaDatePickerProps<DateValue | null> &
   Pick<BoxProps, "minHeight" | "width"> & {
     variant: ResponsiveValue<"base" | "floating" | "ghost">;
     name?: string;

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -29,7 +29,7 @@ import { RangeCalendar } from "./RangeCalendar";
 import { StyledField } from "./StyledField";
 import { useCurrentLocale } from "./utils";
 
-type DateRangePickerProps = AriaDateRangePickerProps<DateValue> &
+type DateRangePickerProps = AriaDateRangePickerProps<DateValue | null> &
   Pick<BoxProps, "minHeight"> & {
     startLabel?: string;
     startName?: string;

--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -31,7 +31,7 @@ type TimePickerProps = Omit<BoxProps, "defaultValue" | "onChange"> & {
    **/
   defaultValue?: TimeValue | null;
   /** Callback for when the time changes */
-  onChange?: (value: TimeValue) => void;
+  onChange?: (value: TimeValue | null) => void;
   /** The maxiumum number of minutes to move when the step buttons are used.
    *
    * Defaults to 30 minutes.


### PR DESCRIPTION
## Background

The values provided into the `onChange` function on date and time pickers in `spor-react` can sometimes be a `null` value in practice, but the type doesn't reflect this.

## Solution

`DatePicker` and `DateRangePicker`: expand the entire prop type to be nullable to match `TimePicker`.
`TimePicker`: widen the `onChange` type only, as the other props already accept `null`.

## Notes

I couldn't immediately find any guidelines on how to increment versions properly, so I'll be grateful for some pointers in that regard. This PR changes the API on these components in a way that will break any TS code which uses any of these pickers without handling the `null` case (but not JS since it doesn't actually change any logic, only the signature), and as such should probably be a major level change.

I tried to implement this internally so we wouldn't have to change the API (which would then only be a patch level update), but couldn't understand how it works with all the jumping into and out of Adobe ARIA/state/etc. packages. Though I'll be happy to spar with you guys about how we can do it that way instead!