### PR TITLE
💄 Removed weird layout bug at around 1000px width

### DIFF
--- a/apps/docs/app/root/layout/RootLayout.tsx
+++ b/apps/docs/app/root/layout/RootLayout.tsx
@@ -14,6 +14,7 @@ export const RootLayout = ({ children }: BaseLayoutProps) => {
       flexDirection="column"
       minHeight="100vh"
       backgroundColor={backgroundColor}
+      overflow="auto"
     >
       <SiteHeader />
       <Flex flex="1" flexDirection="column" alignItems="stretch">


### PR DESCRIPTION
## Background

A weird bug happened where the header would not take the entire width of the screen.

## Solution
Added an overflow auto and it seemed to sort itself out.


Before at 1025px: 
![Screenshot 2024-04-10 at 13 15 31](https://github.com/nsbno/spor/assets/31248055/d1ad1de0-3794-4e31-8e80-cdc8c5db19f0)

Now at 1025px: 
![Screenshot 2024-04-10 at 13 16 43](https://github.com/nsbno/spor/assets/31248055/305e155d-5ba0-4c64-8b5c-b6ae85bfcead)
