### PR TITLE
Improve layout of content for responsive when content overflow

### DIFF
--- a/.changeset/large-bobcats-kick.md
+++ b/.changeset/large-bobcats-kick.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Improve layout of tables when content overflow and in responsive views

--- a/packages/spor-react/src/table/Table.tsx
+++ b/packages/spor-react/src/table/Table.tsx
@@ -32,7 +32,7 @@ export const Table = forwardRef<TableProps, "table">((props, ref) => {
   const { variant, size, colorScheme, children, ...rest } = props;
   return (
     <Box {...rest} {...getStyleProps(props)}>
-      <Box overflowX="auto">
+      <Box overflowX="auto" role="region">
         <ChakraTable
           variant={variant}
           size={size}

--- a/packages/spor-react/src/theme/components/table.ts
+++ b/packages/spor-react/src/theme/components/table.ts
@@ -17,13 +17,17 @@ const config = helpers.defineMultiStyleConfig({
       borderCollapse: "collapse",
       ...baseText("default", props),
       width: "100%",
+      minWidth: "600px",
     },
     th: {
       fontWeight: "bold",
       textAlign: "start",
+      verticalAlign: "top",
+      minWidth: "68px",
     },
     td: {
       textAlign: "start",
+      verticalAlign: "top",
     },
     tfoot: {
       tr: {


### PR DESCRIPTION
## Background

We had issues with layout of tables with lot of columns and content, especially when mobile breakpoints matches. 

## Solution

By setting a minimum width to the table and a minimum width to table cells it is possible to control when the horizontal scroll display and a vertical align has been also added to cells to preserve readability of the table rows

## Screenshot
![image](https://github.com/nsbno/spor/assets/14735344/ff722399-915a-48f3-9158-47d75eb7f6f4)

