### PR TITLE
InfoSelect center value when screen-reader only

### DIFF
--- a/.changeset/three-masks-yell.md
+++ b/.changeset/three-masks-yell.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Vertical align for infoselect

--- a/packages/spor-react/src/input/InfoSelect.tsx
+++ b/packages/spor-react/src/input/InfoSelect.tsx
@@ -224,9 +224,9 @@ export function InfoSelect<T extends object>({
           </chakra.div>
           <Box
             {...valueProps}
-            h={isLabelSrOnly ? "" : (!hasChosenValue  ? "0px" : "18px")}
+            h={isLabelSrOnly ? "" : !hasChosenValue ? "0px" : "18px"}
             hidden={!hasChosenValue}
-            transform={isLabelSrOnly ? "" :"scale(1) translateY(-10px)"}
+            transform={isLabelSrOnly ? "" : "scale(1) translateY(-10px)"}
             transitionProperty={"var(--spor-transition-property-common)"}
             transitionDuration={"var(--spor-transition-duration-normal)"}
           >

--- a/packages/spor-react/src/input/InfoSelect.tsx
+++ b/packages/spor-react/src/input/InfoSelect.tsx
@@ -224,9 +224,9 @@ export function InfoSelect<T extends object>({
           </chakra.div>
           <Box
             {...valueProps}
-            h={!hasChosenValue ? "0px" : "18px"}
+            h={isLabelSrOnly ? "" : (!hasChosenValue  ? "0px" : "18px")}
             hidden={!hasChosenValue}
-            transform={"scale(1) translateY(-10px)"}
+            transform={isLabelSrOnly ? "" :"scale(1) translateY(-10px)"}
             transitionProperty={"var(--spor-transition-property-common)"}
             transitionDuration={"var(--spor-transition-duration-normal)"}
           >

--- a/packages/spor-react/src/theme/components/info-select.ts
+++ b/packages/spor-react/src/theme/components/info-select.ts
@@ -40,7 +40,6 @@ const config = helpers.defineMultiStyleConfig({
       justifyContent: "space-between",
       alignItems: "center",
       fontSize: "mobile.md",
-      h: 8,
       ...baseBorder("default", props),
       _hover: {
         ...baseBorder("hover", props),


### PR DESCRIPTION
## Background

PhoneNumberInput had top aligned country code.

## Solution

Skip setting hieght and transform when `isLabelSrOnly` is true, to keep vertical center aligned value.

## UU checks

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [X] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)
- [ ] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Desribe how code reviewer may test your solution (what page, expected result).

## Screenshots

| Before | After |
| ------ | ----- |
| ![bilde](https://github.com/nsbno/spor/assets/62022184/55ebb9de-7eae-4f5f-a529-c2c063e3d9d2)|![bilde](https://github.com/nsbno/spor/assets/62022184/fca9ffe6-4cff-440f-b8f8-890139835fca)|
|![bilde](https://github.com/nsbno/spor/assets/62022184/9cb470ac-5bfa-495c-b73d-5b9a6534ad89)|![bilde](https://github.com/nsbno/spor/assets/62022184/a2b6b736-a15c-4c0b-a917-5de07d09e1b8)|
