### PR TITLE
Change color tokens for orange

### DIFF
--- a/.changeset/afraid-avocados-clean.md
+++ b/.changeset/afraid-avocados-clean.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-design-tokens": patch
+---
+
+Change hex values of tokens to match designsystem in Figma

--- a/packages/spor-design-tokens/tokens/color/palette.json
+++ b/packages/spor-design-tokens/tokens/color/palette.json
@@ -130,13 +130,13 @@
           "value": "#FF9B33"
         },
         "400": {
-          "value": "#FF8200"
+          "value": "#DF8200"
         },
         "500": {
-          "value": "#CF6C05"
+          "value": "#BB4D0F"
         },
         "600": {
-          "value": "#A75A0A"
+          "value": "#71310C"
         }
       },
       "red": {


### PR DESCRIPTION
## Summary

Changed 3 hex values for design tokens did not match the designsystem in Figma (values 400, 500, 600).
