### PR TITLE
Only use semantic tokens in the documentation website

### DIFF
--- a/.changeset/poor-wombats-impress.md
+++ b/.changeset/poor-wombats-impress.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+CardSelect: Add fontWeight prop

--- a/apps/docs/app/features/portable-text/PortableText.tsx
+++ b/apps/docs/app/features/portable-text/PortableText.tsx
@@ -264,26 +264,36 @@ const components: Partial<PortableTextReactComponents> = {
       }
       return <CodeBlock code={value.reactImport} marginTop={3} />;
     },
-    tipsPanel: ({ value }) => (
-      <Box
-        as="article"
-        backgroundColor="mint"
-        color="text.default.light"
-        marginTop={3}
-        padding={4}
-        borderRadius="md"
-      >
-        <Flex gap={1} alignItems="end">
-          <FavouriteOutline30Icon />
-          <Heading as="h3" variant="sm" fontWeight="bold">
-            {value.title}
-          </Heading>
-        </Flex>
-        <Box __css={{ " > p:first-of-type": { mt: 1 } }}>
-          <PortableText value={value.content} />
+    tipsPanel: ({ value }) => {
+      const textColor = useColorModeValue(
+        "text.default.light",
+        "text.default.dark",
+      );
+      const backgroundColor = useColorModeValue(
+        "bg.tertiary.light",
+        "bg.tertiary.dark",
+      );
+      return (
+        <Box
+          as="article"
+          backgroundColor={backgroundColor}
+          color={textColor}
+          marginTop={3}
+          padding={4}
+          borderRadius="md"
+        >
+          <Flex gap={1} alignItems="end">
+            <FavouriteOutline30Icon />
+            <Heading as="h3" variant="sm" fontWeight="bold">
+              {value.title}
+            </Heading>
+          </Flex>
+          <Box __css={{ " > p:first-of-type": { mt: 1 } }}>
+            <PortableText value={value.content} />
+          </Box>
         </Box>
-      </Box>
-    ),
+      );
+    },
     bestPracticePanel: ({ value }) => (
       <SimpleGrid
         columns={[1, 2]}

--- a/apps/docs/app/features/portable-text/code-block/CodeBlock.tsx
+++ b/apps/docs/app/features/portable-text/code-block/CodeBlock.tsx
@@ -73,7 +73,7 @@ export const CodeBlockContainer = ({
       onKeyUp={handleKeyUp}
       {...props}
     >
-      <Box position="absolute" top={2} right={2}>
+      <Box position="absolute" top={2} right={2} zIndex="docked">
         <CopyCodeButton ref={copyButtonRef} code={code} />
       </Box>
       <Box>{children}</Box>
@@ -102,10 +102,7 @@ export const CopyCodeButton = forwardRef<CopyCodeButtonProps, "button">(
     return (
       <DarkMode>
         <Button
-          variant="tertiary"
-          color="white"
-          backgroundColor="darkGrey"
-          boxShadow="inset 0 0 0 1px white, 0 0 10px 0.25rem rgba(0,0,0,0.7)"
+          variant="primary"
           size="xs"
           onClick={onCopy}
           _active={{ backgroundColor: "mint", color: "darkGrey" }}

--- a/apps/docs/app/root/layout/SiteNavigation.tsx
+++ b/apps/docs/app/root/layout/SiteNavigation.tsx
@@ -34,7 +34,7 @@ export const NavigationLink = ({ children, href }: NavigationItemProps) => {
       whiteSpace="nowrap"
       fontWeight="bold"
       fontStyle="sm"
-      _focusVisible={{ borderColor: "greenHaze", outline: "none" }}
+      _focusVisible={{ borderColor: "outline.focus.dark", outline: "none" }}
       _hover={{ backgroundColor: "ghost.surface.hover.dark" }}
       _active={{
         backgroundColor: "ghost.surface.active.dark",

--- a/apps/docs/app/root/layout/SiteSettings.tsx
+++ b/apps/docs/app/root/layout/SiteSettings.tsx
@@ -30,6 +30,7 @@ export const SiteSettings = ({ showLabel }: SiteSettingsProps) => {
         size="md"
         icon={<SettingsX1Fill24Icon />}
         withChevron={false}
+        fontWeight="bold"
         {...labelProps}
       >
         <Flex gap={4} flexDirection="column" maxWidth="30ch">

--- a/apps/docs/app/root/layout/SkipToContent.tsx
+++ b/apps/docs/app/root/layout/SkipToContent.tsx
@@ -1,6 +1,14 @@
-import { Box } from "@vygruppen/spor-react";
+import { Box, useColorModeValue } from "@vygruppen/spor-react";
 
 export const SkipToContent = () => {
+  const backgroundColor = useColorModeValue(
+    "bg.default.dark",
+    "bg.default.light",
+  );
+  const textColor = useColorModeValue(
+    "text.default.dark",
+    "text.default.light",
+  );
   return (
     <Box
       as="a"
@@ -12,8 +20,8 @@ export const SkipToContent = () => {
       left="0"
       right="0"
       padding={2}
-      backgroundColor="night"
-      color="white"
+      backgroundColor={backgroundColor}
+      color={textColor}
       borderBottomRadius="sm"
       minWidth="40ch"
       boxShadow="md"
@@ -24,7 +32,8 @@ export const SkipToContent = () => {
       _focusVisible={{
         transform: "none",
         opacity: 1,
-        boxShadow: "0 0 0 4px var(--spor-colors-burntYellow)",
+        outline: "4px solid",
+        outlineColor: "burntYellow",
       }}
     >
       Skip to content

--- a/apps/docs/app/routes/_base.components.overview/route.tsx
+++ b/apps/docs/app/routes/_base.components.overview/route.tsx
@@ -1,5 +1,12 @@
 import { Link, useLoaderData } from "@remix-run/react";
-import { Box, Card, Heading, Image, SimpleGrid } from "@vygruppen/spor-react";
+import {
+  Box,
+  Card,
+  Heading,
+  Image,
+  SimpleGrid,
+  useColorModeValue,
+} from "@vygruppen/spor-react";
 import { PortableText } from "~/features/portable-text/PortableText";
 import { getClient } from "~/utils/sanity/client";
 import { urlBuilder } from "~/utils/sanity/utils";
@@ -65,6 +72,10 @@ export const loader = async () => {
 
 export default function ComponentsPage() {
   const { components, article } = useLoaderData<typeof loader>();
+  const backgroundColor = useColorModeValue(
+    "bg.tertiary.light",
+    "bg.tertiary.dark",
+  );
   return (
     <Box>
       <Heading as="h1" variant="xl-display" marginBottom={2}>
@@ -83,7 +94,7 @@ export default function ComponentsPage() {
               <Image
                 src={urlBuilder.image(component.mainImage).width(300).url()}
                 alt={component.title}
-                backgroundColor="mint"
+                backgroundColor={backgroundColor}
                 padding="1em"
                 width="100%"
                 height="10em"
@@ -91,7 +102,7 @@ export default function ComponentsPage() {
                 objectPosition="center center"
               />
             ) : (
-              <Box height="10em" backgroundColor="mint" />
+              <Box height="10em" backgroundColor={backgroundColor} />
             )}
             <Heading as="h2" variant="sm" fontWeight="bold" padding={3}>
               {component.title}

--- a/apps/docs/app/routes/_base.resources.design-tokens/RoundingTokens.tsx
+++ b/apps/docs/app/routes/_base.resources.design-tokens/RoundingTokens.tsx
@@ -11,6 +11,7 @@ import {
   Th,
   Thead,
   Tr,
+  useColorModeValue,
 } from "@vygruppen/spor-react";
 import { useTokenFormatter } from "~/routes/_base.resources.design-tokens/useTokenFormatter";
 import { SharedTokenLayout } from "./SharedTokenLayout";
@@ -44,6 +45,14 @@ type RoundingTokenTableProps = BoxProps;
 
 const RoundingTokensTable = (props: RoundingTokenTableProps) => {
   const tokenFormatter = useTokenFormatter();
+  const backgroundColor = useColorModeValue(
+    "bg.tertiary.light",
+    "bg.tertiary.dark",
+  );
+  const outlineColor = useColorModeValue(
+    "outline.default.light",
+    "outline.default.dark",
+  );
   return (
     <Box {...props}>
       <Table variant="simple" colorScheme="grey">
@@ -59,12 +68,12 @@ const RoundingTokensTable = (props: RoundingTokenTableProps) => {
             <Tr key={key}>
               <Td>
                 <Box
-                  width={"150px"}
-                  height={"72px"}
+                  width="150px"
+                  height="72px"
                   borderRadius={key}
                   border="md"
-                  borderColor="greenHaze"
-                  backgroundColor="mint"
+                  borderColor={outlineColor}
+                  backgroundColor={backgroundColor}
                 />
               </Td>
               <Td>

--- a/apps/docs/app/routes/_base.resources.design-tokens/SpacingTokens.tsx
+++ b/apps/docs/app/routes/_base.resources.design-tokens/SpacingTokens.tsx
@@ -11,6 +11,7 @@ import {
   Th,
   Thead,
   Tr,
+  useColorModeValue,
 } from "@vygruppen/spor-react";
 import { Fragment } from "react";
 import { useTokenFormatter } from "~/routes/_base.resources.design-tokens/useTokenFormatter";
@@ -43,6 +44,10 @@ type SpacingTokenTableProps = BoxProps;
 
 const SpacingTokensTable = (props: SpacingTokenTableProps) => {
   const tokenFormatter = useTokenFormatter();
+  const backgroundColor = useColorModeValue(
+    "surface.tertiary.light",
+    "surface.tertiary.dark",
+  );
   return (
     <Box {...props}>
       <Table variant="simple" colorScheme="grey">
@@ -63,7 +68,7 @@ const SpacingTokensTable = (props: SpacingTokenTableProps) => {
                     <Box
                       width={token}
                       height={token}
-                      backgroundColor="primaryGreen"
+                      backgroundColor={backgroundColor}
                     />
                   </Td>
                   <Td>

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -4,6 +4,7 @@ import {
   chakra,
   Flex,
   forwardRef,
+  ResponsiveValue,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
 import {
@@ -43,6 +44,8 @@ type CardSelectProps = BoxProps & {
   placement?: AriaPositionProps["placement"];
   /** Whether or not to show the chevron. Defaults to true */
   withChevron?: boolean;
+  /** Defaults to normal */
+  fontWeight?: ResponsiveValue<"normal" | "bold">;
 } & (
     | {
         /** The text label of the trigger button */
@@ -82,6 +85,7 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
       crossOffset = 0,
       placement = "bottom",
       withChevron = true,
+      fontWeight = "normal",
       ...props
     },
     externalRef,
@@ -118,6 +122,7 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
         <chakra.button
           type="button"
           ref={triggerRef}
+          fontWeight="bold"
           sx={styles.trigger}
           aria-label={label}
           {...buttonProps}


### PR DESCRIPTION
## Background

Now that we have a bunch of semantic tokens, we can use those!

## Solution

Use semantic tokens instead of actual colors, so that the page works better as a multibrand site.

Also, add a `fontWeight` prop to the CardSelect.
