### PR TITLE
Fix for HMR crashing issue by disabling CachedChecks.

### DIFF
--- a/apps/docs/vite.config.mts
+++ b/apps/docs/vite.config.mts
@@ -8,6 +8,7 @@ installGlobals();
 export default defineConfig({
   server: {
     port: 3000,
+    fs: {cachedChecks: false}
   },
   plugins: [
     remix({


### PR DESCRIPTION
## Background

Currently with Vite and Remix there was a bug that happened, which caused the HMR to crash whenever you did any changes to the components - which ended up in you having to restart the server. Every. Single. Time.

It tried to access chunks in the spor-react/dist and had no luck in finding these, which made the HMR crash.

## Solution

What I did was setting CachedChecks to false.

<!-- Summarize what has been done to solve the challenge. -->

When the CachedChecks is set to true (which also is the default behaviour) Vite caches the result of file system checks. This means that Vite will remember whether files have changed since the last check, improving the performance by avoiding file system operations. But it's less accurate and might miss or not locate files that already exists.

When its set to False: Vite will not cache the file system checks. This means Vite will perform fresh checks on files each time it needs to determine if anything has changed. This can potentially result in more accurate detections, but it might also lead to slower performances with a large number of files.

However, after some testing and asking others to also test the performance didn't seem to be affected that much. And one could argue that a better developer experience and avoiding having to restart the server all the time offsets the potential performance impact.
