### PR TITLE
Add back button to FullScreenDrawer

### DIFF
--- a/.changeset/strong-insects-hammer.md
+++ b/.changeset/strong-insects-hammer.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+FullScreenDrawer: Added back button as default view. Title gets more space on mobile.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.38",
+  "version": "0.0.39",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/docs": {
       "name": "@vygruppen/docs",
-      "version": "0.0.39",
+      "version": "0.0.38",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/docs": {
       "name": "@vygruppen/docs",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/modal/FullScreenDrawer.tsx
+++ b/packages/spor-react/src/modal/FullScreenDrawer.tsx
@@ -10,7 +10,12 @@ import {
   useModalContext,
 } from "@chakra-ui/react";
 import tokens from "@vygruppen/spor-design-tokens";
-import { CloseFill24Icon, CloseFill30Icon } from "@vygruppen/spor-icon-react";
+import {
+  ArrowLeftFill24Icon,
+  ArrowLeftFill30Icon,
+  CloseFill24Icon,
+  CloseFill30Icon,
+} from "@vygruppen/spor-icon-react";
 import React, { useEffect, useState } from "react";
 import { Button, IconButton } from "../button";
 import { createTexts, useTranslation } from "../i18n";
@@ -42,7 +47,7 @@ export const FullScreenDrawer = ({
   children,
   title,
   placement = "bottom",
-  leftButton = null,
+  leftButton = <DrawerBackButton />,
   rightButton = <DrawerCloseButton />,
   isOpen,
   onClose,
@@ -119,13 +124,15 @@ const DrawerTopMenu = ({
       transition="box-shadow 0.2s"
       boxShadow={isScrolled ? "md" : undefined}
     >
-      <Box flex="1">{leftButton}</Box>
+      <Box flex="1">
+        <Box width="fit-content">{leftButton}</Box>
+      </Box>
       <DrawerHeader
         as="h2"
         fontSize="md"
         fontWeight="bold"
         textAlign="center"
-        flex="1"
+        flex="2"
         margin={0}
         padding={0}
       >
@@ -173,11 +180,56 @@ const DrawerCloseButton = () => {
   );
 };
 
+const DrawerBackButton = () => {
+  const { onClose } = useModalContext();
+  const { t } = useTranslation();
+
+  const [isScreenSizeMinSm] = useMediaQuery(
+    `(min-width: ${tokens.size.breakpoint.sm})`,
+  );
+
+  if (isScreenSizeMinSm) {
+    return (
+      <Button
+        variant="ghost"
+        leftIcon={<ArrowLeftFill24Icon />}
+        onClick={onClose}
+        aria-label={t(texts.close)}
+        width="fit-content"
+        marginLeft="auto"
+      >
+        {t(texts.back)}
+      </Button>
+    );
+  }
+
+  return (
+    <IconButton
+      variant="ghost"
+      icon={<ArrowLeftFill30Icon />}
+      onClick={onClose}
+      aria-label={t(texts.close)}
+    />
+  );
+};
+
 const texts = createTexts({
   close: {
     nb: "Lukk",
     nn: "Lukk",
     en: "Close",
     sv: "Stäng",
+  },
+  back: {
+    nb: "Tilbake",
+    nn: "Tilbake",
+    en: "Back",
+    sv: "Tillbaka",
+  },
+  backAriaLabel: {
+    nb: "Gå tilbake",
+    nn: "Gå tilbake",
+    en: "Go back",
+    sv: "Gå tillbaka",
   },
 });

--- a/packages/spor-react/src/modal/FullScreenDrawer.tsx
+++ b/packages/spor-react/src/modal/FullScreenDrawer.tsx
@@ -194,7 +194,7 @@ const DrawerBackButton = () => {
         variant="ghost"
         leftIcon={<ArrowLeftFill24Icon />}
         onClick={onClose}
-        aria-label={t(texts.close)}
+        aria-label={t(texts.backAriaLabel)}
         width="fit-content"
         marginLeft="auto"
       >
@@ -219,6 +219,12 @@ const texts = createTexts({
     nn: "Lukk",
     en: "Close",
     sv: "Stäng",
+  },
+  closeAriaLabel: {
+    nb: "Lukk vindu",
+    nn: "Lukk vindauge",
+    en: "Close window",
+    sv: "Stäng fönster",
   },
   back: {
     nb: "Tilbake",


### PR DESCRIPTION
## Background

FullScreenDrawer needed a back button according to the designsystem in Figma. And for new designs for Cargonet.

## Solution

Added back button and more spacing for the title.

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave

## How to test

Test by going to the Drawer page in documentation and open the FullScreenDrawer.

## Screenshots

| Desktop | Mobile |
| ------ | ----- |
| <img width="1023" alt="image" src="https://github.com/nsbno/spor/assets/42611957/3238fc95-9c7b-434e-b967-029da4a6bd62"> | <img width="423" alt="image" src="https://github.com/nsbno/spor/assets/42611957/e30bb4f9-6835-4d28-ad9f-62c2521af337"> |
