### PR TITLE
FullScreeenDrawer and SimpleDrawer: add props for drawer body

### DIFF
--- a/.changeset/young-moles-arrive.md
+++ b/.changeset/young-moles-arrive.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Added body prop for FullScreenDrawer and SimpleDrawer for accessability reasons

--- a/packages/spor-react/src/modal/FullScreenDrawer.tsx
+++ b/packages/spor-react/src/modal/FullScreenDrawer.tsx
@@ -15,12 +15,9 @@ import React, { useEffect, useState } from "react";
 import { Button, IconButton } from "../button";
 import { createTexts, useTranslation } from "../i18n";
 import { Drawer } from "./Drawer";
+import { DrawerBodyProps } from "./SimpleDrawer";
 
 type DrawerPlacement = "top" | "right" | "bottom" | "left";
-
-type DrawerBodyProps = {
-  id?: string;
-};
 
 type FullScreenDrawerProps = {
   /** The content inside the drawer */

--- a/packages/spor-react/src/modal/FullScreenDrawer.tsx
+++ b/packages/spor-react/src/modal/FullScreenDrawer.tsx
@@ -18,6 +18,10 @@ import { Drawer } from "./Drawer";
 
 type DrawerPlacement = "top" | "right" | "bottom" | "left";
 
+type DrawerBodyProps = {
+  id?: string;
+};
+
 type FullScreenDrawerProps = {
   /** The content inside the drawer */
   children: React.ReactNode;
@@ -33,6 +37,8 @@ type FullScreenDrawerProps = {
   isOpen: boolean;
   /** Function that will be called when the drawer closes */
   onClose: () => void;
+  /** Props for drawer body */
+  body?: DrawerBodyProps;
 };
 
 export const FullScreenDrawer = ({
@@ -43,6 +49,7 @@ export const FullScreenDrawer = ({
   rightButton = <DrawerCloseButton />,
   isOpen,
   onClose,
+  body,
 }: FullScreenDrawerProps) => {
   const [isContentBoxScrolled, setContentBoxScrolled] = useState(false);
 
@@ -75,7 +82,7 @@ export const FullScreenDrawer = ({
           leftButton={leftButton}
           rightButton={rightButton}
         />
-        <DrawerBody overflow="auto" onScroll={onContentScroll}>
+        <DrawerBody overflow="auto" onScroll={onContentScroll} {...body}>
           {children}
         </DrawerBody>
       </DrawerContent>

--- a/packages/spor-react/src/modal/SimpleDrawer.tsx
+++ b/packages/spor-react/src/modal/SimpleDrawer.tsx
@@ -8,12 +8,18 @@ import {
   DrawerOverlay,
 } from "./Drawer";
 
+type DrawerBodyProps = {
+  id?: string;
+};
+
 export type SimpleDrawerProps = {
   children: React.ReactNode;
   title?: React.ReactNode;
   placement: "top" | "right" | "bottom" | "left";
   isOpen: boolean;
   onClose: () => void;
+  /** Props for drawer body */
+  body?: DrawerBodyProps;
 };
 /** A very basic drawer component that's easy to use
  *
@@ -29,6 +35,7 @@ export const SimpleDrawer = ({
   placement,
   children,
   title,
+  body,
   ...props
 }: SimpleDrawerProps) => {
   return (
@@ -37,7 +44,7 @@ export const SimpleDrawer = ({
       <DrawerContent>
         <DrawerCloseButton />
         {title && <DrawerHeader>{title}</DrawerHeader>}
-        <DrawerBody>{children}</DrawerBody>
+        <DrawerBody {...body}>{children}</DrawerBody>
       </DrawerContent>
     </Drawer>
   );

--- a/packages/spor-react/src/modal/SimpleDrawer.tsx
+++ b/packages/spor-react/src/modal/SimpleDrawer.tsx
@@ -8,7 +8,7 @@ import {
   DrawerOverlay,
 } from "./Drawer";
 
-type DrawerBodyProps = {
+export type DrawerBodyProps = {
   id?: string;
 };
 


### PR DESCRIPTION
## Background
Chakra, for drawer, sets `aria-describedby` default value for chakra-modal to be the id of the drawer body. This creates some voiceover issues on iphone (in browser) as any child components in the drawer body that doesn't have `aria-describedby` set instead uses the `aria-describedby` default value set for the entire modal.

## Solution
Add a prop to FullScreenDrawer and SimpleDrawer that contains props for drawer body. This will enable the user to set a specific id for drawer body that doesn't match the default `aria-describedby`.