### PR TITLE
🐛 Fix bug where metro cant find index-file.

### DIFF
--- a/.changeset/brave-poets-roll.md
+++ b/.changeset/brave-poets-roll.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react-native": minor
+---
+
+Fixing bug where Metro can't find the index.mjs-file.

--- a/packages/spor-icon-react-native/package.json
+++ b/packages/spor-icon-react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vygruppen/spor-icon-react-native",
   "version": "2.6.0",
-  "main": "./dist/index.js",
+  "main": "./dist/index.mjs",
   "types": "./dist/types.d.ts",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
## Background

The three newest React Native icon versions are currently broken because Metro cant find the index-file.

## Solution

Changing the path to a .mjs file ending similarly to the other packages, which is the file-ending that metro is looking for.
