### PR TITLE
Remove ProgressDot export

### DIFF
--- a/.changeset/curvy-feet-allow.md
+++ b/.changeset/curvy-feet-allow.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+ProgressIndicator: Remove ProgressDot import, as it wasn't meant for public exposure.

--- a/packages/spor-react/src/progress-indicator/ProgressIndicator.tsx
+++ b/packages/spor-react/src/progress-indicator/ProgressIndicator.tsx
@@ -1,6 +1,6 @@
+import { useMultiStyleConfig } from "@chakra-ui/react";
 import React from "react";
 import { Box, createTexts, useTranslation } from "..";
-import { useMultiStyleConfig } from "@chakra-ui/react";
 import { ProgressDot } from "./ProgressDot";
 
 type ProgressIndicatorProps = {

--- a/packages/spor-react/src/progress-indicator/index.tsx
+++ b/packages/spor-react/src/progress-indicator/index.tsx
@@ -1,2 +1,1 @@
 export * from "./ProgressIndicator";
-export * from "./ProgressDot";


### PR DESCRIPTION
## Background

With #932, we exported a component that's only used internally.

## Solution

Remove the export. It's in theory a breaking change, but the previous version hasn't been published yet.
