### PR TITLE
Fix pressable card

### DIFF
--- a/.changeset/hot-buttons-juggle.md
+++ b/.changeset/hot-buttons-juggle.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+PressableCard: Make variant optional. Fix background on darkmode.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.27",
+  "version": "0.0.28",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/docs": {
       "name": "@vygruppen/docs",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.4.4",
@@ -38261,7 +38261,7 @@
     },
     "packages/spor-icon": {
       "name": "@vygruppen/spor-icon",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "MIT",
       "devDependencies": {
         "bestzip": "^2.2.0"
@@ -38395,7 +38395,7 @@
     },
     "packages/spor-icon-react": {
       "name": "@vygruppen/spor-icon-react",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
         "@svgr/core": "^8.1.0",
@@ -38418,7 +38418,7 @@
     },
     "packages/spor-icon-react-native": {
       "name": "@vygruppen/spor-icon-react-native",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "devDependencies": {
         "@shopify/restyle": "^2.1.0",
@@ -38990,7 +38990,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "9.8.0",
+      "version": "9.8.3",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.6.1",
@@ -38999,7 +38999,7 @@
         "@emotion/styled": "^11.10.4",
         "@internationalized/date": "^3.0.1",
         "@vygruppen/spor-design-tokens": ">3.4.0",
-        "@vygruppen/spor-icon-react": ">3.2.3",
+        "@vygruppen/spor-icon-react": ">3.6.0",
         "@vygruppen/spor-loader": ">0.3.1",
         "awesome-phonenumber": "^5.10.0",
         "deepmerge": "^4.3.1",

--- a/packages/spor-react/src/layout/PressableCard.tsx
+++ b/packages/spor-react/src/layout/PressableCard.tsx
@@ -9,7 +9,7 @@ import {
 
 type PressableCardProps = BoxProps & {
   /** Defaults to "base"  */
-  variant: "floating" | "accent" | "base";
+  variant?: "floating" | "accent" | "base";
 };
 
 /**
@@ -43,7 +43,7 @@ type PressableCardProps = BoxProps & {
  */
 
 export const PressableCard = forwardRef<PressableCardProps, As>(
-  ({ children, variant = "base", ...props }, ref) => {
+  ({ children, variant = "floating", ...props }, ref) => {
     const styles = useStyleConfig("PressableCard", {
       variant,
     });

--- a/packages/spor-react/src/layout/StaticCard.tsx
+++ b/packages/spor-react/src/layout/StaticCard.tsx
@@ -70,7 +70,6 @@ export const StaticCard = forwardRef<StaticCardProps, As>(
     return (
       <Box __css={styles} {...props} ref={ref}>
         {children}
-        <Card />
       </Box>
     );
   },

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -13,9 +13,15 @@ const config = defineStyleConfig({
     display: "block",
     borderRadius: "md",
     cursor: "pointer",
-    ...focusVisibleStyles(props),
+    transitionProperty: "common",
+    transitionDuration: "fast",
+    "button&, a&, label&, &.is-clickable": {
+      outline: "1px solid",
+      ...focusVisibleStyles(props),
+    },
     _disabled: {
       ...baseBackground("disabled", props),
+      ...baseBorder("disabled", props),
       ...baseText("disabled", props),
       outline: "none",
       pointerEvents: "none",

--- a/packages/spor-react/src/theme/components/pressable-card.ts
+++ b/packages/spor-react/src/theme/components/pressable-card.ts
@@ -16,7 +16,6 @@ const config = defineStyleConfig({
     transitionProperty: "common",
     transitionDuration: "fast",
     "button&, a&, label&, &.is-clickable": {
-      outline: "1px solid",
       ...focusVisibleStyles(props),
     },
     _disabled: {

--- a/packages/spor-react/src/theme/utils/floating-utils.ts
+++ b/packages/spor-react/src/theme/utils/floating-utils.ts
@@ -31,8 +31,8 @@ export function floatingBackground(
     case "default":
       return {
         backgroundColor: mode(
-          "floating.surface.default.light",
-          "floating.surface.default.dark",
+          "white",
+          `color-mix(in srgb, white 10%, var(--spor-colors-bg-default-dark))`,
         )(props),
       };
   }

--- a/packages/spor-react/src/theme/utils/floating-utils.ts
+++ b/packages/spor-react/src/theme/utils/floating-utils.ts
@@ -25,7 +25,7 @@ export function floatingBackground(
       return {
         backgroundColor: mode(
           "floating.surface.hover.light",
-          "floating.surface.hover.dark",
+          `color-mix(in srgb, white 10%, var(--spor-colors-bg-default-dark))`,
         )(props),
       };
     case "default":


### PR DESCRIPTION
## Background

- Made variant optional, as it caused errors when defining "to" and "as" attributes
- Fixed background on darkmode
- Transition
