### PR TITLE
Stop Card from overriding style props

### DIFF
--- a/.changeset/plenty-gorillas-collect.md
+++ b/.changeset/plenty-gorillas-collect.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Stop Card from disregarding allowed styling related props

--- a/packages/spor-react/src/card/Card.tsx
+++ b/packages/spor-react/src/card/Card.tsx
@@ -1,6 +1,11 @@
-import { As, chakra, forwardRef, useStyleConfig } from "@chakra-ui/react";
+import {
+  As,
+  Box,
+  BoxProps,
+  forwardRef,
+  useStyleConfig,
+} from "@chakra-ui/react";
 import React from "react";
-import { BoxProps } from "../layout";
 
 export type CardProps = Exclude<BoxProps, "size"> & {
   size?: "sm" | "lg";
@@ -53,9 +58,9 @@ export const Card = forwardRef<CardProps, As>(
     });
 
     return (
-      <chakra.div sx={styles} {...props} ref={ref}>
+      <Box __css={styles} {...props} ref={ref}>
         {children}
-      </chakra.div>
+      </Box>
     );
   },
 );


### PR DESCRIPTION
## Background

A recent change (9.0.1) changed the Card component to use `sx`-prop to set the default styling, instead of `_css`.
Since `sx` has the highest precedence it will override any style props passed to the Card (Card accepts props that extends `HTMLChakraProps<"div">`)

example:
`<Card display="flex">` will not actually result in an element with `display: flex` as long as `Card` is implemented with `sx={styles}` and styles includes (among other default styling): `display: block`. 


## Solution

Revert the implementation of Card back to being styled with `__css` which as a lower precedence than style props
