### PR TITLE
Add autoId prop to Heading

### DIFF
--- a/.changeset/selfish-humans-battle.md
+++ b/.changeset/selfish-humans-battle.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Heading: New prop "autoId" lets you autogenerate an ID based on the content
+slugify: New export that lets you slugify a string

--- a/packages/spor-react/src/typography/Heading.tsx
+++ b/packages/spor-react/src/typography/Heading.tsx
@@ -1,5 +1,6 @@
 import { HeadingProps as ChakraHeadingProps, Text } from "@chakra-ui/react";
 import React from "react";
+import { slugify } from "..";
 import type { textStyles } from "../theme/foundations";
 
 export type HeadingProps = Omit<ChakraHeadingProps, "textStyle" | "as"> & {
@@ -7,6 +8,8 @@ export type HeadingProps = Omit<ChakraHeadingProps, "textStyle" | "as"> & {
   as: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   /** The size and style of the heading. Defaults to xl-display */
   variant?: keyof typeof textStyles;
+  /** If true, generate an ID based on the children */
+  autoId?: boolean;
 };
 /**
  * Create your own fancy headings with this component.
@@ -23,11 +26,24 @@ export type HeadingProps = Omit<ChakraHeadingProps, "textStyle" | "as"> & {
  * ```tsx
  * <Heading as="h1" variant="2xl">Look at me!</Heading>
  * ```
+ *
+ * If you want to generate an ID based on the children, you can use the `autoId` prop.
+ * Please note that this only works with string children (not JSX, nor arrays of strings).
+ *
+ * ```tsx
+ * <Heading as="h1" autoId>Page heading</Heading> // Will set id="page-heading"
+ * ```
  */
 export const Heading = ({
   as,
   variant = "xl-display",
+  autoId = false,
+  id: externalId,
   ...props
 }: HeadingProps) => {
-  return <Text as={as} textStyle={variant} {...props} />;
+  const id =
+    externalId ?? (autoId && typeof props.children === "string")
+      ? slugify(props.children as string)
+      : undefined;
+  return <Text as={as} textStyle={variant} id={id} {...props} />;
 };

--- a/packages/spor-react/src/util/index.tsx
+++ b/packages/spor-react/src/util/index.tsx
@@ -1,1 +1,2 @@
 export * from "./externals";
+export * from "./slugify";

--- a/packages/spor-react/src/util/slugify.tsx
+++ b/packages/spor-react/src/util/slugify.tsx
@@ -1,7 +1,12 @@
-/** Makes a slug-version of any string */
-export function slugify(text: string): string {
+/**
+ * Makes a slug-version of any string, with a maximum length of 50 characters
+ **/
+export function slugify(text: string | string[]): string {
   if (!text) {
     return text;
+  }
+  if (Array.isArray(text)) {
+    text = text.join(" ");
   }
   return (
     text
@@ -17,5 +22,6 @@ export function slugify(text: string): string {
       .replace(/--+/g, "-") // Replace multiple - with single -
       .replace(/^-+/, "") // Trim - from start of text
       .replace(/-+$/, "")
+      .substring(0, 50)
   );
 }

--- a/packages/spor-react/src/util/slugify.tsx
+++ b/packages/spor-react/src/util/slugify.tsx
@@ -1,0 +1,21 @@
+/** Makes a slug-version of any string */
+export function slugify(text: string): string {
+  if (!text) {
+    return text;
+  }
+  return (
+    text
+      .normalize("NFD") // Normalize to NFD Unicode form
+      .replace(/[\u0300-\u036f]/g, "") // Remove diacritics
+      .replace(/[\u00C6\u00E6]/g, "ae") // Replace Æ, æ
+      .replace(/[\u00D8\u00F8]/g, "oe") // Replace Ø, ø
+      .replace(/[\u00C5\u00E5]/g, "aa") // Replace Å, å
+      // Extend the replacement rules as needed
+      .toLowerCase()
+      .replace(/\s+/g, "-") // Replace spaces with -
+      .replace(/[^\w-]+/g, "") // Remove all non-word chars
+      .replace(/--+/g, "-") // Replace multiple - with single -
+      .replace(/^-+/, "") // Trim - from start of text
+      .replace(/-+$/, "")
+  );
+}

--- a/packages/spor-react/src/util/slugify.tsx
+++ b/packages/spor-react/src/util/slugify.tsx
@@ -1,12 +1,21 @@
 /**
- * Makes a slug-version of any string, with a maximum length of 50 characters
+ * Makes a slug-version of any string.
+ *
+ * By default, the maximum length of the slug is 50 characters. You can override this with the `maxLength` parameter.
+ *
+ * ```tsx
+ * slugify("Hello, world!"); // hello-world
+ * slugify("Hello, world!", 6); // hello-
  **/
-export function slugify(text: string | string[]): string {
+export function slugify(text: string | string[], maxLength = 50): string {
   if (!text) {
     return text;
   }
   if (Array.isArray(text)) {
     text = text.join(" ");
+  }
+  if (maxLength < 1) {
+    throw new Error("The maxLength parameter must be a positive number");
   }
   return (
     text
@@ -22,6 +31,6 @@ export function slugify(text: string | string[]): string {
       .replace(/--+/g, "-") // Replace multiple - with single -
       .replace(/^-+/, "") // Trim - from start of text
       .replace(/-+$/, "")
-      .substring(0, 50)
+      .substring(0, maxLength)
   );
 }


### PR DESCRIPTION
## Background

We need auto-generated IDs for headings every once in a while. Having a custom slugify function everywhere just gets messy very quickly.

## Solution

This solution introduces two new features:

- Create and export a `slugify` function. This can be useful in several contexts outside of ID generation (like slugs etc).
- The Heading component now has an `autoId` boolean prop that uses this `slugify` function to generate an id based on the children of the heading. If it's too long, it's shortened to 50 characters. If it's not a string (or array of strings) it won't generate an ID.
