### PR TITLE
Make Combobox & ListBox accessible

### DIFF
--- a/.changeset/friendly-knives-buy.md
+++ b/.changeset/friendly-knives-buy.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Combobox & ListBox: Add semantics for accessibility

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.42",
+  "version": "0.0.43",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/docs": {
       "name": "@vygruppen/docs",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^2.9.0",
         "@vygruppen/spor-icon-react": "^3.9.0",
-        "@vygruppen/spor-react": "^9.14.1",
+        "@vygruppen/spor-react": "^9.15.0",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "9.14.1",
+      "version": "9.15.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -104,7 +104,6 @@ export function Combobox<T extends object>({
     allowsEmptyCollection: Boolean(emptyContent),
     defaultFilter: contains,
     shouldCloseOnBlur: true,
-    /* label, */
     ...rest,
   });
 

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useId, useRef, useState } from "react";
 import { AriaComboBoxProps, useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
 import { ColorSpinner, Input, InputProps, ListBox } from "..";
@@ -93,8 +93,10 @@ export function Combobox<T extends object>({
 
   const fallbackInputRef = useRef<HTMLInputElement>(null);
   const inputRef = externalInputRef ?? fallbackInputRef;
-  const listBoxRef = useRef(null);
+  const listBoxRef = useRef<HTMLUListElement>(null);
   const popoverRef = useRef(null);
+
+  const listboxId = `${useId()}-listbox`;
 
   const inputWidth = useInputWidth(inputRef);
 
@@ -137,13 +139,29 @@ export function Combobox<T extends object>({
     state,
   );
 
+  /* useEffect(() => {
+    const handleMouseOver = (e: MouseEvent) => {
+      if (state.isOpen && !inputRef.current?.contains(e.target as Node)) {
+        state.close();
+      }
+    };
+    window.addEventListener("mouseover", handleMouseOver);
+    return () => window.removeEventListener("mouseover", handleMouseOver);
+  }); */
+
+  console.log(state.selectedItem);
+
   return (
     <>
       <Input
         {...styleProps(comboBoxProps)}
         aria-haspopup="listbox"
         ref={inputRef}
+        role="combobox"
         label={label}
+        aria-expanded={state.isOpen}
+        aria-autocomplete="list"
+        aria-controls={listboxId}
         borderBottomLeftRadius={
           state.isOpen && !isLoading ? 0 : borderBottomLeftRadius
         }
@@ -169,7 +187,7 @@ export function Combobox<T extends object>({
           )
         }
       />
-
+      <span aria-hidden="true" data-trigger="multiselect"></span>
       {state.isOpen && !isLoading && (
         <Popover
           state={state}
@@ -186,6 +204,7 @@ export function Combobox<T extends object>({
           <ListBox
             {...listBoxProps}
             state={state}
+            id={listboxId}
             listBoxRef={listBoxRef}
             emptyContent={emptyContent}
             maxWidth={inputWidth}

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -139,18 +139,6 @@ export function Combobox<T extends object>({
     state,
   );
 
-  /* useEffect(() => {
-    const handleMouseOver = (e: MouseEvent) => {
-      if (state.isOpen && !inputRef.current?.contains(e.target as Node)) {
-        state.close();
-      }
-    };
-    window.addEventListener("mouseover", handleMouseOver);
-    return () => window.removeEventListener("mouseover", handleMouseOver);
-  }); */
-
-  console.log(state.selectedItem);
-
   return (
     <>
       <Input

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -104,7 +104,7 @@ export function Combobox<T extends object>({
     allowsEmptyCollection: Boolean(emptyContent),
     defaultFilter: contains,
     shouldCloseOnBlur: true,
-    label,
+    /* label, */
     ...rest,
   });
 
@@ -135,6 +135,7 @@ export function Combobox<T extends object>({
       inputRef,
       listBoxRef,
       popoverRef,
+      label,
     },
     state,
   );

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -49,6 +49,7 @@ export const Input = forwardRef<InputProps, "input">(
           paddingRight={rightIcon ? 7 : undefined}
           {...props}
           id={inputId}
+          aria-labelledby={inputId}
           ref={ref}
           placeholder=" " // This is needed to make the label work as expected
         />

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -135,6 +135,7 @@ function Option({ item, state }: OptionProps) {
     optionProps,
     isSelected,
     isDisabled,
+    isFocusVisible,
     isFocused,
     labelProps,
     descriptionProps,
@@ -151,6 +152,10 @@ function Option({ item, state }: OptionProps) {
   if (isFocused) {
     dataFields["data-focus"] = true;
   }
+  if (isFocusVisible) {
+    dataFields["data-focus-visible"] = true;
+  }
+
 
   /* 
   Workaround to fix click througs on mobile devices

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -156,7 +156,6 @@ function Option({ item, state }: OptionProps) {
     dataFields["data-focus-visible"] = true;
   }
 
-
   /* 
   Workaround to fix click througs on mobile devices
   Related to https://github.com/adobe/react-spectrum/issues/4970

--- a/packages/spor-react/src/theme/components/listbox.ts
+++ b/packages/spor-react/src/theme/components/listbox.ts
@@ -4,6 +4,7 @@ import { mode } from "@chakra-ui/theme-tools";
 import { baseBorder } from "../utils/base-utils";
 import { ghostBackground, ghostText } from "../utils/ghost-utils";
 import { surface } from "../utils/surface-utils";
+import { outlineBorder } from "../utils/outline-utils";
 
 const parts = anatomy("ListBox").parts(
   "container",
@@ -38,11 +39,11 @@ const config = helpers.defineMultiStyleConfig({
       _active: {
         ...ghostBackground("active", props),
       },
+      _focusVisible: {
+        ...outlineBorder("focus", props),
+      },
       _hover: {
         ...ghostBackground("hover", props),
-      },
-      _focus: {
-        ...ghostBackground("selected", props),
       },
       _selected: {
         ...ghostBackground("active", props),


### PR DESCRIPTION
## Background

It was not possible to use the arrows to navigate through Combobox. Both Combobox and ListBox was lacking semantics and styling for focus and focusvisible. 

## Solution

Added the semantics and styling

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)
- [x] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Go to /components/combobox and use the arrows to navigate. Enter button to make a selection.

