### PR TITLE
Re-implement buttons

### DIFF
--- a/.changeset/large-eels-eat.md
+++ b/.changeset/large-eels-eat.md
@@ -1,5 +1,7 @@
 ---
-"@vygruppen/spor-react": patch
+"@vygruppen/spor-react": minor
 ---
 
-Button: Support the new design direction
+Button: The Button component is all new and shiny – and with no breaking changes at all. However, since the implementation is completely different, you might want to double check that everything looks as it should.
+
+A new feature is that the right icon is now always right aligned, which makes this component much more versatile than before. The variant="control" is now deprecated as well.

--- a/.changeset/large-eels-eat.md
+++ b/.changeset/large-eels-eat.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Button: Support the new design direction

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -65,6 +65,7 @@ export type ButtonProps = Exclude<
 export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
   const {
     as = "button",
+    fontWeight,
     size,
     children,
     isLoading,
@@ -86,6 +87,11 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
     leftIcon,
     rightIcon,
   });
+
+  // We want to explicitly allow to override the fontWeight prop
+  if (fontWeight) {
+    styles.fontWeight = fontWeight;
+  }
 
   return (
     <Box

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -22,7 +22,9 @@ export type ButtonProps = Exclude<
   size?: "xs" | "sm" | "md" | "lg";
   /** The different variants of a button
    *
-   * Defaults to "primary"
+   * Defaults to "primary".
+   *
+   * "control" is deprecated, and will be removed in a future version
    */
   variant?:
     | "control"
@@ -37,7 +39,6 @@ export type ButtonProps = Exclude<
  *
  * There are several button variants. You can specify which one you want with the `variant` prop. The available variants are:
  *
- * - `control`: This button is used for ticket controls only.
  * - `primary`: This is our main button. It's used for the main actions in a view, like a call to action. There should only be a single primary button in each view.
  * - `secondary`: Used for secondary actions in a view, and when you need to make several actions available at the same time.
  * - `tertiary`: Used for additional choices, like a less important secondary action.
@@ -136,7 +137,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
   );
 });
 
-function getLoaderWidth(size: any) {
+function getLoaderWidth(size: Required<ButtonProps["size"]>) {
   switch (size) {
     case "xs":
       return "4rem";

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -1,10 +1,11 @@
 import {
   Box,
   Center,
-  Button as ChakraButton,
   ButtonProps as ChakraButtonProps,
+  Flex,
   forwardRef,
   useButtonGroup,
+  useStyleConfig,
 } from "@chakra-ui/react";
 import React from "react";
 import { createTexts, useTranslation } from "../i18n";
@@ -63,61 +64,42 @@ export type ButtonProps = Exclude<
  */
 export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
   const {
+    as = "button",
     size,
-    variant,
     children,
     isLoading,
     isDisabled,
     leftIcon,
     rightIcon,
+    sx,
     ...rest
   } = props;
   const ariaLabel = useCorrectAriaLabel(props);
   const buttonGroup = useButtonGroup();
-  const finalVariant = (variant ??
-    buttonGroup?.variant ??
-    "primary") as Required<ButtonProps["variant"]>;
   const finalSize = (size ?? buttonGroup?.size ?? "md") as Required<
     ButtonProps["size"]
   >;
+  const styles = useStyleConfig("Button", {
+    ...buttonGroup,
+    ...rest,
+    size: finalSize,
+    leftIcon,
+    rightIcon,
+  });
 
   return (
-    <ChakraButton
-      size={finalSize}
-      variant={finalVariant}
+    <Box
       {...rest}
+      as={as}
+      sx={{ ...styles, ...sx }}
       ref={ref}
       aria-label={ariaLabel}
       aria-busy={isLoading}
-      isDisabled={isDisabled || isLoading}
-      leftIcon={
-        isLoading && leftIcon ? (
-          <Box visibility={isLoading ? "hidden" : "visible"} aria-hidden="true">
-            {leftIcon}
-          </Box>
-        ) : (
-          leftIcon
-        )
-      }
-      rightIcon={
-        isLoading && rightIcon ? (
-          <Box visibility={isLoading ? "hidden" : "visible"} aria-hidden="true">
-            {rightIcon}
-          </Box>
-        ) : (
-          rightIcon
-        )
-      }
+      disabled={isDisabled || isLoading}
       position="relative"
     >
       {isLoading && (
-        <Center
-          position="absolute"
-          right="0"
-          paddingBottom={1}
-          left="0"
-          paddingTop={2}
-        >
+        <Center position="absolute" right={0} left={0} top={1} bottom={0}>
           <ColorInlineLoader
             maxWidth={getLoaderWidth(finalSize)}
             width="80%"
@@ -126,14 +108,26 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
           />
         </Center>
       )}
-      <Box
+      <Flex
+        justifyContent="space-between"
+        alignItems="center"
+        gap={1}
         visibility={isLoading ? "hidden" : "visible"}
-        whiteSpace="normal"
-        textAlign="left"
+        aria-hidden={isLoading}
       >
-        {children}
-      </Box>
-    </ChakraButton>
+        <Flex justifyContent="center" alignItems="center" gap={1}>
+          {leftIcon}
+          <Box
+            visibility={isLoading ? "hidden" : "visible"}
+            whiteSpace="normal"
+            textAlign="left"
+          >
+            {children}
+          </Box>
+        </Flex>
+        {rightIcon}
+      </Flex>
+    </Box>
   );
 });
 

--- a/packages/spor-react/src/button/IconButton.tsx
+++ b/packages/spor-react/src/button/IconButton.tsx
@@ -8,6 +8,10 @@ import React from "react";
 import { ColorSpinner } from "..";
 
 export type IconButtonProps = Omit<ChakraIconButtonProps, "variant"> & {
+  /** The button variant.
+   *
+   * "control" is deprecated
+   */
   variant:
     | "control"
     | "primary"

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -7,7 +7,6 @@ const config = defineStyleConfig({
   baseStyle: {
     border: 0,
     borderRadius: "xl",
-    fontWeight: "bold",
     transitionProperty: "common",
     transitionDuration: "normal",
     textWrap: "wrap",
@@ -100,7 +99,6 @@ const config = defineStyleConfig({
     tertiary: (props) => ({
       backgroundColor: "transparent",
       color: mode("darkGrey", "white")(props),
-      fontWeight: "normal",
       boxShadow: `inset 0 0 0 1px ${mode(
         colors.blackAlpha[400],
         colors.whiteAlpha[400],
@@ -125,7 +123,6 @@ const config = defineStyleConfig({
     ghost: (props) => ({
       backgroundColor: "transparent",
       color: mode("darkGrey", "white")(props),
-      fontWeight: "normal",
       _focusVisible: {
         boxShadow: getBoxShadowString({
           borderColor: mode("greenHaze", "azure")(props),
@@ -180,11 +177,13 @@ const config = defineStyleConfig({
       minHeight: 8,
       minWidth: 8,
       fontSize: "18px",
+      fontWeight: "bold",
     },
     md: {
       minHeight: 7,
       minWidth: 7,
       fontSize: "18px",
+      fontWeight: "bold",
     },
     sm: {
       minHeight: 6,

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -2,7 +2,6 @@ import { defineStyleConfig } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
 import { colors } from "../foundations";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
-import { focusVisible } from "../utils/focus-utils";
 
 const config = defineStyleConfig({
   baseStyle: {
@@ -36,18 +35,15 @@ const config = defineStyleConfig({
       // hardcoded background color as alpha-"hack" below is not feasible for dark mode with solid background color
       backgroundColor: mode("pine", "coralGreen")(props),
       color: mode("white", "darkTeal")(props),
-      ...focusVisible({
-        focus: {
-          boxShadow: `inset 0 0 0 2px ${mode(
-            colors.greenHaze,
-            colors.azure,
-          )(props)}, inset 0 0 0 4px ${mode(
-            colors.white,
-            colors.darkGrey,
-          )(props)}`,
-        },
-        notFocus: { boxShadow: "none" },
-      }),
+      _focusVisible: {
+        boxShadow: `inset 0 0 0 2px ${mode(
+          colors.greenHaze,
+          colors.azure,
+        )(props)}, inset 0 0 0 4px ${mode(
+          colors.white,
+          colors.darkGrey,
+        )(props)}`,
+      },
       _hover: {
         backgroundColor: mode("darkTeal", "blueGreen")(props),
       },
@@ -63,29 +59,24 @@ const config = defineStyleConfig({
       _hover: {
         backgroundColor: mode("coralGreen", "greenHaze")(props),
       },
-      ...focusVisible({
-        focus: {
+      _focusVisible: {
+        boxShadow: `inset 0 0 0 2px ${mode(
+          colors.greenHaze,
+          colors.primaryGreen,
+        )(props)}, inset 0 0 0 4px ${mode(
+          colors.white,
+          colors.darkTeal,
+        )(props)}`,
+        _hover: {
           boxShadow: `inset 0 0 0 2px ${mode(
             colors.greenHaze,
-            colors.primaryGreen,
+            colors.azure,
           )(props)}, inset 0 0 0 4px ${mode(
             colors.white,
-            colors.darkTeal,
+            colors.blackAlpha[500],
           )(props)}`,
-          _hover: {
-            boxShadow: `inset 0 0 0 2px ${mode(
-              colors.greenHaze,
-              colors.azure,
-            )(props)}, inset 0 0 0 4px ${mode(
-              colors.white,
-              colors.blackAlpha[500],
-            )(props)}`,
-          },
         },
-        notFocus: {
-          boxShadow: "none",
-        },
-      }),
+      },
       _active: {
         backgroundColor: mode("mint", "darkTeal")(props),
         boxShadow: `inset 0 0 0 2px ${mode(
@@ -114,20 +105,12 @@ const config = defineStyleConfig({
         colors.blackAlpha[400],
         colors.whiteAlpha[400],
       )(props)}`,
-      ...focusVisible({
-        focus: {
-          boxShadow: getBoxShadowString({
-            borderWidth: 2,
-            borderColor: "azure",
-          }),
-        },
-        notFocus: {
-          boxShadow: `inset 0 0 0 1px ${mode(
-            colors.blackAlpha[400],
-            colors.whiteAlpha[400],
-          )(props)}`,
-        },
-      }),
+      _focusVisible: {
+        boxShadow: getBoxShadowString({
+          borderWidth: 2,
+          borderColor: "azure",
+        }),
+      },
       _hover: {
         boxShadow: `inset 0 0 0 2px currentColor`,
       },
@@ -143,17 +126,12 @@ const config = defineStyleConfig({
       backgroundColor: "transparent",
       color: mode("darkGrey", "white")(props),
       fontWeight: "normal",
-      ...focusVisible({
-        focus: {
-          boxShadow: getBoxShadowString({
-            borderColor: mode("greenHaze", "azure")(props),
-            borderWidth: 2,
-          }),
-        },
-        notFocus: {
-          outline: "none",
-        },
-      }),
+      _focusVisible: {
+        boxShadow: getBoxShadowString({
+          borderColor: mode("greenHaze", "azure")(props),
+          borderWidth: 2,
+        }),
+      },
       _hover: {
         backgroundColor: mode("seaMist", "whiteAlpha.200")(props),
         _disabled: {
@@ -181,26 +159,20 @@ const config = defineStyleConfig({
           borderWidth: 2,
         }),
       },
-      ...focusVisible({
-        focus: {
+      _focusVisible: {
+        boxShadow: getBoxShadowString({
+          borderColor: mode("greenHaze", "azure")(props),
+          borderWidth: 2,
+          baseShadow: "sm",
+        }),
+        _hover: {
           boxShadow: getBoxShadowString({
             borderColor: mode("greenHaze", "azure")(props),
             borderWidth: 2,
-            baseShadow: "sm",
+            baseShadow: "md",
           }),
-          _hover: {
-            boxShadow: getBoxShadowString({
-              borderColor: mode("greenHaze", "azure")(props),
-              borderWidth: 2,
-              baseShadow: "md",
-            }),
-          },
         },
-        notFocus: {
-          outline: "none",
-          boxShadow: "sm",
-        },
-      }),
+      },
     }),
   },
   sizes: {

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -218,12 +218,14 @@ const config = defineStyleConfig({
       minHeight: 6,
       minWidth: 6,
       fontSize: "16px",
+      fontWeight: "normal",
     },
     xs: {
       minHeight: 5,
       minWidth: 5,
       fontSize: "16px",
       paddingX: 2,
+      fontWeight: "normal",
     },
   },
   defaultProps: {

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -54,7 +54,7 @@ const config = defineStyleConfig({
     secondary: (props) => ({
       // FIXME: Update to use global defined background color for darkMode whenever it is available instead of alpha
       backgroundColor: mode("seaMist", "primaryGreen")(props),
-      color: mode("darkTeal", "white")(props),
+      color: mode("darkTeal", "seaMist")(props),
       // order is important here for now while we do not have global defined background color for darkMode
       _hover: {
         backgroundColor: mode("coralGreen", "greenHaze")(props),


### PR DESCRIPTION
## Background

The buttons have gotten a new design!

## Solution

There were several tweaks done here. 

- sm and xs buttons get normal font weight
- focus styles are only applied when you use the keyboard to navigate, not when you focus something by clicking it
- when we have a right icon, we left-align the "left icon and/or text" part
- we also re-implement the button using our own implementation instead of Chakra's approach
- we deprecate the "control" button variant

## Image
<img width="288" alt="image" src="https://github.com/nsbno/spor/assets/1307267/982e4b91-a9b5-4b30-86e2-3c14bebb677e">
