### PR TITLE
oppdatert changeset og oppdatert variants navn

### DIFF
--- a/.changeset/thirty-bikes-develop.md
+++ b/.changeset/thirty-bikes-develop.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+cardSelect: updated variants names

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -24,7 +24,7 @@ type CardSelectProps = BoxProps & {
    * - `outline` is a button with a border and text
    * - `card` is a button with a drop shadow (like a card) and text
    */
-  variant: "ghost" | "outline" | "card";
+  variant: "base" | "ghost" | "floating";
   /** The size of the trigger button */
   size: "sm" | "md" | "lg";
   /** Whether the card select is open / active, if controlled */


### PR DESCRIPTION
## Background

component had the old variant names

## Solution

changed to the new ones

OLD: "ghost" | "outline" | "card";
NEW:  "base" | "ghost" | "floating"; 
