### PR TITLE
Left icon support on combobox

### DIFF
--- a/.changeset/twelve-pigs-act.md
+++ b/.changeset/twelve-pigs-act.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+ComboBox: Fix a bug where left icons didn't work as expected.

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import { AriaComboBoxProps, useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
-import { ColorSpinner, Input, InputProps, ListBox } from "..";
+import { Input, InputProps, ListBox } from "..";
 import { Popover } from "./Popover";
-import { InputLeftElement } from "@chakra-ui/react";
 
 type OverridableInputProps = Pick<
 InputProps,

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -1,31 +1,31 @@
 import React, { useEffect, useRef, useState } from "react";
 import { AriaComboBoxProps, useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
-import { ColorSpinner,Input, InputProps, ListBox } from "..";
+import { ColorSpinner, Input, InputProps, ListBox } from "..";
 import { Popover } from "./Popover";
 
 type OverridableInputProps = Pick<
-InputProps,
-| "marginTop"
-| "marginBottom"
-| "marginRight"
-| "marginLeft"
-| "marginY"
-| "marginX"
-| "paddingTop"
-| "paddingBottom"
-| "paddingLeft"
-| "paddingRight"
-| "paddingY"
-| "paddingX"
-| "leftIcon"
-| "rightIcon"
-| "borderTopRightRadius"
-| "borderTopLeftRadius"
-| "borderBottomRightRadius"
-| "borderBottomLeftRadius"
-| "onFocus"
->
+  InputProps,
+  | "marginTop"
+  | "marginBottom"
+  | "marginRight"
+  | "marginLeft"
+  | "marginY"
+  | "marginX"
+  | "paddingTop"
+  | "paddingBottom"
+  | "paddingLeft"
+  | "paddingRight"
+  | "paddingY"
+  | "paddingX"
+  | "leftIcon"
+  | "rightIcon"
+  | "borderTopRightRadius"
+  | "borderTopLeftRadius"
+  | "borderBottomRightRadius"
+  | "borderBottomLeftRadius"
+  | "onFocus"
+>;
 
 export type ComboboxProps<T> = AriaComboBoxProps<T> & {
   /** The label of the combobox */
@@ -62,8 +62,6 @@ export type ComboboxProps<T> = AriaComboBoxProps<T> & {
  * </Combobox>
  * ```
  */
-
-
 
 export function Combobox<T extends object>({
   label,
@@ -108,7 +106,7 @@ export function Combobox<T extends object>({
     ...rest,
   });
 
-  const comboBoxProps: OverridableInputProps = { 
+  const comboBoxProps: OverridableInputProps = {
     borderTopLeftRadius,
     borderTopRightRadius,
     marginBottom,
@@ -126,8 +124,6 @@ export function Combobox<T extends object>({
     leftIcon,
   };
 
- 
-
   const {
     inputProps: { size, ...inputProps },
     listBoxProps,
@@ -140,7 +136,6 @@ export function Combobox<T extends object>({
     },
     state,
   );
-
 
   return (
     <>
@@ -174,7 +169,7 @@ export function Combobox<T extends object>({
           )
         }
       />
-      
+
       {state.isOpen && !isLoading && (
         <Popover
           state={state}
@@ -219,7 +214,7 @@ const useInputWidth = (inputRef: React.RefObject<HTMLInputElement>) => {
 
 function styleProps(obj: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(
-    Object.entries(obj).filter(([, value]) => value !== undefined)
+    Object.entries(obj).filter(([, value]) => value !== undefined),
   );
 }
 

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -3,6 +3,30 @@ import { AriaComboBoxProps, useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
 import { ColorSpinner, Input, InputProps, ListBox } from "..";
 import { Popover } from "./Popover";
+import { InputLeftElement } from "@chakra-ui/react";
+
+type OverridableInputProps = Pick<
+InputProps,
+| "marginTop"
+| "marginBottom"
+| "marginRight"
+| "marginLeft"
+| "marginY"
+| "marginX"
+| "paddingTop"
+| "paddingBottom"
+| "paddingLeft"
+| "paddingRight"
+| "paddingY"
+| "paddingX"
+| "leftIcon"
+| "rightIcon"
+| "borderTopRightRadius"
+| "borderTopLeftRadius"
+| "borderBottomRightRadius"
+| "borderBottomLeftRadius"
+| "onFocus"
+>
 
 export type ComboboxProps<T> = AriaComboBoxProps<T> & {
   /** The label of the combobox */
@@ -15,28 +39,7 @@ export type ComboboxProps<T> = AriaComboBoxProps<T> & {
   inputRef?: React.RefObject<HTMLInputElement>;
   /** If you want to allow an empty collection */
   allowsEmptyCollection?: boolean;
-} & Pick<
-    InputProps,
-    | "marginTop"
-    | "marginBottom"
-    | "marginRight"
-    | "marginLeft"
-    | "marginY"
-    | "marginX"
-    | "paddingTop"
-    | "paddingBottom"
-    | "paddingLeft"
-    | "paddingRight"
-    | "paddingY"
-    | "paddingX"
-    | "leftIcon"
-    | "rightIcon"
-    | "borderTopRightRadius"
-    | "borderTopLeftRadius"
-    | "borderBottomRightRadius"
-    | "borderBottomLeftRadius"
-    | "onFocus"
-  >;
+} & OverridableInputProps;
 /**
  * A combobox is a combination of an input and a list of suggestions.
  *
@@ -60,6 +63,7 @@ export type ComboboxProps<T> = AriaComboBoxProps<T> & {
  * </Combobox>
  * ```
  */
+
 export function Combobox<T extends object>({
   label,
   isLoading,
@@ -103,6 +107,26 @@ export function Combobox<T extends object>({
     ...rest,
   });
 
+  const ComboBoxProps: OverridableInputProps = { 
+    borderTopLeftRadius,
+    borderTopRightRadius,
+    marginBottom,
+    marginTop,
+    marginRight,
+    marginLeft,
+    marginX,
+    marginY,
+    paddingBottom,
+    paddingRight,
+    paddingTop,
+    paddingLeft,
+    paddingX,
+    paddingY,
+    leftIcon,
+  };
+
+ 
+
   const {
     inputProps: { size, ...inputProps },
     listBoxProps,
@@ -115,11 +139,18 @@ export function Combobox<T extends object>({
     },
     state,
   );
+ 
+
+  function styleProps(obj: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(
+      Object.entries(obj).filter(([, value]) => value !== undefined)
+    );
+  }
 
   return (
     <>
       <Input
-        {...inputProps}
+        {...styleProps(ComboBoxProps)}
         aria-haspopup="listbox"
         ref={inputRef}
         label={label}
@@ -129,39 +160,10 @@ export function Combobox<T extends object>({
         borderBottomRightRadius={
           state.isOpen && !isLoading ? 0 : borderBottomRightRadius
         }
-        borderTopLeftRadius={borderTopLeftRadius}
-        borderTopRightRadius={borderTopRightRadius}
-        marginBottom={marginBottom}
-        marginTop={marginTop}
-        marginRight={marginRight}
-        marginLeft={marginLeft}
-        marginX={marginX}
-        marginY={marginY}
-        paddingBottom={paddingBottom}
-        paddingRight={paddingRight}
-        paddingTop={paddingTop}
-        paddingLeft={paddingLeft}
-        paddingX={paddingX}
-        paddingY={paddingY}
-        leftIcon={leftIcon}
-        rightIcon={
-          isLoading ? (
-            <ColorSpinner
-              width="1.5rem"
-              alignSelf="center"
-              paddingRight={paddingRight}
-              css={{
-                div: {
-                  display: "flex",
-                  alignItems: "center",
-                },
-              }}
-            />
-          ) : (
-            rightIcon
-          )
-        }
+        {...inputProps}
+        
       />
+      
       {state.isOpen && !isLoading && (
         <Popover
           state={state}

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { AriaComboBoxProps, useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
-import { Input, InputProps, ListBox } from "..";
+import { ColorSpinner,Input, InputProps, ListBox } from "..";
 import { Popover } from "./Popover";
 
 type OverridableInputProps = Pick<
@@ -63,6 +63,8 @@ export type ComboboxProps<T> = AriaComboBoxProps<T> & {
  * ```
  */
 
+
+
 export function Combobox<T extends object>({
   label,
   isLoading,
@@ -106,7 +108,7 @@ export function Combobox<T extends object>({
     ...rest,
   });
 
-  const ComboBoxProps: OverridableInputProps = { 
+  const comboBoxProps: OverridableInputProps = { 
     borderTopLeftRadius,
     borderTopRightRadius,
     marginBottom,
@@ -138,18 +140,12 @@ export function Combobox<T extends object>({
     },
     state,
   );
- 
 
-  function styleProps(obj: Record<string, unknown>): Record<string, unknown> {
-    return Object.fromEntries(
-      Object.entries(obj).filter(([, value]) => value !== undefined)
-    );
-  }
 
   return (
     <>
       <Input
-        {...styleProps(ComboBoxProps)}
+        {...styleProps(comboBoxProps)}
         aria-haspopup="listbox"
         ref={inputRef}
         label={label}
@@ -160,7 +156,23 @@ export function Combobox<T extends object>({
           state.isOpen && !isLoading ? 0 : borderBottomRightRadius
         }
         {...inputProps}
-        
+        rightIcon={
+          isLoading ? (
+            <ColorSpinner
+              width="1.5rem"
+              alignSelf="center"
+              paddingRight={paddingRight}
+              css={{
+                div: {
+                  display: "flex",
+                  alignItems: "center",
+                },
+              }}
+            />
+          ) : (
+            rightIcon
+          )
+        }
       />
       
       {state.isOpen && !isLoading && (
@@ -204,6 +216,12 @@ const useInputWidth = (inputRef: React.RefObject<HTMLInputElement>) => {
   }, []);
   return inputWidth;
 };
+
+function styleProps(obj: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => value !== undefined)
+  );
+}
 
 const debounce = (fn: () => void, ms = 100) => {
   let timer: any;


### PR DESCRIPTION
## Background

Despite the Combo-box using the Input, a left icon wasn't supported.

## Solution

Removed undefined props so that the icon would set properly and the input styling for icons would kick in.
![Screenshot 2024-04-11 at 12 02 56](https://github.com/nsbno/spor/assets/31248055/5521e2b0-911b-4c4c-97ed-eb2ce16508a8)


