### PR TITLE
Improve PressableCard 

### DIFF
--- a/.changeset/lazy-bugs-shake.md
+++ b/.changeset/lazy-bugs-shake.md
@@ -1,6 +1,0 @@
----
-"@vygruppen/spor-react": patch
----
-
-- Make PressableCard more scalable (removed as)
-- Edit "white" colorScheme on StaticCard to support darkmode

--- a/.changeset/lovely-houses-check.md
+++ b/.changeset/lovely-houses-check.md
@@ -1,7 +1,0 @@
----
-"@vygruppen/spor-icon": minor
-"@vygruppen/spor-icon-react": minor
-"@vygruppen/spor-icon-react-native": minor
----
-
-Added new fancy outline icons for Dropdown

--- a/.changeset/witty-readers-mate.md
+++ b/.changeset/witty-readers-mate.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Improve PressableCard, make variant optional

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.26",
+  "version": "0.0.27",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/packages/spor-icon-react-native/CHANGELOG.md
+++ b/packages/spor-icon-react-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vygruppen/spor-icon-react-native
 
+## 2.8.0
+
+### Minor Changes
+
+- 5503c91: Added new fancy outline icons for Dropdown
+
 ## 2.7.0
 
 ### Minor Changes

--- a/packages/spor-icon-react-native/package.json
+++ b/packages/spor-icon-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vygruppen/spor-icon-react-native",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "main": "./dist/index.mjs",
   "types": "./dist/types.d.ts",
   "license": "MIT",

--- a/packages/spor-icon-react/CHANGELOG.md
+++ b/packages/spor-icon-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vygruppen/spor-icon-react
 
+## 3.7.0
+
+### Minor Changes
+
+- 5503c91: Added new fancy outline icons for Dropdown
+
 ## 3.6.0
 
 ### Minor Changes

--- a/packages/spor-icon-react/package.json
+++ b/packages/spor-icon-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vygruppen/spor-icon-react",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types.d.ts",

--- a/packages/spor-icon/CHANGELOG.md
+++ b/packages/spor-icon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vygruppen/spor-icon
 
+## 2.7.0
+
+### Minor Changes
+
+- 5503c91: Added new fancy outline icons for Dropdown
+
 ## 2.6.0
 
 ### Minor Changes

--- a/packages/spor-icon/package.json
+++ b/packages/spor-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vygruppen/spor-icon",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "main": "./dist/spor-icons.zip",
   "license": "MIT",
   "files": [

--- a/packages/spor-react/CHANGELOG.md
+++ b/packages/spor-react/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @vygruppen/spor-react
 
+## 9.8.3
+
+### Patch Changes
+
+- 50a42b2: Fix render of RadioCardGroup and RadioCard
+- 72afbd7: Removed static values Table styles
+
+## 9.8.2
+
+### Patch Changes
+
+- 5503c91: Fixes on new Cards
+  - Make PressableCard more scalable (removed as)
+  - Edit "white" colorScheme on StaticCard to support darkmode
+
 ## 9.8.1
 
 ### Patch Changes

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vygruppen/spor-react",
-  "version": "9.8.1",
+  "version": "9.8.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -23,7 +23,7 @@
     "@emotion/styled": "^11.10.4",
     "@internationalized/date": "^3.0.1",
     "@vygruppen/spor-design-tokens": ">3.4.0",
-    "@vygruppen/spor-icon-react": ">3.2.3",
+    "@vygruppen/spor-icon-react": ">3.6.0",
     "@vygruppen/spor-loader": ">0.3.1",
     "awesome-phonenumber": "^5.10.0",
     "deepmerge": "^4.3.1",

--- a/packages/spor-react/src/layout/PressableCard.tsx
+++ b/packages/spor-react/src/layout/PressableCard.tsx
@@ -9,7 +9,7 @@ import {
 
 type PressableCardProps = BoxProps & {
   /** Defaults to "base"  */
-  variant: "floating" | "accent" | "base";
+  variant?: "floating" | "accent" | "base";
 };
 
 /**

--- a/packages/spor-react/src/layout/PressableCard.tsx
+++ b/packages/spor-react/src/layout/PressableCard.tsx
@@ -43,7 +43,7 @@ type PressableCardProps = BoxProps & {
  */
 
 export const PressableCard = forwardRef<PressableCardProps, As>(
-  ({ children, variant = "base", ...props }, ref) => {
+  ({ children, variant = "floating", ...props }, ref) => {
     const styles = useStyleConfig("PressableCard", {
       variant,
     });

--- a/packages/spor-react/src/layout/RadioCard.tsx
+++ b/packages/spor-react/src/layout/RadioCard.tsx
@@ -9,7 +9,7 @@ import {
 import { dataAttr } from "@chakra-ui/utils";
 import React, { useId } from "react";
 
-type RadioCardProps = UseRadioProps &
+export type RadioCardProps = UseRadioProps &
   BoxProps & {
     children: React.ReactNode;
     /** Defaults to "base" */

--- a/packages/spor-react/src/layout/StaticCard.tsx
+++ b/packages/spor-react/src/layout/StaticCard.tsx
@@ -70,7 +70,6 @@ export const StaticCard = forwardRef<StaticCardProps, As>(
     return (
       <Box __css={styles} {...props} ref={ref}>
         {children}
-        <Card />
       </Box>
     );
   },

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -51,11 +51,11 @@ const config = defineStyleConfig({
     }),
     floating: (props) => ({
       ...floatingBackground("default", props),
-      boxShadow: "md",
+      boxShadow: "sm",
       _hover: {
         ...floatingBackground("hover", props),
         ...floatingBorder("hover", props),
-        boxShadow: "lg",
+        boxShadow: "md",
       },
       _active: {
         ...floatingBackground("active", props),

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -13,12 +13,16 @@ const config = defineStyleConfig({
     display: "block",
     borderRadius: "md",
     cursor: "pointer",
-    transition: "all 0.1s",
-    ...focusVisibleStyles(props),
+    transitionProperty: "common",
+    transitionDuration: "fast",
+    "button&, a&, label&, &.is-clickable": {
+      outline: "1px solid",
+      ...focusVisibleStyles(props),
+    },
     _disabled: {
       ...baseBackground("disabled", props),
+      ...baseBorder("disabled", props),
       ...baseText("disabled", props),
-      outline: "none",
       pointerEvents: "none",
     },
   }),
@@ -47,11 +51,11 @@ const config = defineStyleConfig({
     }),
     floating: (props) => ({
       ...floatingBackground("default", props),
-      boxShadow: "sm",
+      boxShadow: "md",
       _hover: {
         ...floatingBackground("hover", props),
         ...floatingBorder("hover", props),
-        boxShadow: "md",
+        boxShadow: "lg",
       },
       _active: {
         ...floatingBackground("active", props),

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -13,6 +13,7 @@ const config = defineStyleConfig({
     display: "block",
     borderRadius: "md",
     cursor: "pointer",
+    transition: "all 0.1s",
     ...focusVisibleStyles(props),
     _disabled: {
       ...baseBackground("disabled", props),

--- a/packages/spor-react/src/theme/utils/floating-utils.ts
+++ b/packages/spor-react/src/theme/utils/floating-utils.ts
@@ -31,9 +31,10 @@ export function floatingBackground(
     case "default":
       return {
         backgroundColor: mode(
-          "floating.surface.default.light",
-          "floating.surface.default.dark",
+          "white",
+          `color-mix(in srgb, white 10%, var(--spor-colors-bg-default-dark))`,
         )(props),
+        color: "inherit",
       };
   }
 }


### PR DESCRIPTION
## Background

- Made variant optional, because defining "as" or "to" created an error without variant
- Changed default to floating
- Fix background on darkmode