### PR TITLE
Add dark colors to static card

### DIFF
--- a/.changeset/three-cheetahs-provide.md
+++ b/.changeset/three-cheetahs-provide.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Added dark color variants to static card

--- a/packages/spor-react/src/theme/components/static-card.ts
+++ b/packages/spor-react/src/theme/components/static-card.ts
@@ -23,12 +23,14 @@ type CardThemeProps = {
   colorScheme:
     | "white"
     | "grey"
-    | "blue"
     | "green"
-    | "teal"
-    | "yellow"
     | "orange"
-    | "red";
+    | "red"
+    | "yellow"
+    | "blue"
+    | "darkBlue"
+    | "darkGreen"
+    | "darkYellow";
   theme: any;
   colorMode: "light" | "dark";
 };
@@ -56,6 +58,21 @@ const getColorSchemeBaseProps = (props: CardThemeProps) => {
     case "red": {
       return {
         backgroundColor: "pink",
+      };
+    }
+    case "darkBlue": {
+      return {
+        backgroundColor: "darkBlue",
+      };
+    }
+    case "darkGreen": {
+      return {
+        backgroundColor: "pine",
+      };
+    }
+    case "darkYellow": {
+      return {
+        backgroundColor: "banana",
       };
     }
     default:

--- a/packages/spor-react/src/theme/components/static-card.ts
+++ b/packages/spor-react/src/theme/components/static-card.ts
@@ -63,11 +63,13 @@ const getColorSchemeBaseProps = (props: CardThemeProps) => {
     case "darkBlue": {
       return {
         backgroundColor: "darkBlue",
+        color: "white",
       };
     }
     case "darkGreen": {
       return {
         backgroundColor: "pine",
+        color: "white",
       };
     }
     case "darkYellow": {


### PR DESCRIPTION
## Background
Added some missing dark colors to Static card as described in figma. 

## Solution

Added dark colors for blue, yellow and green. 

Figma: 
https://www.figma.com/file/Tmr2URVX2vNkyRLqKhNRQA/Vy_komponentbibliotek?type=design&node-id=22583-12506&mode=design&t=5FgQV05lY5rMX2nS-0
