### PR TITLE
Fix listbox focus styles

### DIFF
--- a/.changeset/forty-melons-think.md
+++ b/.changeset/forty-melons-think.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+ListBox: Fix focus styles for listbox

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -93,11 +93,11 @@ export function Combobox<T extends object>({
   const inputWidth = useInputWidth(inputRef);
 
   const state = useComboBoxState({
-    ...rest,
-    defaultFilter: contains,
     allowsEmptyCollection: Boolean(emptyContent),
+    defaultFilter: contains,
     shouldCloseOnBlur: true,
     label,
+    ...rest,
   });
 
   const {

--- a/packages/spor-react/src/theme/components/listbox.ts
+++ b/packages/spor-react/src/theme/components/listbox.ts
@@ -44,7 +44,10 @@ const config = helpers.defineMultiStyleConfig({
       _hover: {
         ...ghostBackground("hover", props),
       },
-      ...focusVisibleStyles(props),
+      _focus: {
+        ...ghostBackground("selected", props),
+        ...focusVisibleStyles(props)._focusVisible,
+      },
       _selected: {
         ...ghostBackground("selected", props),
       },


### PR DESCRIPTION
## Background

The focus styles for listbox items were not like they used to.

## Solution

Fix them like this:

![2024-03-05 23 00 52](https://github.com/nsbno/spor/assets/1307267/71f9111e-d283-458c-b6fe-b81ec469fef4)

