### PR TITLE
Bump node version to v20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install Dependencies
         run: npm install

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -1,5 +1,5 @@
 # base node image
-FROM node:16-alpine as base
+FROM node:20-alpine as base
 
 # set for base and all that inherit from it
 ENV NODE_ENV=production

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "turbo": "^1.11.0"
   },
   "engines": {
-    "npm": ">=7.0.0",
-    "node": ">=14.0.0"
+    "npm": ">=10.0.0",
+    "node": ">=18.0.0"
   },
-  "packageManager": "npm@8.1.2",
+  "packageManager": "npm@10.0.0",
   "prettier": {}
 }


### PR DESCRIPTION
## Background

We were using Node v16, which was deprecated and no longer supported. The newest version of Remix also breaks with node 16.

## Solution

Bump everything to node 20.
