### PR TITLE
Fix bug with buttons that were broken when links

### DIFF
--- a/.changeset/orange-hotels-shake.md
+++ b/.changeset/orange-hotels-shake.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Button: Fix bug with broken buttons when there were links

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -116,6 +116,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
       )}
       <Flex
         justifyContent="space-between"
+        flex={1}
         alignItems="center"
         gap={1}
         visibility={isLoading ? "hidden" : "visible"}

--- a/packages/spor-react/src/theme/components/button.ts
+++ b/packages/spor-react/src/theme/components/button.ts
@@ -7,6 +7,8 @@ const config = defineStyleConfig({
   baseStyle: {
     border: 0,
     borderRadius: "xl",
+    display: "flex",
+    alignItems: "center",
     transitionProperty: "common",
     transitionDuration: "normal",
     textWrap: "wrap",


### PR DESCRIPTION
## Background

After the reimplementation of buttons, a bug had appeared that made the buttons look silly and broken when they were rendered as anchors (links – ´<Button as="a" />` for instance).

## Solution

The bug came from anchors defaulting to being inline, while buttons default to be inline-block.

This fix sets them all to be "display: flex", which looked like it worked the best.
