### PR TITLE
bugfix: add missing semicolon

### DIFF
--- a/.changeset/ninety-plants-think.md
+++ b/.changeset/ninety-plants-think.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Added missing semicolon to font-faces

--- a/packages/spor-react/src/theme/font-faces.ts
+++ b/packages/spor-react/src/theme/font-faces.ts
@@ -28,7 +28,7 @@ export const fontFaces = `
   font-display: swap
 }
 @font-face {
-  font-family: ${tokens.asset.font["vy-sans"]["medium-italic"].name}
+  font-family: ${tokens.asset.font["vy-sans"]["medium-italic"].name};
   src: url("https://www.vy.no/styles/font/VySans-RegularItalic.woff2")
       format("woff2"),
     url("https://www.vy.no/styles/font/VySans-RegularItalic.woff")


### PR DESCRIPTION
## Background

Missing semicolon in fontface css
<img width="1594" alt="image" src="https://github.com/nsbno/spor/assets/26740919/17c57a48-9208-463a-8acd-f87ff9ba8d19">

## Solution

adding the missing semicolon