### PR TITLE
Add pressable card to Spor

### DIFF
--- a/.changeset/calm-wolves-invite.md
+++ b/.changeset/calm-wolves-invite.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Added pressable card

--- a/.changeset/calm-wolves-invite.md
+++ b/.changeset/calm-wolves-invite.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-react": minor
 ---
 
-Added pressable card
+Added pressable card, and small changes to default color in static card

--- a/.changeset/calm-wolves-invite.md
+++ b/.changeset/calm-wolves-invite.md
@@ -1,5 +1,5 @@
 ---
-"@vygruppen/spor-react": patch
+"@vygruppen/spor-react": minor
 ---
 
 Added pressable card

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/packages/spor-react/src/card/PressableCard.tsx
+++ b/packages/spor-react/src/card/PressableCard.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { BoxProps, Card, useStyleConfig } from "@chakra-ui/react";
+import { Box, BoxProps, Card, useStyleConfig } from "@chakra-ui/react";
 
 type PressableCardProps = Omit<BoxProps, "as"> & {
+  variant: "floating" | "accent" | "base";
   size?: "sm" | "lg";
   as: "button" | "a" | "label" | React.ComponentType;
 };
@@ -36,9 +37,16 @@ type PressableCardProps = Omit<BoxProps, "as"> & {
  * ```
  */
 export const PressableCard = ({
+  children,
   as = "button",
+  size = "sm",
+  variant = "base",
   ...props
 }: PressableCardProps) => {
-  const styles = useStyleConfig("PressableCard");
-  return <Card __css={styles} {...props} />;
+  const styles = useStyleConfig("PressableCard", { variant, size });
+  return (
+    <Box as={as} __css={styles} {...props}>
+      {children}
+    </Box>
+  );
 };

--- a/packages/spor-react/src/card/PressableCard.tsx
+++ b/packages/spor-react/src/card/PressableCard.tsx
@@ -11,12 +11,20 @@ type PressableCardProps = Omit<BoxProps, "as"> & {
  * The most basic version looks like this:
  *
  * ```tsx
- * <PressableCard colorScheme="white">
+ * <PressableCard>
  *   Content
  * </PressableCard>
  * ```
  *
- *Pressable cards can also be rendered as whatever DOM element you want – like a li (list item) or an article. You do this by specifying the `as` prop:
+ * There are lots of color schemes available. You can also set the size as either `sm` or `lg`. The default is `sm`.
+ *
+ * ```tsx
+ * <PressableCard colorScheme="orange" size="lg">
+ *   A smaller card
+ * </PressableCard>
+ * ```
+ *
+ * Pressable cards can also be rendered as button, link or label – like a li (list item) or an article. You do this by specifying the `as` prop:
  *
  * ```tsx
  * <PressableCard colorScheme="green" as="section">

--- a/packages/spor-react/src/card/PressableCard.tsx
+++ b/packages/spor-react/src/card/PressableCard.tsx
@@ -25,7 +25,9 @@ type PressableCardProps = Omit<BoxProps, "as"> & {
  * </PressableCard>
  * ```
  *
- * Pressable cards can also be rendered as button, link or label – like a li (list item) or an article. You do this by specifying the `as` prop:
+ * Pressable cards can also be rendered as button, link or label – like a li (list item) or an article.
+ * You do this by specifying the `as` prop. If no `as` is specified, button is chosen as default:
+ *
  *
  * ```tsx
  * <PressableCard colorScheme="green" as="section">

--- a/packages/spor-react/src/card/PressableCard.tsx
+++ b/packages/spor-react/src/card/PressableCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, BoxProps, useStyleConfig } from "@chakra-ui/react";
+import { BoxProps, Card, useStyleConfig } from "@chakra-ui/react";
 
 type PressableCardProps = Omit<BoxProps, "as"> & {
   size?: "sm" | "lg";
@@ -33,7 +33,10 @@ type PressableCardProps = Omit<BoxProps, "as"> & {
  * </PressableCard>
  * ```
  */
-export const PressableCard = ({ ...props }: PressableCardProps) => {
+export const PressableCard = ({
+  as = "button",
+  ...props
+}: PressableCardProps) => {
   const styles = useStyleConfig("PressableCard");
-  return <Box __css={styles} {...props} />;
+  return <Card __css={styles} {...props} />;
 };

--- a/packages/spor-react/src/card/PressableCard.tsx
+++ b/packages/spor-react/src/card/PressableCard.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Box, useStyleConfig } from "@chakra-ui/react";
+/**
+ * Renders a Pressable card.
+ *
+ * The most basic version looks like this:
+ *
+ * ```tsx
+ * <PressableCard colorScheme="white">
+ *   Content
+ * </PressableCard>
+ * ```
+ *
+ *Pressable cards can also be rendered as whatever DOM element you want – like a li (list item) or an article. You do this by specifying the `as` prop:
+ *
+ * ```tsx
+ * <PressableCard colorScheme="green" as="section">
+ *   This is now a <section /> element
+ * </PressableCard>
+ * ```
+ */
+export const PressableCard = ({ colorScheme, ...props }: any) => {
+  const styles = useStyleConfig("PressableCard", { colorScheme });
+  return <Box __css={styles} {...props} />;
+};

--- a/packages/spor-react/src/card/PressableCard.tsx
+++ b/packages/spor-react/src/card/PressableCard.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { Box, useStyleConfig } from "@chakra-ui/react";
+import { Box, BoxProps, useStyleConfig } from "@chakra-ui/react";
+
+type PressableCardProps = Omit<BoxProps, "as"> & {
+  as: "button" | "a" | "label" | React.ComponentType;
+};
+
 /**
  * Renders a Pressable card.
  *
@@ -19,7 +24,7 @@ import { Box, useStyleConfig } from "@chakra-ui/react";
  * </PressableCard>
  * ```
  */
-export const PressableCard = ({ colorScheme, ...props }: any) => {
-  const styles = useStyleConfig("PressableCard", { colorScheme });
+export const PressableCard = ({ ...props }: PressableCardProps) => {
+  const styles = useStyleConfig("PressableCard");
   return <Box __css={styles} {...props} />;
 };

--- a/packages/spor-react/src/card/PressableCard.tsx
+++ b/packages/spor-react/src/card/PressableCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Box, BoxProps, useStyleConfig } from "@chakra-ui/react";
 
 type PressableCardProps = Omit<BoxProps, "as"> & {
+  size?: "sm" | "lg";
   as: "button" | "a" | "label" | React.ComponentType;
 };
 

--- a/packages/spor-react/src/card/index.tsx
+++ b/packages/spor-react/src/card/index.tsx
@@ -1,2 +1,3 @@
 export * from "./Card";
 export * from "./StaticCard";
+export * from "./PressableCard";

--- a/packages/spor-react/src/theme/components/index.ts
+++ b/packages/spor-react/src/theme/components/index.ts
@@ -39,4 +39,5 @@ export { default as Tabs } from "./tabs";
 export { default as Textarea } from "./textarea";
 export { default as Toast } from "./toast";
 export { default as StaticCard } from "./static-card";
+export { default as PressableCard } from "./pressable-card";
 export { default as TravelTag } from "./travel-tag";

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -1,0 +1,66 @@
+import { defineStyleConfig } from "@chakra-ui/react";
+import { mode } from "@chakra-ui/theme-tools";
+import { colors } from "../foundations";
+import { baseBorder } from "../utils/base-utils";
+
+const config = defineStyleConfig({
+  baseStyle: (props: any) => ({
+    appearance: "none",
+    border: "none",
+    overflow: "hidden",
+    fontSize: "inherit",
+    display: "block",
+    borderRadius: "md",
+    // Except for white cards, all cards are light mode always
+    color: "text.default.light",
+    ...getColorSchemeBaseProps(props),
+  }),
+});
+
+export default config;
+
+type CardThemeProps = {
+  colorScheme:
+    | "white"
+    | "grey"
+    | "blue"
+    | "green"
+    | "teal"
+    | "yellow"
+    | "orange"
+    | "red";
+  theme: any;
+  colorMode: "light" | "dark";
+};
+
+const getColorSchemeBaseProps = (props: CardThemeProps) => {
+  switch (props.colorScheme) {
+    case "white":
+      return {
+        ...baseBorder("default", props),
+        backgroundColor: mode(
+          "white",
+          `color-mix(in srgb, white 10%, var(--spor-colors-bg-default-dark))`,
+        )(props),
+        color: "inherit",
+      };
+    case "grey":
+      return {
+        backgroundColor: "lightGrey",
+      };
+    case "green": {
+      return {
+        backgroundColor: "seaMist",
+      };
+    }
+    case "red": {
+      return {
+        backgroundColor: "pink",
+      };
+    }
+    default:
+      return {
+        backgroundColor: colors[props.colorScheme]?.[100] ?? "platinum",
+      };
+  }
+};

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -1,7 +1,7 @@
 import { defineStyleConfig } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
 import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
-import { floatingBorder } from "../utils/floating-utils";
+import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { accentBackground, accentText } from "../utils/accent-utils";
 
@@ -27,12 +27,12 @@ const config = defineStyleConfig({
   }),
   variants: {
     base: (props) => ({
-      ...accentBackground("default", props),
+      ...baseBackground("default", props),
       _hover: {
-        ...accentBackground("hover", props),
+        ...baseBackground("hover", props),
       },
       _active: {
-        ...accentBackground("active", props),
+        ...baseBackground("active", props),
       },
     }),
     accent: (props) => ({
@@ -45,12 +45,12 @@ const config = defineStyleConfig({
       },
     }),
     floating: (props) => ({
-      ...accentBackground("default", props),
+      ...floatingBackground("default", props),
       _hover: {
-        ...accentBackground("hover", props),
+        ...floatingBackground("hover", props),
       },
       _active: {
-        ...accentBackground("active", props),
+        ...floatingBackground("active", props),
       },
     }),
   },

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -1,10 +1,9 @@
 import { defineStyleConfig } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
-import { colors } from "../foundations";
 import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
 import { floatingBorder } from "../utils/floating-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
-import { accentBackground } from "../utils/accent-utils";
+import { accentBackground, accentText } from "../utils/accent-utils";
 
 const config = defineStyleConfig({
   baseStyle: (props: any) => ({
@@ -14,8 +13,6 @@ const config = defineStyleConfig({
     fontSize: "inherit",
     display: "block",
     borderRadius: "md",
-    // Except for white cards, all cards are light mode always
-    color: "text.default.light",
     ...getColorSchemeBaseProps(props),
     ...getColorSchemeClickableProps(props),
     ...focusVisibleStyles(props),
@@ -86,22 +83,14 @@ const config = defineStyleConfig({
 export default config;
 
 type CardThemeProps = {
-  colorScheme:
-    | "white"
-    | "grey"
-    | "blue"
-    | "green"
-    | "teal"
-    | "yellow"
-    | "orange"
-    | "red";
+  colorScheme: "accent" | "default";
   theme: any;
   colorMode: "light" | "dark";
 };
 
 const getColorSchemeBaseProps = (props: CardThemeProps) => {
   switch (props.colorScheme) {
-    case "white":
+    case "default":
       return {
         ...baseBorder("default", props),
         backgroundColor: mode(
@@ -110,48 +99,43 @@ const getColorSchemeBaseProps = (props: CardThemeProps) => {
         )(props),
         color: "inherit",
       };
-    case "grey":
+    case "accent":
       return {
-        backgroundColor: "lightGrey",
-      };
-    case "green": {
-      return {
-        backgroundColor: "seaMist",
-      };
-    }
-    case "red": {
-      return {
-        backgroundColor: "pink",
-      };
-    }
-    default:
-      return {
-        backgroundColor: colors[props.colorScheme]?.[100] ?? "platinum",
+        ...accentBackground("default", props),
+        ...accentText("default", props),
+        _hover: {
+          ...accentBackground("hover", props),
+        },
+        _active: {
+          ...accentBackground("active", props),
+        },
       };
   }
 };
 
 function getColorSchemeClickableProps(props: CardThemeProps) {
   switch (props.colorScheme) {
-    case "white":
+    case "default":
       return {
         ...floatingBorder("default", props),
       };
-    case "grey":
+    case "accent":
       return {
-        outlineColor: "steel",
-      };
-    default:
-      return {
-        backgroundColor: colors[props.colorScheme]?.[100] ?? "platinum",
-        outlineColor: colors[props.colorScheme]?.[200] ?? "silver",
+        ...accentBackground("default", props),
+        ...accentText("default", props),
+        _hover: {
+          ...accentBackground("hover", props),
+        },
+        _active: {
+          ...accentBackground("active", props),
+        },
       };
   }
 }
 
 const getColorSchemeHoverProps = (props: CardThemeProps) => {
   switch (props.colorScheme) {
-    case "white":
+    case "default":
       return {
         backgroundColor: mode(
           "white",
@@ -159,34 +143,37 @@ const getColorSchemeHoverProps = (props: CardThemeProps) => {
         )(props),
         ...floatingBorder("hover", props),
       };
-    case "grey":
+    case "accent":
       return {
-        outlineColor: "osloGrey",
-      };
-    default:
-      return {
-        backgroundColor: colors[props.colorScheme]?.[200] ?? "silver",
-        outlineColor: colors[props.colorScheme]?.[400] ?? "silver",
+        ...accentBackground("default", props),
+        ...accentText("default", props),
+        _hover: {
+          ...accentBackground("hover", props),
+        },
+        _active: {
+          ...accentBackground("active", props),
+        },
       };
   }
 };
 const getColorSchemeActiveProps = (props: CardThemeProps) => {
   const { colorScheme } = props;
   switch (colorScheme) {
-    case "white":
+    case "default":
       return {
         backgroundColor: mode("bg.tertiary.light", `bg.default.dark`)(props),
         ...floatingBorder("active", props),
       };
-    case "grey":
+    case "accent":
       return {
-        backgroundColor: "white",
-        outlineColor: "steel",
-      };
-    default:
-      return {
-        backgroundColor: colors[colorScheme]?.[50] ?? "lightGrey",
-        outlineColor: colors[colorScheme]?.[100] ?? "silver",
+        ...accentBackground("default", props),
+        ...accentText("default", props),
+        _hover: {
+          ...accentBackground("hover", props),
+        },
+        _active: {
+          ...accentBackground("active", props),
+        },
       };
   }
 };

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -1,7 +1,8 @@
 import { defineStyleConfig } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
 import { colors } from "../foundations";
-import { baseBorder } from "../utils/base-utils";
+import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { floatingBorder } from "../utils/floating-utils";
 
 const config = defineStyleConfig({
   baseStyle: (props: any) => ({
@@ -14,6 +15,15 @@ const config = defineStyleConfig({
     // Except for white cards, all cards are light mode always
     color: "text.default.light",
     ...getColorSchemeBaseProps(props),
+    ...getColorSchemeClickableProps(props),
+    ...getColorSchemeActiveProps(props),
+    _hover: getColorSchemeHoverProps(props),
+    _disabled: {
+      ...baseBackground("disabled", props),
+      ...baseBorder("disabled", props),
+      ...baseText("disabled", props),
+      pointerEvents: "none",
+    },
   }),
 });
 
@@ -61,6 +71,66 @@ const getColorSchemeBaseProps = (props: CardThemeProps) => {
     default:
       return {
         backgroundColor: colors[props.colorScheme]?.[100] ?? "platinum",
+      };
+  }
+};
+
+function getColorSchemeClickableProps(props: CardThemeProps) {
+  switch (props.colorScheme) {
+    case "white":
+      return {
+        ...floatingBorder("default", props),
+      };
+    case "grey":
+      return {
+        outlineColor: "steel",
+      };
+    default:
+      return {
+        backgroundColor: colors[props.colorScheme]?.[100] ?? "platinum",
+        outlineColor: colors[props.colorScheme]?.[200] ?? "silver",
+      };
+  }
+}
+
+const getColorSchemeHoverProps = (props: CardThemeProps) => {
+  switch (props.colorScheme) {
+    case "white":
+      return {
+        backgroundColor: mode(
+          "white",
+          `color-mix(in srgb, white 20%, var(--spor-colors-bg-default-dark))`,
+        )(props),
+        ...floatingBorder("hover", props),
+      };
+    case "grey":
+      return {
+        outlineColor: "osloGrey",
+      };
+    default:
+      return {
+        backgroundColor: colors[props.colorScheme]?.[200] ?? "silver",
+        outlineColor: colors[props.colorScheme]?.[400] ?? "silver",
+      };
+  }
+};
+const getColorSchemeActiveProps = (props: CardThemeProps) => {
+  const { colorScheme } = props;
+  switch (colorScheme) {
+    case "white":
+      return {
+        backgroundColor: mode("bg.tertiary.light", `bg.default.dark`)(props),
+        ...floatingBorder("active", props),
+      };
+    case "grey":
+      return {
+        backgroundColor: "white",
+        outlineColor: "steel",
+      };
+    default:
+      return {
+        backgroundColor: colors[colorScheme]?.[50] ?? "lightGrey",
+        outlineColor: colors[colorScheme]?.[100] ?? "silver",
       };
   }
 };

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -85,7 +85,6 @@ const config = defineStyleConfig({
 
 export default config;
 
-//Droppe denne evt etter å ha hørt med PØ
 type CardThemeProps = {
   colorScheme:
     | "white"

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -3,6 +3,8 @@ import { mode } from "@chakra-ui/theme-tools";
 import { colors } from "../foundations";
 import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
 import { floatingBorder } from "../utils/floating-utils";
+import { focusVisibleStyles } from "../utils/focus-utils";
+import { accentBackground } from "../utils/accent-utils";
 
 const config = defineStyleConfig({
   baseStyle: (props: any) => ({
@@ -16,6 +18,7 @@ const config = defineStyleConfig({
     color: "text.default.light",
     ...getColorSchemeBaseProps(props),
     ...getColorSchemeClickableProps(props),
+    ...focusVisibleStyles(props),
     ...getColorSchemeActiveProps(props),
     _hover: getColorSchemeHoverProps(props),
     _disabled: {
@@ -25,10 +28,64 @@ const config = defineStyleConfig({
       pointerEvents: "none",
     },
   }),
+  variants: {
+    base: (props) => ({
+      ...accentBackground("default", props),
+      _hover: {
+        ...accentBackground("hover", props),
+      },
+      _active: {
+        ...accentBackground("active", props),
+      },
+    }),
+    accent: (props) => ({
+      ...accentBackground("default", props),
+      _hover: {
+        ...accentBackground("hover", props),
+      },
+      _active: {
+        ...accentBackground("active", props),
+      },
+    }),
+    floating: (props) => ({
+      ...accentBackground("default", props),
+      _hover: {
+        ...accentBackground("hover", props),
+      },
+      _active: {
+        ...accentBackground("active", props),
+      },
+    }),
+  },
+  sizes: {
+    sm: {
+      boxShadow: "sm",
+
+      _hover: {
+        boxShadow: "md",
+      },
+
+      _active: {
+        boxShadow: "none",
+      },
+    },
+    lg: {
+      boxShadow: "md",
+
+      _hover: {
+        boxShadow: "lg",
+      },
+
+      _active: {
+        boxShadow: "sm",
+      },
+    },
+  },
 });
 
 export default config;
 
+//Droppe denne evt etter å ha hørt med PØ
 type CardThemeProps = {
   colorScheme:
     | "white"

--- a/packages/spor-react/src/theme/components/static-card.ts
+++ b/packages/spor-react/src/theme/components/static-card.ts
@@ -1,7 +1,7 @@
 import { defineStyleConfig } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
 import { colors } from "../foundations";
-import { baseBorder } from "../utils/base-utils";
+import { baseBorder, baseText } from "../utils/base-utils";
 
 const config = defineStyleConfig({
   baseStyle: (props: any) => ({
@@ -60,7 +60,8 @@ const getColorSchemeBaseProps = (props: CardThemeProps) => {
     }
     default:
       return {
-        backgroundColor: colors[props.colorScheme]?.[100] ?? "platinum",
+        backgroundColor: colors[props.colorScheme]?.[100] ?? "default",
+        ...baseText("default", props),
       };
   }
 };


### PR DESCRIPTION
## Background

<!-- Why is this pull request necessary? -->
I Figma finnes en variant av card som er pressable. Denne finnes ikke i Spor p.t.

## Solution

La til pressable card i spor

<!-- Summarize what has been done to solve the challenge. -->
