### PR TITLE
Make full onChange value nullable for DateRangePicker

### DIFF
--- a/.changeset/swift-pots-brush.md
+++ b/.changeset/swift-pots-brush.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Make full date range type nullable in onChange

--- a/.changeset/swift-pots-brush.md
+++ b/.changeset/swift-pots-brush.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-react": minor
 ---
 
-Make full date range type nullable in onChange
+DateRangePicker: Make full date range type nullable in onChange

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -40,10 +40,12 @@ type DateRangePickerProps = Omit<
     endName?: string;
     variant: ResponsiveValue<"base" | "floating" | "ghost">;
     withPortal?: boolean;
-    onChange?: (dates: {
-      start: DateValue | null;
-      end: DateValue | null;
-    }) => void;
+    onChange?: (
+      dates: {
+        start: DateValue | null;
+        end: DateValue | null;
+      } | null,
+    ) => void;
   };
 /**
  * A date range picker component.


### PR DESCRIPTION
## Background

Turns out not only the inner `start` and `end` fields in the `onChange` handler of `DateRangePicker` are nullable, but the wrapping object itself is also in practice null sometimes.

## Solution

Add null as a possible type to the input value of `DateRangePicker`'s `onChange` function signature.
