### PR TITLE
Fix bug with colors being overridden

### DIFF
--- a/.changeset/spicy-rabbits-sort.md
+++ b/.changeset/spicy-rabbits-sort.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+general: Fix a bug with brand styles overriding all colors

--- a/package-lock.json
+++ b/package-lock.json
@@ -17376,7 +17376,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -37868,6 +37867,7 @@
         "@vygruppen/spor-icon-react": "*",
         "@vygruppen/spor-loader": "*",
         "awesome-phonenumber": "^5.10.0",
+        "deepmerge": "^4.3.1",
         "framer-motion": "^9.1.7",
         "lottie-react": "^2.3.1",
         "react-aria": "^3.30.0",

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -26,6 +26,7 @@
     "@vygruppen/spor-icon-react": "*",
     "@vygruppen/spor-loader": "*",
     "awesome-phonenumber": "^5.10.0",
+    "deepmerge": "^4.3.1",
     "framer-motion": "^9.1.7",
     "lottie-react": "^2.3.1",
     "react-aria": "^3.30.0",

--- a/packages/spor-react/src/provider/SporProvider.tsx
+++ b/packages/spor-react/src/provider/SporProvider.tsx
@@ -1,8 +1,9 @@
 import { ChakraProvider, ChakraProviderProps } from "@chakra-ui/react";
 import { Global } from "@emotion/react";
+import deepmerge from "deepmerge";
 import React from "react";
 import { Language, LanguageProvider } from "..";
-import { brandTheme, fontFaces, theme as defaultSporTheme, Brand } from "../";
+import { Brand, brandTheme, theme as defaultSporTheme, fontFaces } from "../";
 
 type SporProviderProps = ChakraProviderProps & {
   language?: Language;
@@ -52,12 +53,9 @@ export const SporProvider = ({
   children,
   ...props
 }: SporProviderProps) => {
-  const brandCustomizations = brandTheme[brand];
+  const brandCustomizations = brandTheme[brand] ?? {};
 
-  const extendedTheme = {
-    ...theme,
-    ...brandCustomizations,
-  };
+  const extendedTheme = deepmerge(theme, brandCustomizations);
 
   return (
     <LanguageProvider language={language}>


### PR DESCRIPTION
## Background

When we added support for adding brand overrides, all of our colors were overridden.

## Solution

Use the `deepmerge` npm dependency to merge the themes. We could've implemented deepmerge ourselves, but the [npm package](https://www.npmjs.com/package/deepmerge) is used by around 20 million people and is tiny and typesafe, so I opted for that instead.