### PR TITLE
Redefine __dirname, since it needs to be defined differently when using esmodules

### DIFF
--- a/apps/docs/app/utils/icons.server.ts
+++ b/apps/docs/app/utils/icons.server.ts
@@ -1,5 +1,10 @@
 import fs from "fs/promises";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+
+const __dirname = path.dirname(__filename);
 
 /** Gets the file buffer of the spor icon .zip file */
 export const getIconsZipFile = async () => {


### PR DESCRIPTION
## Background

When upgrading Remix to use Vite, we ended up moving to using esmodules, instead of commonjs modules. This broke our download icons code, because esmodules doesn't expose the __dirname global variable.

## Solution

Figure out the __dirname variable another way – [courtesy of StackOverflow](https://stackoverflow.com/questions/72456535/referenceerror-dirname-is-not-defined-in-es-module-scope).


