### PR TITLE
Added floating to bg and border

### DIFF
--- a/.changeset/fluffy-carpets-thank.md
+++ b/.changeset/fluffy-carpets-thank.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Added missing floating background color and floating border to datepicker.

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -87,9 +87,9 @@ const config = helpers.defineMultiStyleConfig({
       [$arrowBackground.variable]: surface("default", props).backgroundColor,
     },
     calendarPopover: {
-      ...baseBackground("default", props),
+      ...floatingBackground("default", props),
       ...baseText("default", props),
-      ...baseBorder("default", props),
+      ...floatingBorder("default", props),
       boxShadow: "md",
     },
     weekdays: {


### PR DESCRIPTION
## Background

There was no background on the datepicker, which made it impossible to see.

## Solution

Added floating BG to border and background on the popover of the datepicker.

Before: 
<img width="1396" alt="Screenshot 2024-04-18 at 11 20 22" src="https://github.com/nsbno/spor/assets/31248055/3cdb8585-6596-4683-b23b-dc243f982b2b">

After:
<img width="1461" alt="Screenshot 2024-04-18 at 11 19 41" src="https://github.com/nsbno/spor/assets/31248055/ffe0e36b-186b-4823-b31f-b8e1a2699944">
