### PR TITLE
Change the way the stepper breaks

### DIFF
--- a/.changeset/three-waves-roll.md
+++ b/.changeset/three-waves-roll.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Stepper: Change the breakpoint for when the stepper changes from one design to another

--- a/packages/spor-react/src/stepper/Stepper.tsx
+++ b/packages/spor-react/src/stepper/Stepper.tsx
@@ -90,7 +90,7 @@ export const Stepper = ({
               </Box>
             )}
           </Box>
-          <Flex justifyContent="center" display={["none", "flex"]}>
+          <Flex justifyContent="center" display={["none", null, "flex"]}>
             {steps.map((step, index) => (
               <StepperStep key={index} stepNumber={index + 1} variant={variant}>
                 {step}

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -30,7 +30,7 @@ export const StepperStep = ({
       )}
 
       <Button
-        size={"xs"}
+        size="xs"
         variant={
           state === "active"
             ? "primary"

--- a/packages/spor-react/src/theme/components/stepper.ts
+++ b/packages/spor-react/src/theme/components/stepper.ts
@@ -18,24 +18,24 @@ const parts = anatomy("stepper").parts(
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
 const config = helpers.defineMultiStyleConfig({
-  baseStyle: (props) => ({
+  baseStyle: {
     root: {
       display: "flex",
       alignItems: "center",
-      justifyContent: ["space-between", "center"],
-      minHeight: ["48px", "60px"],
+      justifyContent: ["space-between", null, "center"],
+      minHeight: ["48px", null, "60px"],
       overflowX: "auto",
       width: "100%",
     },
     container: {
-      paddingX: [2, 2, 0],
+      paddingX: [2, null, null, 0],
       maxWidth: "container.lg",
       marginX: "auto",
       width: "100%",
     },
     innerContainer: {
       overflow: "hidden",
-      display: ["flex", "none"],
+      display: ["flex", null, "none"],
       alignItems: "center",
       justifyContent: "space-between",
     },
@@ -62,7 +62,7 @@ const config = helpers.defineMultiStyleConfig({
       textStyle: "sm",
       whiteSpace: "nowrap",
     },
-  }),
+  },
   variants: {
     base: () => ({
       root: {


### PR DESCRIPTION
## Background

The stepper broke from its more compact display to its more wide-screeny look too early.

## Solution

Change the breakpoints so that the Stepper component switches over first on small desktops.
