### PR TITLE
Background on darkmode

### DIFF
--- a/apps/docs/app/root/layout/RootLayout.tsx
+++ b/apps/docs/app/root/layout/RootLayout.tsx
@@ -1,14 +1,21 @@
-import { Flex, useColorModeValue } from "@chakra-ui/react";
+import { Flex, useColorMode } from "@chakra-ui/react";
 import { SiteHeader } from "./SiteHeader";
+import { useEffect, useState } from "react";
 
 type BaseLayoutProps = {
   children: React.ReactNode;
 };
 export const RootLayout = ({ children }: BaseLayoutProps) => {
-  const backgroundColor = useColorModeValue(
-    "bg.default.light",
-    "bg.default.dark",
-  );
+  const [background, setBackground] = useState("light");
+  const { colorMode } = useColorMode();
+
+  useEffect(() => {
+    setBackground(colorMode);
+  }, [colorMode]);
+
+  const backgroundColor =
+    background === "light" ? "bg.default.light" : "bg.default.dark";
+
   return (
     <Flex
       flexDirection="column"

--- a/apps/docs/app/root/layout/SiteSettings.tsx
+++ b/apps/docs/app/root/layout/SiteSettings.tsx
@@ -48,7 +48,7 @@ export const SiteSettings = ({ showLabel }: SiteSettingsProps) => {
               <FormLabel margin="0">Dark mode</FormLabel>
               <Switch
                 size="sm"
-                onChange={toggleColorMode}
+                onChange={() => toggleColorMode()}
                 defaultChecked={colorMode === "dark"}
               />
             </FormControl>

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.27",
+  "version": "0.0.28",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",


### PR DESCRIPTION
## Background

It seemed the background didn't always render the correct color.

The fault is hard to produce locally. I have added a client-side render to fix this issue. Shouldn't affect the performance much.

Solves https://github.com/nsbno/spor/issues/1078

No changesets as it doesn't concern any packages.
