### PR TITLE
Lower the z index issue for form error messages

### DIFF
--- a/.changeset/calm-ligers-cover.md
+++ b/.changeset/calm-ligers-cover.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Lower the zIndex of form error messages

--- a/packages/spor-react/src/input/FormErrorMessage.tsx
+++ b/packages/spor-react/src/input/FormErrorMessage.tsx
@@ -60,7 +60,7 @@ export const FormErrorMessage = ({
         position="absolute"
         top={-0.5}
         left={3}
-        zIndex="popover"
+        zIndex="dropdown"
         maxWidth="50ch"
         {...errorMessageProps}
         {...boxProps}


### PR DESCRIPTION
## Background

The form error messages had a too high zindex set.

## Solution

Lower it, so that it hides behind modals etc.
