### PR TITLE
fix: Update TextLink colors for primary and secondary

### DIFF
--- a/.changeset/smart-coins-yawn.md
+++ b/.changeset/smart-coins-yawn.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Updated TextLink colors for variants primary and secondary to align with figma.

--- a/.changeset/smart-coins-yawn.md
+++ b/.changeset/smart-coins-yawn.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-react": patch
 ---
 
-Updated TextLink colors for variants primary and secondary to align with figma.
+TextLink: Updated colors for primary and secondary variants to align with Figma

--- a/packages/spor-react/src/theme/components/link.ts
+++ b/packages/spor-react/src/theme/components/link.ts
@@ -1,6 +1,8 @@
 import { defineStyleConfig } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
 import { focusVisibleStyles } from "../utils/focus-util";
+import { baseBackground, brandBackground } from "../utils/background-utils";
+import { baseText, brandText } from "../utils/text-utils";
 
 const config = defineStyleConfig({
   baseStyle: (props) => ({
@@ -38,14 +40,14 @@ const config = defineStyleConfig({
   }),
   variants: {
     primary: (props) => ({
-      color: mode("pine", "coralGreen")(props),
+      ...brandText("default", props),
       _hover: {
-        color: mode("white", "darkTeal")(props),
-        backgroundColor: mode("darkTeal", "blueGreen")(props),
+        ...brandText("hover", props),
+        ...brandBackground("hover", props),
       },
       _active: {
-        color: mode("white", "darkTeal")(props),
-        backgroundColor: mode("greenHaze", "seaMist")(props),
+        ...brandText("active", props),
+        ...brandBackground("active", props),
       },
     }),
     secondary: (props) => ({
@@ -53,19 +55,19 @@ const config = defineStyleConfig({
         "blackAlpha.400",
         "whiteAlpha.400",
       )(props)}, ${mode("blackAlpha.400", "whiteAlpha.400")(props)})`,
-      color: mode("darkGrey", "white")(props),
+      ...baseText("default", props),
       "&:focus, &:focus-visible, &:active, &:hover": {
         outline: "solid",
         outlineWidth: "1px",
       },
+      ...baseBackground("default", props),
       _hover: {
-        color: mode("darkGrey", "white")(props),
         outlineColor: mode("darkGrey", "white")(props),
+        ...baseBackground("hover", props),
       },
       _active: {
         outlineColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
-        backgroundColor: mode("mint", "whiteAlpha.100")(props),
-        color: mode("darkGrey", "white")(props),
+        ...baseBackground("active", props),
       },
     }),
   },

--- a/packages/spor-react/src/theme/components/link.ts
+++ b/packages/spor-react/src/theme/components/link.ts
@@ -40,21 +40,30 @@ const config = defineStyleConfig({
     primary: (props) => ({
       color: mode("pine", "coralGreen")(props),
       _hover: {
-        color: mode("darkTeal", "white")(props),
-        backgroundColor: mode("coralGreen", "whiteAlpha.200")(props),
+        color: mode("white", "darkTeal")(props),
+        backgroundColor: mode("darkTeal", "blueGreen")(props),
       },
       _active: {
-        color: mode("pine", "white")(props),
-        backgroundColor: mode("mint", "whiteAlpha.100")(props),
+        color: mode("white", "darkTeal")(props),
+        backgroundColor: mode("greenHaze", "seaMist")(props),
       },
     }),
     secondary: (props) => ({
+      backgroundImage: `linear-gradient(${mode(
+        "blackAlpha.400",
+        "whiteAlpha.400",
+      )(props)}, ${mode("blackAlpha.400", "whiteAlpha.400")(props)})`,
       color: mode("darkGrey", "white")(props),
+      "&:focus, &:focus-visible, &:active, &:hover": {
+        outline: "solid",
+        outlineWidth: "1px",
+      },
       _hover: {
-        backgroundColor: mode("blackAlpha.100", "whiteAlpha.200")(props),
         color: mode("darkGrey", "white")(props),
+        outlineColor: mode("darkGrey", "white")(props),
       },
       _active: {
+        outlineColor: mode("blackAlpha.400", "whiteAlpha.400")(props),
         backgroundColor: mode("mint", "whiteAlpha.100")(props),
         color: mode("darkGrey", "white")(props),
       },

--- a/packages/spor-react/src/theme/utils/text-utils.ts
+++ b/packages/spor-react/src/theme/utils/text-utils.ts
@@ -38,3 +38,23 @@ export function accentText(state: AccentTextState, props: StyleFunctionProps) {
       };
   }
 }
+
+type BrandTextState = Subset<State, "hover" | "active" | "default">;
+
+export function brandText(state: BrandTextState, props: StyleFunctionProps) {
+  switch (state) {
+    case "hover":
+      return {
+        color: mode("white", "darkTeal")(props),
+      };
+    case "active":
+      return {
+        color: mode("white", "darkTeal")(props),
+      };
+    case "default":
+    default:
+      return {
+        color: mode("pine", "coralGreen")(props),
+      };
+  }
+}


### PR DESCRIPTION
## Background

Updated TextLink colors to be aligned with Figma.

Closes issue: #924 

## Solution

Review video below for how it is in practise. Verbal ack from @perweum 

https://github.com/nsbno/spor/assets/3692249/6c8611d6-1875-44f7-bd54-dd34987290ac

