### PR TITLE
Add changeset to release the icons packages

### DIFF
--- a/.changeset/real-years-mix.md
+++ b/.changeset/real-years-mix.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-icon-react": minor
+"@vygruppen/spor-icon-react-native": minor
+---
+
+Add new play icons


### PR DESCRIPTION
## Background

We forgot to add `@vygruppen/spor-icon-react` and `@vygruppen/spor-icon-react-native` to the changeset file when adding the Play icon in a previous PR.

## Solution

Add a changelog file for the icons to be released properly.
