### PR TITLE
Add cargonet brand

### DIFF
--- a/.changeset/late-buckets-travel.md
+++ b/.changeset/late-buckets-travel.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-design-tokens": minor
+"@vygruppen/spor-react": minor
+---
+
+Add support for Brand.CargoNet

--- a/apps/docs/app/root.tsx
+++ b/apps/docs/app/root.tsx
@@ -11,6 +11,7 @@ import {
   isRouteErrorResponse,
   useLoaderData,
   useRouteError,
+  useSearchParams,
 } from "@remix-run/react";
 import { Brand, Language, SporProvider } from "@vygruppen/spor-react";
 import { ReactNode, useContext, useEffect } from "react";
@@ -137,6 +138,15 @@ const Document = withEmotionCache(
       clientStyleData.reset();
     }, []);
 
+    const [searchParams] = useSearchParams();
+    let brand = Brand.VyDigital;
+    const lowercaseBrandParam = searchParams.get("brand")?.toLowerCase();
+    if (lowercaseBrandParam === "cargonet") {
+      brand = Brand.CargoNet;
+    } else if (lowercaseBrandParam === "vyutvikling") {
+      brand = Brand.VyUtvikling;
+    }
+
     return (
       <html lang="en-gb">
         <head>
@@ -158,7 +168,7 @@ const Document = withEmotionCache(
           <SporProvider
             language={Language.English}
             colorModeManager={colorModeManager}
-            brand={Brand.VyDigital}
+            brand={brand}
           >
             <SkipToContent />
             {children}

--- a/apps/docs/app/root/layout/SiteHeader.tsx
+++ b/apps/docs/app/root/layout/SiteHeader.tsx
@@ -36,7 +36,7 @@ export const SiteHeader = () => {
       alignItems="center"
       paddingX={[3, 4, 7]}
       paddingY={[3, 4, 5, 7]}
-      backgroundColor="darkTeal"
+      backgroundColor="bg.tertiary.dark"
     >
       <Box as={Link} marginRight={[0, 0, 11]} to="/">
         <VyLogo

--- a/apps/docs/app/root/layout/SiteNavigation.tsx
+++ b/apps/docs/app/root/layout/SiteNavigation.tsx
@@ -35,9 +35,9 @@ export const NavigationLink = ({ children, href }: NavigationItemProps) => {
       fontWeight="bold"
       fontStyle="sm"
       _focusVisible={{ borderColor: "greenHaze", outline: "none" }}
-      _hover={{ backgroundColor: "pine" }}
+      _hover={{ backgroundColor: "ghost.surface.hover.dark" }}
       _active={{
-        backgroundColor: "celadon",
+        backgroundColor: "ghost.surface.active.dark",
       }}
       backgroundColor={isActive ? "whiteAlpha.200" : "transparent"}
       transitionDuration="fast"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38990,7 +38990,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "9.0.2",
+      "version": "9.0.3",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.6.1",

--- a/packages/spor-design-tokens/tokens/color/cargonet.json
+++ b/packages/spor-design-tokens/tokens/color/cargonet.json
@@ -1,0 +1,424 @@
+{
+  "color": {
+    "cargonet": {
+      "bg": {
+        "default": {
+          "light": {
+            "value": "{color.alias.white.value}"
+          },
+          "dark": {
+            "value": "{color.alias.black.value}"
+          }
+        },
+        "secondary": {
+          "light": {
+            "value": "{color.alias.lightGrey.value}"
+          },
+          "dark": {
+            "value": "{color.alias.darkGrey.value}"
+          }
+        },
+        "tertiary": {
+          "light": {
+            "value": "{color.alias.cornsilk.value}"
+          },
+          "dark": {
+            "value": "{color.alias.golden.value}"
+          }
+        }
+      },
+      "text": {
+        "default": {
+          "light": {
+            "value": "{color.alias.darkGrey.value}"
+          },
+          "dark": {
+            "value": "{color.alias.white.value}"
+          }
+        },
+        "secondary": {
+          "light": {
+            "value": "{color.alias.wood.value}"
+          },
+          "dark": {
+            "value": "{color.alias.banana.value}"
+          }
+        },
+        "tertiary": {
+          "light": {
+            "value": "{color.alias.dimGrey.value}"
+          },
+          "dark": {
+            "value": "{color.palette.whiteAlpha.400.value}"
+          }
+        },
+        "inverted": {
+          "light": {
+            "value": "{color.alias.white.value}"
+          },
+          "dark": {
+            "value": "{color.alias.darkGrey.value}"
+          }
+        },
+        "disabled": {
+          "light": {
+            "value": "{color.palette.blackAlpha.400.value}"
+          },
+          "dark": {
+            "value": "{color.palette.whiteAlpha.400.value}"
+          }
+        }
+      },
+      "icon": {
+        "default": {
+          "light": {
+            "value": "{color.alias.darkGrey.value}"
+          },
+          "dark": {
+            "value": "{color.alias.white.value}"
+          }
+        },
+        "secondary": {
+          "light": {
+            "value": "{color.alias.wood.value}"
+          },
+          "dark": {
+            "value": "{color.alias.banana.value}"
+          }
+        },
+        "inverted": {
+          "light": {
+            "value": "{color.alias.white.value}"
+          },
+          "dark": {
+            "value": "{color.palette.whiteAlpha.400.value}"
+          }
+        },
+        "disabled": {
+          "light": {
+            "value": "{color.palette.blackAlpha.400.value}"
+          },
+          "dark": {
+            "value": "{color.palette.whiteAlpha.300.value}"
+          }
+        }
+      },
+      "outline": {
+        "default": {
+          "light": {
+            "value": "{color.palette.blackAlpha.400.value}"
+          },
+          "dark": {
+            "value": "{color.palette.whiteAlpha.400.value}"
+          }
+        },
+        "inverted": {
+          "light": {
+            "value": "{color.palette.whiteAlpha.400.value}"
+          },
+          "dark": {
+            "value": "{color.palette.blackAlpha.400.value}"
+          }
+        },
+        "focus": {
+          "light": {
+            "value": "{color.alias.darkGrey.value}"
+          },
+          "dark": {
+            "value": "{color.alias.burntYellow.value}"
+          }
+        },
+        "error": {
+          "light": {
+            "value": "{color.alias.brightRed.value}"
+          },
+          "dark": {
+            "value": "{color.alias.brightRed.value}"
+          }
+        },
+        "disabled": {
+          "light": {
+            "value": "{color.palette.blackAlpha.200.value}"
+          },
+          "dark": {
+            "value": "{color.palette.whiteAlpha.200.value}"
+          }
+        }
+      },
+      "surface": {
+        "default": {
+          "light": {
+            "value": "{color.alias.white.value}"
+          },
+          "dark": {
+            "value": "{color.palette.whiteAlpha.400.value}"
+          }
+        },
+        "secondary": {
+          "light": {
+            "value": "{color.alias.primrose.value}"
+          },
+          "dark": {
+            "value": "{color.alias.black.value}"
+          }
+        },
+        "tertiary": {
+          "light": {
+            "value": "{color.alias.darkGrey.value}"
+          },
+          "dark": {
+            "value": "{color.alias.dimGrey.value}"
+          }
+        },
+        "disabled": {
+          "light": {
+            "value": "{color.palette.blackAlpha.100.value}"
+          },
+          "dark": {
+            "value": "{color.palette.whiteAlpha.100.value}"
+          }
+        }
+      },
+      "base": {
+        "surface": {
+          "active": {
+            "light": {
+              "value": "{color.alias.cornsilk.value}"
+            },
+            "dark": {
+              "value": "{color.palette.whiteAlpha.100.value}"
+            }
+          }
+        },
+        "outline": {
+          "default": {
+            "light": {
+              "value": "{color.cargonet.outline.default.light.value}"
+            },
+            "dark": {
+              "value": "{color.cargonet.outline.default.dark.value}"
+            }
+          },
+          "hover": {
+            "light": {
+              "value": "{color.alias.darkGrey.value}"
+            },
+            "dark": {
+              "value": "{color.alias.white.value}"
+            }
+          }
+        },
+        "text": {
+          "light": {
+            "value": "{color.cargonet.text.default.light.value}"
+          },
+          "dark": {
+            "value": "{color.cargonet.text.default.dark.value}"
+          }
+        },
+        "icon": {
+          "light": {
+            "value": "{color.cargonet.icon.default.light.value}"
+          },
+          "dark": {
+            "value": "{color.cargonet.icon.default.dark.value}"
+          }
+        }
+      },
+      "brand": {
+        "surface": {
+          "default": {
+            "light": {
+              "value": "{color.alias.banana.value}"
+            },
+            "dark": {
+              "value": "{color.alias.banana.value}"
+            }
+          },
+          "hover": {
+            "light": {
+              "value": "{color.alias.burntYellow.value}"
+            },
+            "dark": {
+              "value": "{color.alias.burntYellow.value}"
+            }
+          },
+          "active": {
+            "light": {
+              "value": "{color.alias.sunshine.value}"
+            },
+            "dark": {
+              "value": "{color.alias.primrose.value}"
+            }
+          }
+        },
+        "text": {
+          "light": {
+            "value": "{color.cargonet.text.default.light.value}"
+          },
+          "dark": {
+            "value": "{color.cargonet.text.default.dark.value}"
+          }
+        },
+        "icon": {
+          "light": {
+            "value": "{color.cargonet.icon.default.light.value}"
+          },
+          "dark": {
+            "value": "{color.cargonet.icon.default.dark.value}"
+          }
+        }
+      },
+      "accent": {
+        "surface": {
+          "default": {
+            "light": {
+              "value": "{color.alias.dimGrey.value}"
+            },
+            "dark": {
+              "value": "{color.palette.whiteAlpha.200.value}"
+            }
+          },
+          "hover": {
+            "light": {
+              "value": "{color.alias.darkGrey.value}"
+            },
+            "dark": {
+              "value": "{color.palette.whiteAlpha.100.value}"
+            }
+          },
+          "active": {
+            "light": {
+              "value": "{color.alias.osloGrey.value}"
+            },
+            "dark": {
+              "value": "{color.palette.whiteAlpha.300.value}"
+            }
+          }
+        },
+        "text": {
+          "light": {
+            "value": "{color.cargonet.text.inverted.light.value}"
+          },
+          "dark": {
+            "value": "{color.cargonet.text.secondary.dark.value}"
+          }
+        },
+        "icon": {
+          "light": {
+            "value": "{color.cargonet.icon.inverted.light.value}"
+          },
+          "dark": {
+            "value": "{color.cargonet.icon.secondary.dark.value}"
+          }
+        },
+        "bg": {
+          "light": {
+            "value": "{color.alias.osloGrey.value}"
+          },
+          "dark": {
+            "value": "{color.palette.whiteAlpha.100.value}"
+          }
+        }
+      },
+      "floating": {
+        "surface": {
+          "default": {
+            "light": {
+              "value": "{color.alias.white.value}"
+            },
+            "dark": {
+              "value": "{color.palette.whiteAlpha.100.value}"
+            }
+          },
+          "hover": {
+            "light": {
+              "value": "{color.alias.white.value}"
+            },
+            "dark": {
+              "value": "{color.palette.whiteAlpha.200.value}"
+            }
+          },
+          "active": {
+            "light": {
+              "value": "{color.alias.cornsilk.value}"
+            },
+            "dark": {
+              "value": "{color.alias.black.value}"
+            }
+          }
+        },
+        "outline": {
+          "default": {
+            "light": {
+              "value": "{color.alias.silver.value}"
+            },
+            "dark": {
+              "value": "{color.palette.whiteAlpha.400.value}"
+            }
+          },
+          "hover": {
+            "light": {
+              "value": "{color.alias.steel.value}"
+            },
+            "dark": {
+              "value": "{color.palette.whiteAlpha.300.value}"
+            }
+          }
+        },
+        "text": {
+          "light": {
+            "value": "{color.cargonet.text.default.light.value}"
+          },
+          "dark": {
+            "value": "{color.cargonet.text.default.dark.value}"
+          }
+        },
+        "icon": {
+          "light": {
+            "value": "{color.cargonet.icon.default.light.value}"
+          },
+          "dark": {
+            "value": "{color.cargonet.icon.default.dark.value}"
+          }
+        }
+      },
+      "ghost": {
+        "surface": {
+          "hover": {
+            "light": {
+              "value": "{color.alias.blonde.value}"
+            },
+            "dark": {
+              "value": "{color.palette.whiteAlpha.200.value}"
+            }
+          },
+          "active": {
+            "light": {
+              "value": "{color.alias.cornsilk.value}"
+            },
+            "dark": {
+              "value": "{color.palette.whiteAlpha.100.value}"
+            }
+          }
+        },
+        "text": {
+          "light": {
+            "value": "{color.cargonet.text.default.light.value}"
+          },
+          "dark": {
+            "value": "{color.cargonet.text.default.dark.value}"
+          }
+        },
+        "icon": {
+          "light": {
+            "value": "{color.cargonet.icon.default.light.value}"
+          },
+          "dark": {
+            "value": "{color.cargonet.icon.default.dark.value}"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/spor-design-tokens/tokens/color/cargonet.json
+++ b/packages/spor-design-tokens/tokens/color/cargonet.json
@@ -257,7 +257,7 @@
             "value": "{color.cargonet.text.default.light.value}"
           },
           "dark": {
-            "value": "{color.cargonet.text.default.dark.value}"
+            "value": "{color.cargonet.text.inverted.dark.value}"
           }
         },
         "icon": {

--- a/packages/spor-react/src/theme/index.ts
+++ b/packages/spor-react/src/theme/index.ts
@@ -1,10 +1,12 @@
 import { theme as defaultTheme } from "@chakra-ui/theme";
+import tokens from "@vygruppen/spor-design-tokens";
 import * as components from "./components";
 import * as foundations from "./foundations";
 
 export enum Brand {
   VyDigital = "VyDigital",
   VyUtvikling = "VyUtvikling",
+  CargoNet = "CargoNet",
 }
 
 export const theme = {
@@ -23,12 +25,14 @@ export const brandTheme = {
       accent: {
         surface: {
           default: {
-            light: foundations.colors.seaMist,
             dark: foundations.colors.darkGrey,
           },
         },
       },
     },
+  },
+  [Brand.CargoNet]: {
+    colors: tokens.color.cargonet as any,
   },
 };
 


### PR DESCRIPTION
## Background

We need to support the CargoNet brand.

## Solution

This PR adds support for specifying the CargoNet brand to the SporProvider, and get yellow components – even in dark mode!

To test it out, you can set ?brand=cargonet in the URL, and the page will be rendered with the CargoNet brand. 🤯 

![image](https://github.com/nsbno/spor/assets/1307267/5c3a3162-80e8-48de-9511-7c308aa8cc33)

