### PR TITLE
Fix issue text-color with select>option in darkmode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/docs": {
       "name": "@vygruppen/docs",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.4.4",
@@ -38990,7 +38990,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "9.6.1",
+      "version": "9.6.4",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.6.1",

--- a/packages/spor-react/src/theme/foundations/styles.ts
+++ b/packages/spor-react/src/theme/foundations/styles.ts
@@ -5,6 +5,9 @@ export const styles = {
     "html, body": {
       color: mode("darkGrey", "lightGrey")(props),
     },
+    "select>option": {
+      color: "darkGrey",
+    },
     svg: {
       display: "initial",
     },


### PR DESCRIPTION

## Background
![image](https://github.com/nsbno/spor/assets/2778221/59fc3c2d-58ce-4eea-bb12-eed5173220cf)
When dark mode is toggled, the background of the select options remains white, causing the options to be unreadable.


## Solution
![image](https://github.com/nsbno/spor/assets/2778221/35903d42-97ad-4bce-a252-67a80ebbdceb)
I'm unsure if the intended fix is this or if the background should be changed (as it seemed while browsing through the various components). However, since the documentation states that it should retain its original design, I just updated the text color.

From docs:
"NativeSelect brukes der man har mange valg, og man vil beholde den originale select-utseende. Foretrekkes der man ikke trenger et avansert design. Et alternativ til InfoSelect." 