### PR TITLE
Edit table UI

### DIFF
--- a/.changeset/spicy-students-explode.md
+++ b/.changeset/spicy-students-explode.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Remove vertical align from table. Can be added manually if other value is needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/docs": {
       "name": "@vygruppen/docs",
-      "version": "0.0.22",
+      "version": "0.0.24",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.4.4",
@@ -38418,7 +38418,7 @@
     },
     "packages/spor-icon-react-native": {
       "name": "@vygruppen/spor-icon-react-native",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "MIT",
       "devDependencies": {
         "@shopify/restyle": "^2.1.0",
@@ -38990,7 +38990,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "9.6.1",
+      "version": "9.6.5",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.6.1",

--- a/packages/spor-react/src/theme/components/table.ts
+++ b/packages/spor-react/src/theme/components/table.ts
@@ -22,12 +22,10 @@ const config = helpers.defineMultiStyleConfig({
     th: {
       fontWeight: "bold",
       textAlign: "start",
-      verticalAlign: "top",
       minWidth: "68px",
     },
     td: {
       textAlign: "start",
-      verticalAlign: "top",
     },
     tfoot: {
       tr: {


### PR DESCRIPTION
## Background

Tables outside Sanity is affected negatively by a static value from Tables.

## Solution

Removed static value "top" from vertical-align. It is possible to add this manually to any of the tags coming from Table.
