### PR TITLE
Make the brand switcher work in Safari

### DIFF
--- a/apps/docs/app/utils/brand-cookie.server.ts
+++ b/apps/docs/app/utils/brand-cookie.server.ts
@@ -4,10 +4,7 @@ import { Brand } from "@vygruppen/spor-react";
 const COOKIE_NAME = "brand";
 
 const cookie = createCookie(COOKIE_NAME, {
-  secure: true,
-  httpOnly: true, // TODO: burde denne kunne endres med js?
-  maxAge: 60 * 60 * 24,
-  path: "/",
+  maxAge: 60 * 60 * 24, // A day
 });
 
 export const getBrandFromCookie = async (cookieHeader: string) => {


### PR DESCRIPTION
## Background

When testing the new dark mode and multi brand support in different browsers, we came across an issue where the brand cookie wasn't set correctly in Safari for some reason.

## Solution

Removing a few restrictions on the cookie seemed to help!
