### PR TITLE
Breadcrumb darkmode bugfix

### DIFF
--- a/.changeset/giant-dingos-hunt.md
+++ b/.changeset/giant-dingos-hunt.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Breadcrumb: endret farge på dropdown right fill icon for darkmode

--- a/packages/spor-react/src/breadcrumb/Breadcrumb.tsx
+++ b/packages/spor-react/src/breadcrumb/Breadcrumb.tsx
@@ -6,6 +6,7 @@ import {
 } from "@chakra-ui/react";
 import { DropdownRightFill18Icon } from "@vygruppen/spor-icon-react";
 import React from "react";
+import { useColorModeValue } from "@chakra-ui/react";
 
 type BreadcrumbProps = ChakraBreadcrumbProps;
 /**
@@ -25,9 +26,10 @@ type BreadcrumbProps = ChakraBreadcrumbProps;
  * ```
  */
 export const Breadcrumb = (props: BreadcrumbProps) => {
+  const iconColor = useColorModeValue("blackAlpha.400", "whiteAlpha.400");
   return (
     <ChakraBreadcrumb
-      separator={<DropdownRightFill18Icon color="blackAlpha.400" />}
+      separator={<DropdownRightFill18Icon color={iconColor} />}
       {...props}
     />
   );


### PR DESCRIPTION
## Background

the arrow icons were black in darkmode

## Solution

added darkmode support for arrowicons
