### PR TITLE
Fix the + and - icon in NumericStepper on dark mode

### DIFF
--- a/.changeset/hungry-fishes-swim.md
+++ b/.changeset/hungry-fishes-swim.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+NumericStepper: Fixed the Icon-color for NumericStepper on dark mode

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -91,7 +91,7 @@ export function NumericStepper({
   return (
     <Flex alignItems="center" {...boxProps}>
       <VerySmallButton
-        icon={<SubtractIcon color="white" stepLabel={clampedStepSize} />}
+        icon={<SubtractIcon stepLabel={clampedStepSize} />}
         aria-label={t(texts.decrementButtonAriaLabel(clampedStepSize))}
         onClick={() => onChange(Math.max(value - clampedStepSize, minValue))}
         visibility={value <= minValue ? "hidden" : "visible"}
@@ -164,7 +164,7 @@ export function NumericStepper({
         </chakra.text>
       )}
       <VerySmallButton
-        icon={<AddIcon color="white" stepLabel={clampedStepSize} />}
+        icon={<AddIcon stepLabel={clampedStepSize} />}
         aria-label={t(texts.incrementButtonAriaLabel(clampedStepSize))}
         onClick={() => onChange(Math.min(value + clampedStepSize, maxValue))}
         visibility={value >= maxValue ? "hidden" : "visible"}


### PR DESCRIPTION
## Background

The changes to buttons made the + and - symbols in NumericStepper unreadable in dark mode:

![bilde](https://github.com/nsbno/spor/assets/15088360/25b9494a-b36d-4bff-ac59-5a1918ba4d79)


## Solution


Fixed it by removing the color override:

![bilde](https://github.com/nsbno/spor/assets/15088360/186f5b08-12fa-4c46-b858-179ced1f102a)

light mode still works as normal:

![bilde](https://github.com/nsbno/spor/assets/15088360/aed5fe5b-bd02-4714-842e-5ef4dbb609c8)

