### PR TITLE
Pagination component

### DIFF
--- a/.changeset/cuddly-peaches-arrive.md
+++ b/.changeset/cuddly-peaches-arrive.md
@@ -1,0 +1,7 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+## New component update
+
+New component for Pagination has been added.

--- a/apps/docs/app/routes/playground/route.tsx
+++ b/apps/docs/app/routes/playground/route.tsx
@@ -1,4 +1,4 @@
-import { Stack } from "@vygruppen/spor-react";
+import { Center, Pagination, Stack } from "@vygruppen/spor-react";
 import { useEffect, useState } from "react";
 import { LivePreview } from "react-live";
 import { LiveEditor } from "~/features/portable-text/interactive-code/LiveEditor";
@@ -25,6 +25,7 @@ export default function PlaygroundPage() {
     setPlaygroundData(newCode);
     localStorage.setItem("playgroundData", newCode);
   };
+  const [pageNumber, setPageNumber] = useState(1);
   return (
     <LiveProvider code={playgroundData}>
       <Stack spacing={2} id="content">
@@ -36,6 +37,13 @@ export default function PlaygroundPage() {
         <LiveError />
         <LivePreview />
       </Stack>
+      <Center>
+        <Pagination
+          totalPages={100}
+          selectedPage={pageNumber}
+          onPageChange={(page) => setPageNumber(page)}
+        />
+      </Center>
     </LiveProvider>
   );
 }

--- a/apps/docs/app/routes/playground/route.tsx
+++ b/apps/docs/app/routes/playground/route.tsx
@@ -1,4 +1,4 @@
-import { Center, Pagination, Stack } from "@vygruppen/spor-react";
+import { Stack } from "@vygruppen/spor-react";
 import { useEffect, useState } from "react";
 import { LivePreview } from "react-live";
 import { LiveEditor } from "~/features/portable-text/interactive-code/LiveEditor";
@@ -25,7 +25,6 @@ export default function PlaygroundPage() {
     setPlaygroundData(newCode);
     localStorage.setItem("playgroundData", newCode);
   };
-  const [pageNumber, setPageNumber] = useState(1);
   return (
     <LiveProvider code={playgroundData}>
       <Stack spacing={2} id="content">
@@ -37,13 +36,6 @@ export default function PlaygroundPage() {
         <LiveError />
         <LivePreview />
       </Stack>
-      <Center>
-        <Pagination
-          totalPages={100}
-          selectedPage={pageNumber}
-          onPageChange={(page) => setPageNumber(page)}
-        />
-      </Center>
     </LiveProvider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38050,7 +38050,7 @@
     },
     "packages/spor-design-tokens": {
       "name": "@vygruppen/spor-design-tokens",
-      "version": "3.5.2",
+      "version": "3.5.3",
       "license": "MIT",
       "devDependencies": {
         "json-to-ts": "^1.7.0",
@@ -38990,7 +38990,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "9.2.1",
+      "version": "9.4.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38050,7 +38050,7 @@
     },
     "packages/spor-design-tokens": {
       "name": "@vygruppen/spor-design-tokens",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "MIT",
       "devDependencies": {
         "json-to-ts": "^1.7.0",
@@ -38990,7 +38990,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "9.4.0",
+      "version": "9.4.1",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.6.1",

--- a/packages/spor-react/src/index.tsx
+++ b/packages/spor-react/src/index.tsx
@@ -17,6 +17,7 @@ export * from "./logo";
 export * from "./media-controller";
 export * from "./modal";
 export * from "./nudge";
+export * from "./pagination";
 export * from "./progress-indicator";
 export * from "./provider";
 export * from "./stepper";

--- a/packages/spor-react/src/pagination/Pagination.tsx
+++ b/packages/spor-react/src/pagination/Pagination.tsx
@@ -1,6 +1,16 @@
 import React from "react";
-import { Button, ButtonGroup, Center, IconButton, createTexts, useTranslation } from "..";
-import { DropdownLeftFill18Icon, DropdownRightFill18Icon } from "@vygruppen/spor-icon-react";
+import {
+  Button,
+  ButtonGroup,
+  Center,
+  IconButton,
+  createTexts,
+  useTranslation,
+} from "..";
+import {
+  DropdownLeftFill18Icon,
+  DropdownRightFill18Icon,
+} from "@vygruppen/spor-icon-react";
 
 type PaginationProps = {
   /** Specify the total amount of pages */
@@ -103,6 +113,8 @@ export const Pagination = ({
                 onPageChange(+pageNumber);
               }
             }}
+            backgroundColor={selectedPage === pageNumber ? "black" : "white"}
+            fontWeight={selectedPage === pageNumber ? "bold" : "normal"}
           >
             {pageNumber}
           </Button>

--- a/packages/spor-react/src/pagination/Pagination.tsx
+++ b/packages/spor-react/src/pagination/Pagination.tsx
@@ -1,14 +1,5 @@
-import React, { forwardRef } from "react";
-import {
-  Button,
-  ButtonGroup,
-  Center,
-  IconButton,
-  createTexts,
-  useTranslation,
-  Flex,
-  TextLink,
-} from "..";
+import React from "react";
+import { Center, createTexts, useTranslation, Flex, TextLink } from "..";
 import {
   ListItem,
   UnorderedList,
@@ -57,7 +48,7 @@ export const Pagination = ({
 
   const renderPaginationButtons = () => {
     const displayPageNumbers = [];
-    const maxVisiblePages = 6;
+    const maxVisiblePages = 8;
     if (totalPages <= maxVisiblePages) {
       displayPageNumbers.push(
         ...Array.from({ length: totalPages }, (_, i) => i + 1),
@@ -97,7 +88,7 @@ export const Pagination = ({
     }
     return displayPageNumbers.map((pageNumber, index) =>
       pageNumber === "..." ? (
-        <ListItem key={index}>
+        <ListItem key={index} sx={style.listItem}>
           <Center>...</Center>
         </ListItem>
       ) : (
@@ -109,6 +100,7 @@ export const Pagination = ({
               onPageChange(+pageNumber);
             }
           }}
+          padding={pageNumber === "..." ? 0 : undefined}
           sx={pageNumber === selectedPage ? style.activeButton : style.link}
         >
           {pageNumber}
@@ -126,21 +118,21 @@ export const Pagination = ({
         padding={0}
         margin={0}
       >
-        <ListItem aria-label={t(texts.previousPage)} sx={style.listItem}>
+        <ListItem aria-label={t(texts.previousPage)}>
           <TextLink
             onClick={() => onPageChange(selectedPage - 1)}
             sx={hasPreviousPage ? style.link : style.disabled}
           >
-            <DropdownLeftFill18Icon />
+            <DropdownLeftFill18Icon sx={style.icon} />
           </TextLink>
         </ListItem>
         {renderPaginationButtons()}
-        <ListItem aria-label={t(texts.nextPage)} sx={style.listItem}>
+        <ListItem aria-label={t(texts.nextPage)}>
           <TextLink
             onClick={() => onPageChange(selectedPage + 1)}
             sx={hasNextPage ? style.link : style.disabled}
           >
-            <DropdownRightFill18Icon />
+            <DropdownRightFill18Icon sx={style.icon} />
           </TextLink>
         </ListItem>
       </UnorderedList>

--- a/packages/spor-react/src/pagination/Pagination.tsx
+++ b/packages/spor-react/src/pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import {
   Button,
   ButtonGroup,
@@ -6,7 +6,15 @@ import {
   IconButton,
   createTexts,
   useTranslation,
+  Flex,
+  TextLink,
 } from "..";
+import {
+  ListItem,
+  UnorderedList,
+  useMultiStyleConfig,
+  Link,
+} from "@chakra-ui/react";
 import {
   DropdownLeftFill18Icon,
   DropdownRightFill18Icon,
@@ -42,92 +50,101 @@ export const Pagination = ({
 }: PaginationProps) => {
   const { t } = useTranslation();
 
-  if (selectedPage === 0) {
-    selectedPage = 1;
-  }
+  const style = useMultiStyleConfig("Pagination", { selectedPage });
 
-  if (totalPages <= 1) {
-    return null;
-  }
+  const hasPreviousPage = selectedPage > 1;
+  const hasNextPage = selectedPage < totalPages;
 
-  const displayPageNumbers = [];
-  const maxVisiblePages = 6;
-
-  if (totalPages <= maxVisiblePages) {
-    displayPageNumbers.push(
-      ...Array.from({ length: totalPages }, (_, i) => i + 1),
-    );
-  } else {
-    if (selectedPage <= Math.floor(maxVisiblePages / 2) + 1) {
-      // If selectedPage is near the beginning, display the first pages.
+  const renderPaginationButtons = () => {
+    const displayPageNumbers = [];
+    const maxVisiblePages = 6;
+    if (totalPages <= maxVisiblePages) {
       displayPageNumbers.push(
-        ...Array.from({ length: maxVisiblePages - 1 }, (_, i) => i + 1),
-      );
-      displayPageNumbers.push("...");
-      displayPageNumbers.push(totalPages);
-    } else if (selectedPage >= totalPages - Math.floor(maxVisiblePages / 2)) {
-      // If selectedPage is near the end, display the last pages.
-      displayPageNumbers.push(1);
-      displayPageNumbers.push("...");
-      displayPageNumbers.push(
-        ...Array.from(
-          { length: maxVisiblePages - 1 },
-          (_, i) => totalPages - maxVisiblePages + 2 + i,
-        ),
+        ...Array.from({ length: totalPages }, (_, i) => i + 1),
       );
     } else {
-      // Display pages with "..." in the middle.
-      displayPageNumbers.push(1);
-      displayPageNumbers.push("...");
-      for (
-        let i = selectedPage - Math.floor((maxVisiblePages - 3) / 2);
-        i <= selectedPage + Math.floor((maxVisiblePages - 3) / 2);
-        i++
-      ) {
-        displayPageNumbers.push(i);
+      if (selectedPage <= Math.floor(maxVisiblePages / 2) + 1) {
+        // If selectedPage is near the beginning, display the first pages.
+        displayPageNumbers.push(
+          ...Array.from({ length: maxVisiblePages - 1 }, (_, i) => i + 1),
+        );
+        displayPageNumbers.push("...");
+        displayPageNumbers.push(totalPages);
+      } else if (selectedPage >= totalPages - Math.floor(maxVisiblePages / 2)) {
+        // If selectedPage is near the end, display the last pages.
+        displayPageNumbers.push(1);
+        displayPageNumbers.push("...");
+        displayPageNumbers.push(
+          ...Array.from(
+            { length: maxVisiblePages - 1 },
+            (_, i) => totalPages - maxVisiblePages + 2 + i,
+          ),
+        );
+      } else {
+        // Display pages with "..." in the middle.
+        displayPageNumbers.push(1);
+        displayPageNumbers.push("...");
+        for (
+          let i = selectedPage - Math.floor((maxVisiblePages - 3) / 2);
+          i <= selectedPage + Math.floor((maxVisiblePages - 3) / 2);
+          i++
+        ) {
+          displayPageNumbers.push(i);
+        }
+        displayPageNumbers.push("...");
+        displayPageNumbers.push(totalPages);
       }
-      displayPageNumbers.push("...");
-      displayPageNumbers.push(totalPages);
     }
-  }
+    return displayPageNumbers.map((pageNumber, index) =>
+      pageNumber === "..." ? (
+        <ListItem key={index}>
+          <Center>...</Center>
+        </ListItem>
+      ) : (
+        <Link
+          key={index}
+          as={ListItem}
+          onClick={() => {
+            if (pageNumber !== "...") {
+              onPageChange(+pageNumber);
+            }
+          }}
+          sx={pageNumber === selectedPage ? style.activeButton : style.link}
+        >
+          {pageNumber}
+        </Link>
+      ),
+    );
+  };
+
   return (
-    <ButtonGroup spacing={[0, 1]}>
-      <IconButton
-        aria-label={t(texts.previousPage)}
-        icon={<DropdownLeftFill18Icon />}
-        variant="ghost"
-        visibility={selectedPage === 1 ? "hidden" : "visible"}
-        onClick={() => onPageChange(selectedPage - 1)}
-      />
-      {displayPageNumbers.map((pageNumber, index) =>
-        pageNumber === "..." ? (
-          <Center key={index}>...</Center>
-        ) : (
-          <Button
-            key={index}
-            size="xs"
-            padding={pageNumber === "..." ? 0 : undefined}
-            variant={pageNumber === selectedPage ? "tertiary" : "ghost"}
-            onClick={() => {
-              if (pageNumber !== "...") {
-                onPageChange(+pageNumber);
-              }
-            }}
-            backgroundColor={selectedPage === pageNumber ? "black" : "white"}
-            fontWeight={selectedPage === pageNumber ? "bold" : "normal"}
+    <Flex as="nav" aria-label="pagination">
+      <UnorderedList
+        display="flex"
+        listStyleType="none"
+        gap={[0, 1]}
+        padding={0}
+        margin={0}
+      >
+        <ListItem aria-label={t(texts.previousPage)} sx={style.listItem}>
+          <TextLink
+            onClick={() => onPageChange(selectedPage - 1)}
+            sx={hasPreviousPage ? style.link : style.disabled}
           >
-            {pageNumber}
-          </Button>
-        ),
-      )}
-      <IconButton
-        aria-label={t(texts.nextPage)}
-        icon={<DropdownRightFill18Icon />}
-        variant="ghost"
-        visibility={selectedPage === totalPages ? "hidden" : "visible"}
-        onClick={() => onPageChange(selectedPage + 1)}
-      />
-    </ButtonGroup>
+            <DropdownLeftFill18Icon />
+          </TextLink>
+        </ListItem>
+        {renderPaginationButtons()}
+        <ListItem aria-label={t(texts.nextPage)} sx={style.listItem}>
+          <TextLink
+            onClick={() => onPageChange(selectedPage + 1)}
+            sx={hasNextPage ? style.link : style.disabled}
+          >
+            <DropdownRightFill18Icon />
+          </TextLink>
+        </ListItem>
+      </UnorderedList>
+    </Flex>
   );
 };
 

--- a/packages/spor-react/src/pagination/Pagination.tsx
+++ b/packages/spor-react/src/pagination/Pagination.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { Button, ButtonGroup, Center, IconButton, createTexts, useTranslation } from "..";
+import { DropdownLeftFill18Icon, DropdownRightFill18Icon } from "@vygruppen/spor-icon-react";
+
+type PaginationProps = {
+  /** Specify the total amount of pages */
+  totalPages: number;
+  /** Specify the currently selected page */
+  selectedPage: number;
+  /** Callback for when a page is clicked */
+  onPageChange: (selected: number) => void;
+};
+
+/**
+ * A pagination component is used to navigate between multiple pages.
+ *
+ * You specify the total amount of pages and the currently selected page.
+ *
+ * ```tsx
+ * <Pagination
+ *   totalPages={10}
+ *   selectedPage={3}
+ *   onPageChange={handlePageChange}
+ * />
+ * ```
+ **/
+
+export const Pagination = ({
+  totalPages,
+  selectedPage,
+  onPageChange,
+}: PaginationProps) => {
+  const { t } = useTranslation();
+
+  if (selectedPage === 0) {
+    selectedPage = 1;
+  }
+
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const displayPageNumbers = [];
+  const maxVisiblePages = 6;
+
+  if (totalPages <= maxVisiblePages) {
+    displayPageNumbers.push(
+      ...Array.from({ length: totalPages }, (_, i) => i + 1),
+    );
+  } else {
+    if (selectedPage <= Math.floor(maxVisiblePages / 2) + 1) {
+      // If selectedPage is near the beginning, display the first pages.
+      displayPageNumbers.push(
+        ...Array.from({ length: maxVisiblePages - 1 }, (_, i) => i + 1),
+      );
+      displayPageNumbers.push("...");
+      displayPageNumbers.push(totalPages);
+    } else if (selectedPage >= totalPages - Math.floor(maxVisiblePages / 2)) {
+      // If selectedPage is near the end, display the last pages.
+      displayPageNumbers.push(1);
+      displayPageNumbers.push("...");
+      displayPageNumbers.push(
+        ...Array.from(
+          { length: maxVisiblePages - 1 },
+          (_, i) => totalPages - maxVisiblePages + 2 + i,
+        ),
+      );
+    } else {
+      // Display pages with "..." in the middle.
+      displayPageNumbers.push(1);
+      displayPageNumbers.push("...");
+      for (
+        let i = selectedPage - Math.floor((maxVisiblePages - 3) / 2);
+        i <= selectedPage + Math.floor((maxVisiblePages - 3) / 2);
+        i++
+      ) {
+        displayPageNumbers.push(i);
+      }
+      displayPageNumbers.push("...");
+      displayPageNumbers.push(totalPages);
+    }
+  }
+  return (
+    <ButtonGroup spacing={[0, 1]}>
+      <IconButton
+        aria-label={t(texts.previousPage)}
+        icon={<DropdownLeftFill18Icon />}
+        variant="ghost"
+        visibility={selectedPage === 1 ? "hidden" : "visible"}
+        onClick={() => onPageChange(selectedPage - 1)}
+      />
+      {displayPageNumbers.map((pageNumber, index) =>
+        pageNumber === "..." ? (
+          <Center key={index}>...</Center>
+        ) : (
+          <Button
+            key={index}
+            size="xs"
+            padding={pageNumber === "..." ? 0 : undefined}
+            variant={pageNumber === selectedPage ? "tertiary" : "ghost"}
+            onClick={() => {
+              if (pageNumber !== "...") {
+                onPageChange(+pageNumber);
+              }
+            }}
+          >
+            {pageNumber}
+          </Button>
+        ),
+      )}
+      <IconButton
+        aria-label={t(texts.nextPage)}
+        icon={<DropdownRightFill18Icon />}
+        variant="ghost"
+        visibility={selectedPage === totalPages ? "hidden" : "visible"}
+        onClick={() => onPageChange(selectedPage + 1)}
+      />
+    </ButtonGroup>
+  );
+};
+
+const texts = createTexts({
+  previousPage: {
+    nb: "Forrige side",
+    nn: "Førre side",
+    en: "Previous page",
+    sv: "Föregående sida",
+  },
+  nextPage: {
+    nb: "Neste side",
+    nn: "Neste side",
+    en: "Next page",
+    sv: "Nästa sida",
+  },
+});

--- a/packages/spor-react/src/pagination/index.tsx
+++ b/packages/spor-react/src/pagination/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Pagination";

--- a/packages/spor-react/src/theme/components/index.ts
+++ b/packages/spor-react/src/theme/components/index.ts
@@ -26,6 +26,7 @@ export { default as ListBox } from "./listbox";
 export { default as MediaControllerButton } from "./media-controller-button";
 export { default as Modal } from "./modal";
 export { default as NumericStepper } from "./numeric-stepper";
+export { default as Pagination } from "./pagination";
 export { default as Popover } from "./popover";
 export { default as ProgressBar } from "./progress-bar";
 export { default as ProgressIndicator } from "./progress-indicator";

--- a/packages/spor-react/src/theme/components/pagination.ts
+++ b/packages/spor-react/src/theme/components/pagination.ts
@@ -1,0 +1,74 @@
+import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
+import { anatomy } from "@chakra-ui/theme-tools";
+import { ghostBackground } from "../utils/ghost-utils";
+import { surface } from "../utils/surface-utils";
+import { baseText } from "../utils/base-utils";
+
+const parts = anatomy("Pagination").parts(
+  "listItem",
+  "link",
+  "activeButton",
+  "disabled",
+);
+
+const helpers = createMultiStyleConfigHelpers(parts.keys);
+
+const config = helpers.defineMultiStyleConfig({
+  baseStyle: (props: any) => ({
+    activeButton: {
+      fontWeight: "bold",
+      ...commonStyles,
+      ...ghostBackground("active", props),
+      _hover: {
+        ...ghostBackground("hover", props),
+        borderRadius: 50,
+        _disabled: {
+          ...baseText("disabled", props),
+        },
+      },
+      _active: {
+        borderRadius: 50,
+        ...ghostBackground("active", props),
+      },
+    },
+    disabled: {
+      ...commonStyles,
+      cursor: "not-allowed",
+      pointerEvents: "none",
+      boxShadow: "none",
+      ...baseText("disabled", props),
+    },
+    listItem: {
+      display: "flex",
+    },
+    link: {
+      ...commonStyles,
+      ...ghostBackground("default", props),
+      ...baseText("default", props),
+      _hover: {
+        ...ghostBackground("hover", props),
+        borderRadius: 50,
+        _disabled: {
+          ...baseText("disabled", props),
+        },
+      },
+      _active: {
+        borderRadius: 50,
+        ...ghostBackground("active", props),
+      },
+    },
+  }),
+});
+
+const commonStyles = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 6,
+  height: 6,
+  backgroundImage: "none",
+  borderRadius: 50,
+  fontSize: "xs",
+};
+
+export default config;

--- a/packages/spor-react/src/theme/components/pagination.ts
+++ b/packages/spor-react/src/theme/components/pagination.ts
@@ -1,7 +1,6 @@
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
 import { anatomy } from "@chakra-ui/theme-tools";
 import { ghostBackground } from "../utils/ghost-utils";
-import { surface } from "../utils/surface-utils";
 import { baseText } from "../utils/base-utils";
 
 const parts = anatomy("Pagination").parts(
@@ -9,6 +8,7 @@ const parts = anatomy("Pagination").parts(
   "link",
   "activeButton",
   "disabled",
+  "icon",
 );
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
@@ -22,9 +22,6 @@ const config = helpers.defineMultiStyleConfig({
       _hover: {
         ...ghostBackground("hover", props),
         borderRadius: 50,
-        _disabled: {
-          ...baseText("disabled", props),
-        },
       },
       _active: {
         borderRadius: 50,
@@ -57,6 +54,9 @@ const config = helpers.defineMultiStyleConfig({
         ...ghostBackground("active", props),
       },
     },
+    icon: {
+      bottom: "-0.03em !important",
+    },
   }),
 });
 
@@ -64,8 +64,8 @@ const commonStyles = {
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-  width: 6,
-  height: 6,
+  width: 5,
+  height: 5,
   backgroundImage: "none",
   borderRadius: 50,
   fontSize: "xs",


### PR DESCRIPTION
## Background

There was a need for a reusable component for pagination for web.

## Solution

Created a new component, "Pagination". 
- Uses unordered list, as accessibility recommended to not use buttons
- Has basically styling for ghost

## How to test
Go to playground and paste the following code:

`<Pagination
      totalPages={10}
      selectedPage={1}
      onPageChange={() => {}}
 />`

Could be useful to open the playground route and add functionality to change pages. 

## Screenshots
![image](https://github.com/nsbno/spor/assets/42611957/15895e88-7f70-48c2-8f88-479e1b419f47)
![image](https://github.com/nsbno/spor/assets/42611957/b834f42e-775b-4d48-a9ab-fa0cbed1cbac)
