### PR TITLE
Change input to onBackButtonClick

### DIFF
--- a/.changeset/silly-months-sneeze.md
+++ b/.changeset/silly-months-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Stepper: Change input to onBackButtonClick

--- a/packages/spor-react/src/stepper/Stepper.tsx
+++ b/packages/spor-react/src/stepper/Stepper.tsx
@@ -9,11 +9,10 @@ type StepperProps = {
   /** Callback for when a step is clicked */
   onClick: (clickedStep: number) => void;
   /** Callback for when the back button is clicked (on smaller screens).
-   * A boolean indicating whether or not the user is on the first step is passed as an argument.
    *
    * If this is not provided, the back button will not be shown on smaller screens on the first step.
    */
-  onBackButtonClick?: (isFirstStep: boolean) => void;
+  onBackButtonClick?: (stepNumberToGoTo: number) => void;
   /**
    * Heading shown on smaller devices
    * @deprecated Use `heading` instead
@@ -92,10 +91,11 @@ export const Stepper = ({
                 size="sm"
                 visibility={hideBackButtonOnFirstStep ? "hidden" : "visible"}
                 onClick={() => {
+                  const stepToGoTo = activeStep - 1;
                   if (onBackButtonClick) {
-                    onBackButtonClick(activeStep === 1);
+                    onBackButtonClick(stepToGoTo);
                   }
-                  onClick(activeStep - 1);
+                  onClick(stepToGoTo);
                 }}
               />
               {shownHeading && (


### PR DESCRIPTION
## Background

To give users of the Stepper more freedom to handle onBackButtonClick we want to send back the number of the step clicked, in stead of checking (and returning) `isFirstStep`

## Solution

Make onBackButtonClick return the step to go to instead of `isFirstStep`. 
