### PR TITLE
Update color-tokens for CargoNet and Vy digital

### DIFF
--- a/.changeset/slimy-news-knock.md
+++ b/.changeset/slimy-news-knock.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-design-tokens": minor
+---
+
+Update color-tokens for CargoNet and Vy Digital

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.28",
+  "version": "0.0.29",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/packages/spor-design-tokens/tokens/color/cargonet.json
+++ b/packages/spor-design-tokens/tokens/color/cargonet.json
@@ -15,15 +15,15 @@
             "value": "{color.alias.lightGrey.value}"
           },
           "dark": {
-            "value": "{color.alias.darkGrey.value}"
+            "value": "{color.alias.black.value}"
           }
         },
         "tertiary": {
           "light": {
-            "value": "{color.alias.cornsilk.value}"
+            "value": "{color.alias.bisque.value}"
           },
           "dark": {
-            "value": "{color.alias.golden.value}"
+            "value": "{color.alias.darkGrey.value}"
           }
         }
       },
@@ -38,10 +38,10 @@
         },
         "secondary": {
           "light": {
-            "value": "{color.alias.wood.value}"
+            "value": "{color.alias.dimGrey.value}"
           },
           "dark": {
-            "value": "{color.alias.banana.value}"
+            "value": "{color.alias.champagne.value}"
           }
         },
         "tertiary": {
@@ -62,7 +62,7 @@
         },
         "highlight": {
           "light": {
-            "value": "{color.alias.ocean.value}"
+            "value": "{color.alias.wood.value}"
           },
           "dark": {
             "value": "{color.alias.sky.value}"
@@ -91,7 +91,7 @@
             "value": "{color.alias.wood.value}"
           },
           "dark": {
-            "value": "{color.alias.banana.value}"
+            "value": "{color.alias.champagne.value}"
           }
         },
         "inverted": {
@@ -104,7 +104,7 @@
         },
         "highlight": {
           "light": {
-            "value": "{color.alias.ocean.value}"
+            "value": "{color.alias.wood.value}"
           },
           "dark": {
             "value": "{color.alias.sky.value}"
@@ -138,10 +138,10 @@
         },
         "focus": {
           "light": {
-            "value": "{color.alias.darkGrey.value}"
+            "value": "{color.alias.pumpkin.value}"
           },
           "dark": {
-            "value": "{color.alias.burntYellow.value}"
+            "value": "{color.alias.rajah.value}"
           }
         },
         "error": {
@@ -172,7 +172,7 @@
         },
         "secondary": {
           "light": {
-            "value": "{color.alias.primrose.value}"
+            "value": "{color.alias.champagne.value}"
           },
           "dark": {
             "value": "{color.alias.black.value}"
@@ -199,7 +199,7 @@
         "surface": {
           "active": {
             "light": {
-              "value": "{color.alias.cornsilk.value}"
+              "value": "{color.alias.bisque.value}"
             },
             "dark": {
               "value": "{color.palette.whiteAlpha.100.value}"
@@ -245,43 +245,43 @@
         "surface": {
           "default": {
             "light": {
-              "value": "{color.alias.banana.value}"
+              "value": "{color.alias.saffron.value}"
             },
             "dark": {
-              "value": "{color.alias.banana.value}"
+              "value": "{color.alias.saffron.value}"
             }
           },
           "hover": {
             "light": {
-              "value": "{color.alias.burntYellow.value}"
+              "value": "{color.alias.pumpkin.value}"
             },
             "dark": {
-              "value": "{color.alias.burntYellow.value}"
+              "value": "{color.alias.pumpkin.value}"
             }
           },
           "active": {
             "light": {
-              "value": "{color.alias.sunshine.value}"
+              "value": "{color.alias.rajah.value}"
             },
             "dark": {
-              "value": "{color.alias.primrose.value}"
+              "value": "{color.alias.rajah.value}"
             }
           }
         },
         "text": {
           "light": {
-            "value": "{color.cargonet.text.default.light.value}"
+            "value": "{color.alias.black.value}"
           },
           "dark": {
-            "value": "{color.cargonet.text.inverted.dark.value}"
+            "value": "{color.alias.black.value}"
           }
         },
         "icon": {
           "light": {
-            "value": "{color.cargonet.icon.default.light.value}"
+            "value": "{color.alias.black.value}"
           },
           "dark": {
-            "value": "{color.cargonet.icon.inverted.dark.value}"
+            "value": "{color.alias.black.value}"
           }
         }
       },
@@ -314,7 +314,7 @@
         },
         "text": {
           "light": {
-            "value": "{color.cargonet.text.inverted.light.value}"
+            "value": "{color.alias.champagne.value}"
           },
           "dark": {
             "value": "{color.cargonet.text.default.dark.value}"
@@ -322,7 +322,7 @@
         },
         "icon": {
           "light": {
-            "value": "{color.cargonet.icon.inverted.light.value}"
+            "value": "{color.alias.champagne.value}"
           },
           "dark": {
             "value": "{color.cargonet.icon.default.dark.value}"
@@ -357,7 +357,7 @@
           },
           "active": {
             "light": {
-              "value": "{color.alias.cornsilk.value}"
+              "value": "{color.alias.bisque.value}"
             },
             "dark": {
               "value": "transparent"
@@ -403,7 +403,7 @@
         "surface": {
           "hover": {
             "light": {
-              "value": "{color.alias.blonde.value}"
+              "value": "{color.alias.champagne.value}"
             },
             "dark": {
               "value": "{color.palette.whiteAlpha.200.value}"
@@ -411,7 +411,7 @@
           },
           "active": {
             "light": {
-              "value": "{color.alias.cornsilk.value}"
+              "value": "{color.alias.bisque.value}"
             },
             "dark": {
               "value": "{color.palette.whiteAlpha.100.value}"

--- a/packages/spor-design-tokens/tokens/color/vy-digital.json
+++ b/packages/spor-design-tokens/tokens/color/vy-digital.json
@@ -15,7 +15,7 @@
             "value": "{color.alias.lightGrey.value}"
           },
           "dark": {
-            "value": "{color.alias.darkTeal.value}"
+            "value": "{color.alias.night.value}"
           }
         },
         "tertiary": {
@@ -167,7 +167,7 @@
             "value": "{color.alias.white.value}"
           },
           "dark": {
-            "value": "{color.alias.night.value}"
+            "value": "{color.alias.darkTeal.value}"
           }
         },
         "secondary": {
@@ -175,7 +175,7 @@
             "value": "{color.alias.seaMist.value}"
           },
           "dark": {
-            "value": "{color.alias.darkTeal.value}"
+            "value": "{color.alias.night.value}"
           }
         },
         "tertiary": {


### PR DESCRIPTION
## Background

Some color-tokens needed to be updated. 

Based on this list:
## CargoNet

### Lightmode

| Token | Color |
| --- | --- |
| bg-tertiary | bisque | x
| text-default | darkGrey |x
| text-secondary | dimGrey | x
| text-tertiary | osloGrey | x
| text-highlight | wood | x
| icon-highlight | wood | x
| outline-focus | pumpkin | x
| surface-secondary | champagne | x
| base-surface:active | bisque | x
| brand-surface:default | saffron | x
| brand-surface:hover | pumpkin | x
| brand-surface:active | rajah | x
| brand-text:default | black 100% | x
| brand-icon:default | black 100% | x
| floating-surface:active | bisque | x
| ghost-surface:hover | champagne | x
| ghost-surface:active | bisque | x

### Darkmode

| Token | Color |
| --- | --- |
| bg-default | black 100% | x
| bg-secondary | black 100% | x
| bg-tertiary | darkGrey | x
| text-secondary | champagne | x
| text-highlight | sky | x
| icon-secondary | champagne | x
| icon-highlight | sky | x
| outline-focus | rajah | x
| surface-default | darkGrey | x
| surface-secondary | black 100% | x
| surface-tertiary | dimGrey | x
| brand-surface:default | saffron | x
| brand-surface:hover | pumpkin | x
| brand-surface:active | rajah | x
| brand-text:default | black 100% | x
| brand-icon:default | black 100% | x
| accent-text:default | champagne | x
| accent-icon:default | champagne | x

## Vy

### Darkmode

| Token | Color |
| --- | --- |
| bg-default | Night | x
| bg-secondary | Night | x
| bg-tertiary | Pine | x
| surface-default | darkTeal | x
| surface-secondary | night | x
| surface-tertiary | pine | x
