### PR TITLE
Add custom variant to line tags

### DIFF
--- a/.changeset/calm-tips-scream.md
+++ b/.changeset/calm-tips-scream.md
@@ -1,0 +1,7 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+LineTag, TravelTag, LineIcon: Add new variant="custom" option.
+
+This new variant lets you specify custom foreground and background colors, as well as an icon variant.

--- a/packages/spor-react/src/linjetag/InfoTag.tsx
+++ b/packages/spor-react/src/linjetag/InfoTag.tsx
@@ -24,6 +24,17 @@ export type InfoTagProps = TagProps;
  * />
  * ```
  *
+ * If required, you can also override the colors and icons in these line tags:
+ *
+ * ```tsx
+ * <InfoTag
+ *  variant="custom"
+ *  customIconVariant="ferry"
+ *  foregroundColor="#b4da55"
+ *  backgroundColor="#c0ffee"
+ * />
+ * ```
+ *
  * @see https://spor.vy.no/components/line-tags
  */
 export const InfoTag = ({
@@ -31,11 +42,21 @@ export const InfoTag = ({
   size = "md",
   title,
   description,
+  ...customProps
 }: InfoTagProps) => {
-  const styles = useMultiStyleConfig("InfoTag", { variant, size });
+  const styles = useMultiStyleConfig("InfoTag", {
+    variant,
+    size,
+    ...customProps,
+  });
   return (
     <Box sx={styles.container}>
-      <LineIcon variant={variant} size={size} sx={styles.iconContainer} />
+      <LineIcon
+        variant={variant}
+        size={size}
+        sx={styles.iconContainer}
+        {...(customProps as any)} // TODO: Fix this
+      />
       <Box sx={styles.textContainer}>
         {title && (
           <Box as="span" sx={styles.title}>

--- a/packages/spor-react/src/linjetag/LineIcon.tsx
+++ b/packages/spor-react/src/linjetag/LineIcon.tsx
@@ -3,10 +3,23 @@ import React from "react";
 import { getCorrectIcon } from "./icons";
 import { TagProps } from "./types";
 
-export type LineIconProps = BoxProps & {
-  variant: TagProps["variant"];
-  size: TagProps["size"];
+type DefaultVariants = Exclude<TagProps["variant"], "custom">;
+
+type DefaultVariantProps = {
+  variant: DefaultVariants;
 };
+type CustomVariantProps = {
+  variant: "custom";
+  customIconVariant: DefaultVariants;
+  foregroundColor: string;
+  backgroundColor: string;
+};
+type VariantProps = DefaultVariantProps | CustomVariantProps;
+
+export type LineIconProps = Exclude<BoxProps, "variant"> &
+  VariantProps & {
+    size: TagProps["size"];
+  };
 
 /**
  * A line icon component.
@@ -23,6 +36,18 @@ export type LineIconProps = BoxProps & {
  * <LineIcon variant="subway" size="lg" />
  * ```
  *
+ * If you require some one-off colors, but still want to use the line tag component,
+ * you can do so like this:
+ *
+ * ```tsx
+ * <LineIcon
+ *  variant="custom"
+ *  customIconVariant="ferry"
+ *  foregroundColor="#b4da55"
+ *  backgroundColor="#c0ffee"
+ * />
+ * ```
+ *
  * @see https://spor.vy.no/components/line-tags
  */
 export const LineIcon = ({
@@ -31,8 +56,16 @@ export const LineIcon = ({
   sx,
   ...rest
 }: LineIconProps) => {
-  const styles = useMultiStyleConfig("LineIcon", { variant, size });
-  const Icon: any = getCorrectIcon({ variant, size });
+  const styles = useMultiStyleConfig("LineIcon", { variant, size, ...rest });
+  const Icon: any = getCorrectIcon({
+    variant:
+      variant === "custom" && "customIconVariant" in rest
+        ? rest.customIconVariant
+        : variant === "custom"
+          ? "local-train"
+          : variant,
+    size,
+  });
   if (!Icon) {
     return null;
   }

--- a/packages/spor-react/src/linjetag/TravelTag.tsx
+++ b/packages/spor-react/src/linjetag/TravelTag.tsx
@@ -58,6 +58,19 @@ export type TravelTagProps = TagProps &
  * />
  * ```
  *
+ * If required, you can also override the colors and icons in these travel tags:
+ *
+ * ```tsx
+ * <TravelTag
+ *   variant="custom"
+ *   customIconVariant="ferry"
+ *   foregroundColor="#b4da55"
+ *   backgroundColor="#c0ffee"
+ *   title="3"
+ *   description="Ringen"
+ * />
+ * ```
+ *
  * @see https://spor.vy.no/components/line-tags
  */
 export const TravelTag = forwardRef<TravelTagProps, As>(
@@ -77,13 +90,20 @@ export const TravelTag = forwardRef<TravelTagProps, As>(
       variant,
       size,
       deviationLevel,
+      foregroundColor: variant === "custom" ? rest.foregroundColor : undefined,
+      backgroundColor: variant === "custom" ? rest.backgroundColor : undefined,
     });
 
     const DeviationLevelIcon = getDeviationLevelIcon({ deviationLevel, size });
 
     return (
       <Box sx={styles.container} aria-disabled={isDisabled} ref={ref} {...rest}>
-        <LineIcon variant={variant} size={size} sx={styles.iconContainer} />
+        <LineIcon
+          variant={variant}
+          size={size}
+          sx={styles.iconContainer}
+          {...(rest as any)}
+        />
         <Box sx={styles.textContainer}>
           {title && (
             <Box as="span" sx={styles.title}>

--- a/packages/spor-react/src/linjetag/types.d.ts
+++ b/packages/spor-react/src/linjetag/types.d.ts
@@ -16,9 +16,24 @@ export type Size = "sm" | "md" | "lg";
 
 export type TagType = "info" | "travel";
 
-export type TagProps = {
-  variant: Variant;
+export type TagProps = VariantProps & {
   size: Size;
   title: string;
   description?: string;
 };
+
+type DefaultVariantProps = {
+  variant: Variant;
+};
+type CustomVariantProps = {
+  variant: "custom";
+  /** When variant="custom", the foreground color of the tag */
+  foregroundColor: string;
+  /** When variant="custom", the background color of the tag */
+  backgroundColor: string;
+  /** When variant="custom", this is the icon you want to display.
+   * It should be one of the other variants
+   */
+  customIconVariant: Variant;
+};
+type VariantProps = DefaultVariantProps | CustomVariantProps;

--- a/packages/spor-react/src/theme/components/line-icon.ts
+++ b/packages/spor-react/src/theme/components/line-icon.ts
@@ -92,6 +92,11 @@ const config = helpers.defineMultiStyleConfig({
         },
       },
     }),
+    custom: (props) => ({
+      iconContainer: {
+        backgroundColor: props.backgroundColor,
+      },
+    }),
   },
   sizes: {
     sm: {

--- a/packages/spor-react/src/theme/components/travel-tag.ts
+++ b/packages/spor-react/src/theme/components/travel-tag.ts
@@ -172,6 +172,11 @@ const config = helpers.defineMultiStyleConfig({
         display: "none",
       },
     }),
+    custom: (props) => ({
+      container: {
+        backgroundColor: props.foregroundColor,
+      },
+    }),
   },
   sizes: {
     sm: {


### PR DESCRIPTION
## Background

Team Reise needs to override the colors on certain line tags and travel tags, since they support a plethora of sources, not only our own.

## Solution

Add a new variant="custom" for the LineTag, TravelTag and LineIcon components, which requires custom colors to be set, both for the foreground and background.

It will look like this:

```tsx
<LineIcon
  variant="custom"
  customIconVariant="ferry"
  foregroundColor="#b4da55"
  backgroundColor="#c0ffee"
/>
```

The foregroundColor, backgroundColor and customIconVariant props are required when the variant is `"custom"`