### PR TITLE
fix: make sure icon is vertically aligned in button

### DIFF
--- a/.changeset/tricky-suns-camp.md
+++ b/.changeset/tricky-suns-camp.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+fix issue where icons are not vertically aligned

--- a/.changeset/tricky-suns-camp.md
+++ b/.changeset/tricky-suns-camp.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-react": patch
 ---
 
-fix issue where icons are not vertically aligned
+fix issue where icons are not vertically aligned in button component

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -122,7 +122,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
         visibility={isLoading ? "hidden" : "visible"}
         aria-hidden={isLoading}
       >
-        <Flex gap={1}>
+        <Flex gap={1} alignItems="center">
           {leftIcon}
           <Box
             visibility={isLoading ? "hidden" : "visible"}


### PR DESCRIPTION
## Background

icons that were not .*24Icon was not aligned verticallly.
<img width="1077" alt="image" src="https://github.com/nsbno/spor/assets/26740919/f1bc732d-d8f3-4f02-b07d-c33347af1b85">


## Solution

Added alignItems to inner flex

![image](https://github.com/nsbno/spor/assets/26740919/0b4c3d45-8d7c-4cb2-b374-35347c651c33)

