### PR TITLE
Enable docker build cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
             aws ecr get-login-password --region eu-west-1 \
               | docker login --username AWS --password-stdin "$ECR_ENDPOINT"
             SHORT_SHA1=`echo ${CIRCLE_SHA1}|cut -c1-7`
-            docker build --no-cache -t ${ECR_ENDPOINT}/<< parameters.ecr_repo_name >> -f Dockerfile .
+            docker build -t ${ECR_ENDPOINT}/<< parameters.ecr_repo_name >> -f Dockerfile .
             docker tag ${ECR_ENDPOINT}/<< parameters.ecr_repo_name >> "${ECR_ENDPOINT}/<< parameters.ecr_repo_name >>:commit-${SHORT_SHA1}"
             docker push "${ECR_ENDPOINT}/<< parameters.ecr_repo_name >>:commit-${SHORT_SHA1}"
             docker tag ${ECR_ENDPOINT}/<< parameters.ecr_repo_name >> "${ECR_ENDPOINT}/<< parameters.ecr_repo_name >>:latest"


### PR DESCRIPTION
## Background

In the previous PR we disabled the cache to be able to ensure we weren't reusing any layers from a broken build

## Solution

So here we enable caching again, for faster docker builds 🚀
