### PR TITLE
Three bugfixes in one

### DIFF
--- a/.changeset/warm-bikes-begin.md
+++ b/.changeset/warm-bikes-begin.md
@@ -1,0 +1,7 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Card, NumericStepper: Fix a bug with the focus styles that showed up when it shouldn't have.
+
+DatePicker, DateRangePicker: Fix a bug where you wouldn't automatically jump to the next field once a field was filled out

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -52,14 +52,9 @@ export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
             {props.label}
           </FormLabel>
         )}
-        <Flex {...fieldProps} paddingTop="3" paddingBottom="0.5">
+        <Flex {...fieldProps} ref={ref} paddingTop="3" paddingBottom="0.5">
           {state.segments.map((segment, i) => (
-            <DateTimeSegment
-              ref={i === 0 ? ref : undefined}
-              key={i}
-              segment={segment}
-              state={state}
-            />
+            <DateTimeSegment key={i} segment={segment} state={state} />
           ))}
         </Flex>
         <input

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -14,7 +14,6 @@ import {
   useTranslation,
 } from "..";
 import { getBoxShadowString } from "../theme/utils/box-shadow-utils";
-import { focusVisible } from "../theme/utils/focus-utils";
 
 type NumericStepperProps = {
   /** The name of the input field */
@@ -197,13 +196,10 @@ const VerySmallButton = (props: VerySmallButtonProps) => {
       size="xs"
       minWidth="24px"
       minHeight="24px"
-      sx={focusVisible({
-        notFocus: { boxShadow: "none" },
-        focus: {
-          boxShadow:
-            "inset 0 0 0 2px var(--spor-colors-pine), inset 0 0 0 3px white",
-        },
-      })}
+      _focusVisible={{
+        boxShadow:
+          "inset 0 0 0 2px var(--spor-colors-pine), inset 0 0 0 3px white",
+      }}
       {...props}
     />
   );

--- a/packages/spor-react/src/theme/components/card.ts
+++ b/packages/spor-react/src/theme/components/card.ts
@@ -2,7 +2,6 @@ import { defineStyleConfig } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
 import { colors } from "../foundations";
 import { getBoxShadowString } from "../utils/box-shadow-utils";
-import { focusVisible } from "../utils/focus-utils";
 
 const config = defineStyleConfig({
   baseStyle: (props: any) => ({
@@ -20,21 +19,15 @@ const config = defineStyleConfig({
       ...getColorSchemeClickableProps(props),
       _hover: getColorSchemeHoverProps(props),
       _active: getColorSchemeActiveProps(props),
-      ...focusVisible({
-        focus: {
-          boxShadow: getBoxShadowString({
-            borderColor: mode("greenHaze", "azure")(props),
-            borderWidth: 2,
-            isInset: false,
-          }),
-          outline: "none",
-          _active: getColorSchemeActiveProps(props),
-        },
-        notFocus: {
-          ...getColorSchemeClickableProps(props),
-          _active: getColorSchemeActiveProps(props),
-        },
-      }),
+      _focusVisible: {
+        boxShadow: getBoxShadowString({
+          borderColor: mode("greenHaze", "azure")(props),
+          borderWidth: 2,
+          isInset: false,
+        }),
+        outline: "none",
+        _active: getColorSchemeActiveProps(props),
+      },
       _disabled: {
         backgroundColor: "platinum",
         boxShadow: getBoxShadowString({


### PR DESCRIPTION
## Background

There were a few bugs that needed addressing:

- Clickable cards got the focus visible state when clicked.
- Numeric stepper buttons got the same issue
- Datepickers didn't allow the user to keep typing in a date (typing 22071987 would not automatically fill out a day, month and a year – just reiterate on the first day field).

## Solution

Fix em!
