### PR TITLE
Redesign stepper

### DIFF
--- a/.changeset/green-toys-attack.md
+++ b/.changeset/green-toys-attack.md
@@ -1,0 +1,7 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Stepper: Redesign and re-implement the Stepper component.
+
+This change also introduces a new prop – onBackButtonClick – which is called whenever the back button is clicked on smaller screen. It receives a boolean argument outlining whether or not the current step is the first one or not. If you don't pass this prop, the back button will be hidden on the first step.

--- a/packages/spor-react/src/stepper/Stepper.tsx
+++ b/packages/spor-react/src/stepper/Stepper.tsx
@@ -1,21 +1,28 @@
-import { Flex, HStack, useMultiStyleConfig } from "@chakra-ui/react";
-import { DropdownLeftFill24Icon } from "@vygruppen/spor-icon-react";
+import { Flex, useMultiStyleConfig } from "@chakra-ui/react";
+import { ArrowLeftFill24Icon } from "@vygruppen/spor-icon-react";
 import React from "react";
 import { StepperStep } from ".";
-import {
-  Box,
-  IconButton,
-  SimplePopover,
-  createTexts,
-  useTranslation,
-} from "..";
+import { Box, Heading, IconButton, createTexts, useTranslation } from "..";
 import { StepperProvider } from "./StepperContext";
 
 type StepperProps = {
-  onClick: (clickedStep: number) => void;
+  /** Callback for when a step is clicked */
+  onStepClick: (clickedStep: number) => void;
+  /** Callback for when the back button is clicked (on smaller screens).
+   * A boolean indicating whether or not the user is on the first step is passed as an argument.
+   *
+   * If this is not provided, the back button will not be shown on smaller screens on the first step.
+   */
+  onBackButtonClick?: (isFirstStep: boolean) => void;
+  /** Title shown on smaller devices */
   title?: string;
+  /** The currently active step */
   activeStep: number;
+  /** The labels of each step */
   steps: string[];
+  /** The variant.
+   * "base" has a transparent background,
+   * while "accent" has a slight accent color  */
   variant: "base" | "accent";
 };
 /**
@@ -25,15 +32,16 @@ type StepperProps = {
  *
  * ```tsx
  * <Stepper
- *   title="Eksempel"
+ *   title="Example"
  *   onClick={handleStepClick}
  *   activeStep={2}
- *   steps={['Velg hvor', 'Velg når', 'Velg hvordan']}
+ *   steps={['Where', 'When', 'How']}
  * />
  * ```
  **/
 export const Stepper = ({
-  onClick = () => {},
+  onStepClick = () => {},
+  onBackButtonClick,
   steps,
   activeStep: activeStepAsStringOrNumber,
   title,
@@ -43,52 +51,45 @@ export const Stepper = ({
   const numberOfSteps = steps.length;
   const activeStep = Number(activeStepAsStringOrNumber);
   const { t } = useTranslation();
+  const hideBackButtonOnFirstStep = activeStep === 1 && !onBackButtonClick;
   return (
-    <Box __css={style.root}>
+    <Box sx={style.root}>
       <StepperProvider
-        onClick={onClick}
+        onClick={onStepClick}
         activeStep={activeStep}
         variant={variant}
         numberOfSteps={numberOfSteps}
       >
-        <Box __css={style.container}>
-          <Box __css={style.innerContainer}>
-            <HStack>
-              {activeStep > 1 && (
-                <IconButton
-                  aria-label={t(texts.back)}
-                  icon={<DropdownLeftFill24Icon />}
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => onClick(activeStep - 1)}
-                  __css={style.backButton}
-                />
+        <Box sx={style.container}>
+          <Box sx={style.innerContainer}>
+            <Flex
+              justifyContent="space-between"
+              alignItems="center"
+              gap={2}
+              flex={1}
+            >
+              <IconButton
+                aria-label={t(texts.back)}
+                icon={<ArrowLeftFill24Icon />}
+                variant="ghost"
+                size="sm"
+                visibility={hideBackButtonOnFirstStep ? "hidden" : "visible"}
+                onClick={() => {
+                  if (onBackButtonClick) {
+                    onBackButtonClick(activeStep === 1);
+                  }
+                  onStepClick(activeStep - 1);
+                }}
+              />
+              {title && (
+                <Heading flex={1} variant="sm" as="h3" sx={style.title}>
+                  {title}
+                </Heading>
               )}
-
-              <SimplePopover
-                triggerElement={
-                  <Box as="button" __css={style.stepCounter}>
-                    {t(texts.stepsOf(activeStep, numberOfSteps))}
-                  </Box>
-                }
-                borderRadius="xs"
-              >
-                {steps.map((step, index) => (
-                  <StepperStep
-                    key={step}
-                    stepNumber={index + 1}
-                    variant={variant}
-                  >
-                    {step}
-                  </StepperStep>
-                ))}
-              </SimplePopover>
-            </HStack>
-            {title && (
-              <Box as="h3" __css={style.title}>
-                {title}
+              <Box sx={style.stepCounter}>
+                {t(texts.stepsOf(activeStep, numberOfSteps))}
               </Box>
-            )}
+            </Flex>
           </Box>
           <Flex justifyContent="center" display={["none", null, "flex"]}>
             {steps.map((step, index) => (
@@ -105,10 +106,10 @@ export const Stepper = ({
 
 const texts = createTexts({
   stepsOf: (activeStep, numberOfSteps) => ({
-    nb: `Steg ${activeStep} av ${numberOfSteps}`,
-    nn: `Steg ${activeStep} av ${numberOfSteps}`,
-    sv: `Steg ${activeStep} av ${numberOfSteps}`,
-    en: `Step ${activeStep} of ${numberOfSteps}`,
+    nb: `Steg ${activeStep}/${numberOfSteps}`,
+    nn: `Steg ${activeStep}/${numberOfSteps}`,
+    sv: `Steg ${activeStep}/${numberOfSteps}`,
+    en: `Step ${activeStep}/${numberOfSteps}`,
   }),
   back: {
     nb: "Tilbake",

--- a/packages/spor-react/src/stepper/Stepper.tsx
+++ b/packages/spor-react/src/stepper/Stepper.tsx
@@ -7,7 +7,7 @@ import { StepperProvider } from "./StepperContext";
 
 type StepperProps = {
   /** Callback for when a step is clicked */
-  onStepClick: (clickedStep: number) => void;
+  onClick: (clickedStep: number) => void;
   /** Callback for when the back button is clicked (on smaller screens).
    * A boolean indicating whether or not the user is on the first step is passed as an argument.
    *
@@ -40,7 +40,7 @@ type StepperProps = {
  * ```
  **/
 export const Stepper = ({
-  onStepClick = () => {},
+  onClick = () => {},
   onBackButtonClick,
   steps,
   activeStep: activeStepAsStringOrNumber,
@@ -55,7 +55,7 @@ export const Stepper = ({
   return (
     <Box sx={style.root}>
       <StepperProvider
-        onClick={onStepClick}
+        onClick={onClick}
         activeStep={activeStep}
         variant={variant}
         numberOfSteps={numberOfSteps}
@@ -78,7 +78,7 @@ export const Stepper = ({
                   if (onBackButtonClick) {
                     onBackButtonClick(activeStep === 1);
                   }
-                  onStepClick(activeStep - 1);
+                  onClick(activeStep - 1);
                 }}
               />
               {title && (

--- a/packages/spor-react/src/stepper/Stepper.tsx
+++ b/packages/spor-react/src/stepper/Stepper.tsx
@@ -24,6 +24,8 @@ type StepperProps = {
    * "base" has a transparent background,
    * while "accent" has a slight accent color  */
   variant: "base" | "accent";
+  /** Disables all clicks */
+  isDisabled?: boolean;
 };
 /**
  * A stepper is used to show which step of a process a user is currently in.
@@ -46,6 +48,7 @@ export const Stepper = ({
   activeStep: activeStepAsStringOrNumber,
   title,
   variant,
+  isDisabled,
 }: StepperProps) => {
   const style = useMultiStyleConfig("Stepper", { variant });
   const numberOfSteps = steps.length;
@@ -98,6 +101,7 @@ export const Stepper = ({
                 stepNumber={index + 1}
                 variant={variant}
                 aria-current={index + 1 === activeStep ? "step" : undefined}
+                isDisabled={isDisabled}
               >
                 {step}
               </StepperStep>

--- a/packages/spor-react/src/stepper/Stepper.tsx
+++ b/packages/spor-react/src/stepper/Stepper.tsx
@@ -93,7 +93,12 @@ export const Stepper = ({
           </Box>
           <Flex justifyContent="center" display={["none", null, "flex"]}>
             {steps.map((step, index) => (
-              <StepperStep key={index} stepNumber={index + 1} variant={variant}>
+              <StepperStep
+                key={index}
+                stepNumber={index + 1}
+                variant={variant}
+                aria-current={index + 1 === activeStep ? "step" : undefined}
+              >
                 {step}
               </StepperStep>
             ))}

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -1,13 +1,14 @@
-import { useMultiStyleConfig } from "@chakra-ui/react";
+import { useColorModeValue, useMultiStyleConfig } from "@chakra-ui/react";
 import { DropdownRightFill18Icon } from "@vygruppen/spor-icon-react";
 import React from "react";
-import { Box, Button } from "..";
+import { Box, Button, Text } from "..";
 import { useStepper } from "./StepperContext";
 
 type StepperStepProps = {
   children: React.ReactNode;
   stepNumber: number;
   variant: "base" | "accent";
+  isDisabled?: boolean;
 };
 export const StepperStep = ({
   children,
@@ -15,66 +16,52 @@ export const StepperStep = ({
   variant,
 }: StepperStepProps) => {
   const { activeStep, onClick } = useStepper();
-  const state = getState(stepNumber!, activeStep);
+  const state = getState(stepNumber, activeStep);
   const style = useMultiStyleConfig("Stepper", {
     state,
     variant,
   });
-
-  const adjustedProps = getButtonStylesForState(state);
+  const disabledTextColor = useColorModeValue(
+    "blackAlpha.400",
+    "whiteAlpha.400",
+  );
+  const iconColor = useColorModeValue("blackAlpha.200", "whiteAlpha.200");
 
   return (
-    <Box __css={style.stepContainer}>
+    <Box sx={style.stepContainer}>
       {stepNumber > 1 && (
-        <DropdownRightFill18Icon marginX={5} display={["none", "block"]} />
+        <DropdownRightFill18Icon
+          marginX={5}
+          display={["none", null, "block"]}
+          color={iconColor}
+        />
       )}
-
-      <Button
-        size="xs"
-        variant={
-          state === "active"
-            ? "primary"
-            : state === "completed"
-              ? "tertiary"
-              : "ghost"
-        }
-        {...adjustedProps}
-        onClick={() => onClick(stepNumber)}
-      >
-        {children}
-      </Button>
+      {state === "disabled" ? (
+        <Text
+          variant="xs"
+          fontSize="16px"
+          color={disabledTextColor}
+          cursor="default"
+          paddingX={2}
+        >
+          {children}
+        </Text>
+      ) : (
+        <Button
+          size="xs"
+          variant={state === "active" ? "primary" : "ghost"}
+          onClick={
+            state === "completed" ? () => onClick(stepNumber) : undefined
+          }
+          pointerEvents={state === "active" ? "none" : "auto"}
+          tabIndex={state === "active" ? -1 : undefined}
+          sx={style.stepButton}
+        >
+          {children}
+        </Button>
+      )}
     </Box>
   );
-};
-
-const getButtonStylesForState = (
-  state: "completed" | "active" | "disabled",
-): Record<string, any> => {
-  switch (state) {
-    case "active":
-      return {
-        _hover: {},
-        boxShadow: "none",
-        _focus: {},
-        _active: {},
-        cursor: "auto",
-      };
-    case "completed":
-      return {
-        boxShadow: "none",
-      };
-    case "disabled":
-      return {
-        _disabled: {},
-        _hover: {},
-        _focus: {},
-        _active: {},
-        color: "dimGrey",
-        cursor: "auto",
-      };
-    default:
-      return {};
-  }
 };
 
 const getState = (stepNumber: number, activeStep: number) => {

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -14,6 +14,7 @@ export const StepperStep = ({
   children,
   stepNumber,
   variant,
+  isDisabled: isDisabledOverride,
 }: StepperStepProps) => {
   const { activeStep, onClick } = useStepper();
   const state = getState(stepNumber, activeStep);
@@ -27,6 +28,8 @@ export const StepperStep = ({
   );
   const iconColor = useColorModeValue("blackAlpha.200", "whiteAlpha.200");
 
+  const isDisabled = isDisabledOverride || state === "disabled";
+
   return (
     <Box sx={style.stepContainer}>
       {stepNumber > 1 && (
@@ -36,7 +39,7 @@ export const StepperStep = ({
           color={iconColor}
         />
       )}
-      {state === "disabled" ? (
+      {isDisabled ? (
         <Text
           variant="xs"
           fontSize="16px"

--- a/packages/spor-react/src/theme/components/stepper.ts
+++ b/packages/spor-react/src/theme/components/stepper.ts
@@ -5,7 +5,6 @@ const parts = anatomy("stepper").parts(
   "root",
   "container",
   "innerContainer",
-  "backButton",
   "title",
   "stepCounter",
   "stepContainer",
@@ -38,12 +37,7 @@ const config = helpers.defineMultiStyleConfig({
       display: ["flex", null, "none"],
       alignItems: "center",
       justifyContent: "space-between",
-    },
-    backButton: {
-      borderRadius: "xs",
-      paddingX: 0,
-      width: "auto",
-      minWidth: "auto",
+      gap: 3,
     },
     title: {
       overflow: "hidden",
@@ -51,8 +45,8 @@ const config = helpers.defineMultiStyleConfig({
       WebkitLineClamp: 2,
       display: "-webkit-box",
       WebkitBoxOrient: "vertical",
-      marginLeft: 2,
-      textAlign: "right",
+      textAlign: "center",
+      maxWidth: "80%",
     },
     stepContainer: {
       display: "flex",
@@ -72,6 +66,26 @@ const config = helpers.defineMultiStyleConfig({
     accent: (props) => ({
       root: {
         backgroundColor: mode("seaMist", "pine")(props),
+        color: mode("darkTeal", "seaMist")(props),
+      },
+      stepButton: {
+        color:
+          props.state === "disabled"
+            ? mode("blackAlpha.400", "whiteAlpha.400")(props)
+            : props.state === "completed"
+              ? mode("darkTeal", "white")(props)
+              : mode("white", "darkTeal")(props),
+        _hover: {
+          backgroundColor:
+            props.state === "disabled"
+              ? "transparent"
+              : mode("coralGreen", "greenHaze")(props),
+        },
+      },
+      backButton: {
+        _hover: {
+          backgroundColor: mode("coralGreen", "greenHaze")(props),
+        },
       },
     }),
   },


### PR DESCRIPTION
## Background

There were some visual inconsistencies between the Stepper component and what was designed in Figma.

## Solution

Re-implement most of the styling, and introduce a smaller redesign of both the StepperStep and Stepper components. This makes use of the Button component, and simplifies the design slightly.

![2024-02-13 15 02 53](https://github.com/nsbno/spor/assets/1307267/79e3f1ee-7b4e-47ff-9027-27c5229c3480)

