### PR TITLE
Add static card to spor

### DIFF
--- a/.changeset/fluffy-months-melt.md
+++ b/.changeset/fluffy-months-melt.md
@@ -1,5 +1,5 @@
 ---
-"@vygruppen/spor-react": patch
+"@vygruppen/spor-react": minor
 ---
 
 Added static card

--- a/.changeset/fluffy-months-melt.md
+++ b/.changeset/fluffy-months-melt.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Added static card

--- a/apps/docs/app/routes/_base.resources.illustration-library.all/route.tsx
+++ b/apps/docs/app/routes/_base.resources.illustration-library.all/route.tsx
@@ -49,7 +49,7 @@ export const loader = async () => {
   headers.set("Content-Type", "application/zip");
   headers.set("Content-Disposition", "attachment; filename=illustrations.zip");
   headers.set("Cache-Control", "max-age=60");
-  
+
   return new Response(stream as any, {
     status: 200,
     headers,

--- a/apps/docs/app/routes/_base.resources.illustration-library.all/route.tsx
+++ b/apps/docs/app/routes/_base.resources.illustration-library.all/route.tsx
@@ -49,6 +49,7 @@ export const loader = async () => {
   headers.set("Content-Type", "application/zip");
   headers.set("Content-Disposition", "attachment; filename=illustrations.zip");
   headers.set("Cache-Control", "max-age=60");
+  
   return new Response(stream as any, {
     status: 200,
     headers,

--- a/packages/spor-react/src/alert/AlertIcon.tsx
+++ b/packages/spor-react/src/alert/AlertIcon.tsx
@@ -11,7 +11,7 @@ import { BaseAlertProps } from "./BaseAlert";
 
 type AlertIconProps = { variant: BaseAlertProps["variant"] };
 /**
- * Internal component that shows the correct icon for the alert.
+ * Internal component that shows the correct icon for the alert
  */
 export const AlertIcon = ({ variant }: AlertIconProps) => {
   const Icon = getIcon(variant);

--- a/packages/spor-react/src/card/StaticCard.tsx
+++ b/packages/spor-react/src/card/StaticCard.tsx
@@ -11,18 +11,15 @@ import { Box, useStyleConfig } from "@chakra-ui/react";
  * </StaticCard>
  * ```
  *
- * Cards are not interactive by default. If you specify the `as` prop to be a link or a button, you can make them work as links or buttons respectively. This will also give it a drop shadow.
+ * Static cards can also be rendered as whatever DOM element you want – like a li (list item) or an article. You do this by specifying the `as` prop:
  *
  * ```tsx
- * <StaticCard colorScheme="blue" as="button" onClick={handleClick}>
- *   Click for profit
- * </StaticCard>
- * <StaticCard colorScheme="green" as="a" href="https://vy.no">
- *   Go to start
+ * <StaticCard colorScheme="green" as="section">
+ *   This is now a <section /> element
  * </StaticCard>
  * ```
  */
 export const StaticCard = ({ colorScheme, ...props }: any) => {
   const styles = useStyleConfig("StaticCard", { colorScheme });
-  return <Box as={props.as} __css={styles} {...props} />;
+  return <Box __css={styles} {...props} />;
 };

--- a/packages/spor-react/src/card/StaticCard.tsx
+++ b/packages/spor-react/src/card/StaticCard.tsx
@@ -1,6 +1,27 @@
 import React from "react";
-import { chakra, useStyleConfig } from "@chakra-ui/react";
-
+import { Box, useStyleConfig } from "@chakra-ui/react";
+/**
+ * Renders a static card.
+ *
+ * The most basic version looks like this:
+ *
+ * ```tsx
+ * <StaticCard colorScheme="white">
+ *   Content
+ * </StaticCard>
+ * ```
+ *
+ * Cards are not interactive by default. If you specify the `as` prop to be a link or a button, you can make them work as links or buttons respectively. This will also give it a drop shadow.
+ *
+ * ```tsx
+ * <StaticCard colorScheme="blue" as="button" onClick={handleClick}>
+ *   Click for profit
+ * </StaticCard>
+ * <StaticCard colorScheme="green" as="a" href="https://vy.no">
+ *   Go to start
+ * </StaticCard>
+ * ```
+ */
 export const StaticCard = ({ colorScheme, ...props }: any) => {
   const styles = useStyleConfig("StaticCard", { colorScheme });
   return <Box as={props.as} __css={styles} {...props} />;

--- a/packages/spor-react/src/card/StaticCard.tsx
+++ b/packages/spor-react/src/card/StaticCard.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { chakra, useStyleConfig } from "@chakra-ui/react";
+
+export const StaticCard = ({ colorScheme, ...props }: any) => {
+  const styles = useStyleConfig("StaticCard", { colorScheme });
+  return <Box as={props.as} __css={styles} {...props} />;
+};

--- a/packages/spor-react/src/card/index.tsx
+++ b/packages/spor-react/src/card/index.tsx
@@ -1,1 +1,2 @@
 export * from "./Card";
+export * from "./StaticCard";

--- a/packages/spor-react/src/theme/components/index.ts
+++ b/packages/spor-react/src/theme/components/index.ts
@@ -38,4 +38,5 @@ export { default as Table } from "./table";
 export { default as Tabs } from "./tabs";
 export { default as Textarea } from "./textarea";
 export { default as Toast } from "./toast";
+export { default as StaticCard } from "./static-card";
 export { default as TravelTag } from "./travel-tag";

--- a/packages/spor-react/src/theme/components/static-card.ts
+++ b/packages/spor-react/src/theme/components/static-card.ts
@@ -1,0 +1,66 @@
+import { defineStyleConfig } from "@chakra-ui/react";
+import { mode } from "@chakra-ui/theme-tools";
+import { colors } from "../foundations";
+import { baseBorder } from "../utils/base-utils";
+
+const config = defineStyleConfig({
+  baseStyle: (props: any) => ({
+    appearance: "none",
+    border: "none",
+    overflow: "hidden",
+    fontSize: "inherit",
+    display: "block",
+    borderRadius: "md",
+    // Except for white cards, all cards are light mode always
+    color: "text.default.light",
+    ...getColorSchemeBaseProps(props),
+  }),
+});
+
+export default config;
+
+type CardThemeProps = {
+  colorScheme:
+    | "white"
+    | "grey"
+    | "blue"
+    | "green"
+    | "teal"
+    | "yellow"
+    | "orange"
+    | "red";
+  theme: any;
+  colorMode: "light" | "dark";
+};
+
+const getColorSchemeBaseProps = (props: CardThemeProps) => {
+  switch (props.colorScheme) {
+    case "white":
+      return {
+        ...baseBorder("default", props),
+        backgroundColor: mode(
+          "white",
+          `color-mix(in srgb, white 10%, var(--spor-colors-bg-default-dark))`,
+        )(props),
+        color: "inherit",
+      };
+    case "grey":
+      return {
+        backgroundColor: "lightGrey",
+      };
+    case "green": {
+      return {
+        backgroundColor: "seaMist",
+      };
+    }
+    case "red": {
+      return {
+        backgroundColor: "pink",
+      };
+    }
+    default:
+      return {
+        backgroundColor: colors[props.colorScheme]?.[100] ?? "platinum",
+      };
+  }
+};


### PR DESCRIPTION
## Background

I Figma finnes en variant av card som er static, som er “flat” (ingen skygger, osv. som gir elevation). Denne finnes ikke i Spor p.t.

<!-- Why is this pull request necessary? -->

Ikke ha egne “hacks” som komponenter når de burde finnes i Spor

## Solution

La til static card i spor

<!-- Summarize what has been done to solve the challenge. -->