### PR TITLE
Change render sizes in frontend to rem

### DIFF
--- a/packages/spor-design-tokens/config.ts
+++ b/packages/spor-design-tokens/config.ts
@@ -26,7 +26,12 @@ export default {
       ],
     },
     javascript: {
-      transforms: ["attribute/cti", "name/cti/pascal", "size/px", "color/css"],
+      transforms: [
+        "attribute/cti",
+        "name/cti/pascal",
+        "size/pxToRem",
+        "color/css",
+      ],
       files: [
         {
           format: "typescript/cjs-module",


### PR DESCRIPTION
## Background

The size of elements was rendered in px and this was preventing to apply effect of using zoom settings in browser.

## Solution

By changing the rendering size unit of elements from px to rem, all sizes are connected to the settings of the browser and adapt to user choice 
