### PR TITLE
DatePicker: Fix typerror and accessibility

### DIFF
--- a/.changeset/big-lobsters-cough.md
+++ b/.changeset/big-lobsters-cough.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+DatePicker: Fix warnings and accessibility

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.43",
+  "version": "0.0.44",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/docs": {
       "name": "@vygruppen/docs",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^2.9.0",
         "@vygruppen/spor-icon-react": "^3.9.0",
-        "@vygruppen/spor-react": "^9.15.0",
+        "@vygruppen/spor-react": "^9.16.0",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "9.15.0",
+      "version": "9.16.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
+++ b/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
@@ -7,39 +7,43 @@ import {
   ResponsiveValue,
 } from "@chakra-ui/react";
 import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
-import React from "react";
+import React, { KeyboardEventHandler } from "react";
 import { AriaButtonProps } from "react-aria";
-import { createTexts, useTranslation } from "..";
+import { IconButton, createTexts, useTranslation } from "..";
 
 type CalendarTriggerButtonProps = AriaButtonProps<"button"> & {
   variant: ResponsiveValue<"base" | "floating" | "ghost">;
+  isDisabled?: boolean;
+  ariaLabelledby?: string;
 };
 export const CalendarTriggerButton = forwardRef<CalendarTriggerButtonProps, As>(
-  ({ variant, ...buttonProps }, ref) => {
+  ({ variant, isDisabled, ariaLabelledby, ...buttonProps }, ref) => {
     const { t } = useTranslation();
     const styles = useMultiStyleConfig("Datepicker", { variant });
 
     const { onPress, ...filteredButtonProps } = buttonProps;
 
-    const handleOnPress = (event: KeyboardEvent) => {
-      if (onPress) {
-        if (event.key == "Enter" || event.key == " ") onPress(event as any);
+    const handleCommand: KeyboardEventHandler = (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        onPress?.(event as any);
       }
     };
 
     return (
       <PopoverAnchor>
-        <Box
+        <IconButton
           ref={ref}
-          as="button"
-          type="button"
+          role="button"
+          icon={<CalendarOutline24Icon />}
           aria-label={t(texts.openCalendar)}
           sx={styles.calendarTriggerButton}
+          variant="ghost"
           {...filteredButtonProps}
-          onKeyUp={handleOnPress}
-        >
-          <CalendarOutline24Icon />
-        </Box>
+          isDisabled={isDisabled}
+          onKeyDown={handleCommand}
+          aria-labelledby={ariaLabelledby}
+        />
       </PopoverAnchor>
     );
   },

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -3,9 +3,10 @@ import { DateValue, GregorianCalendar } from "@internationalized/date";
 import { DOMAttributes, FocusableElement } from "@react-types/shared";
 import React, { RefObject, forwardRef, useId, useRef } from "react";
 import { AriaDateFieldProps, useDateField } from "react-aria";
-import { useDateFieldState } from "react-stately";
+import { DateSegment, useDateFieldState } from "react-stately";
 import { DateTimeSegment } from "./DateTimeSegment";
 import { useCurrentLocale } from "./utils";
+import { createTexts, useTranslation } from "../i18n";
 
 function createCalendar(identifier: string) {
   switch (identifier) {
@@ -23,7 +24,7 @@ type DateFieldProps = AriaDateFieldProps<DateValue> & {
   labelId?: string;
 };
 export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
-  (props, externalRef) => {
+  ({ labelId, ...props }, externalRef) => {
     const locale = useCurrentLocale();
     const styles = useMultiStyleConfig("Datepicker", {});
     const state = useDateFieldState({
@@ -31,6 +32,8 @@ export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
       locale,
       createCalendar,
     });
+
+    const { t } = useTranslation();
 
     const internalRef = useRef(null);
     const ref = externalRef ?? internalRef;
@@ -47,7 +50,7 @@ export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
             sx={styles.inputLabel}
             position="absolute"
             paddingTop="2px"
-            id={props.labelId}
+            id={labelId}
           >
             {props.label}
           </FormLabel>
@@ -57,7 +60,8 @@ export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
             <DateTimeSegment
               key={i}
               segment={segment}
-              ariaLabelledby={props.labelId}
+              ariaDescription={t(getAriaLabel(segment.type))}
+              ariaLabel={labelId}
               state={state}
             />
           ))}
@@ -71,3 +75,37 @@ export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
     );
   },
 );
+
+const texts = createTexts({
+  day: {
+    nb: "Velg dag",
+    nn: "Vel dag",
+    sv: "Välj dag",
+    en: "Choose day",
+  },
+  month: {
+    nb: "Velg måned",
+    nn: "Vel månad",
+    sv: "Välj månad",
+    en: "Choose month",
+  },
+  year: {
+    nb: "Velg år",
+    nn: "Vel år",
+    sv: "Välj år",
+    en: "Choose year",
+  },
+});
+
+const getAriaLabel = (segmentType: DateSegment["type"]) => {
+  switch (segmentType) {
+    case "day":
+      return texts.day;
+    case "month":
+      return texts.month;
+    case "year":
+      return texts.year;
+    default:
+      return texts.day;
+  }
+};

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, FormLabel, useMultiStyleConfig } from "@chakra-ui/react";
 import { DateValue, GregorianCalendar } from "@internationalized/date";
 import { DOMAttributes, FocusableElement } from "@react-types/shared";
-import React, { RefObject, forwardRef, useRef } from "react";
+import React, { RefObject, forwardRef, useId, useRef } from "react";
 import { AriaDateFieldProps, useDateField } from "react-aria";
 import { useDateFieldState } from "react-stately";
 import { DateTimeSegment } from "./DateTimeSegment";
@@ -20,6 +20,7 @@ type DateFieldProps = AriaDateFieldProps<DateValue> & {
   label?: React.ReactNode;
   labelProps?: DOMAttributes<FocusableElement>;
   name?: string;
+  labelId?: string;
 };
 export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
   (props, externalRef) => {
@@ -33,7 +34,7 @@ export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
 
     const internalRef = useRef(null);
     const ref = externalRef ?? internalRef;
-    const { fieldProps, labelProps } = useDateField(
+    const { fieldProps } = useDateField(
       props,
       state,
       ref as RefObject<HTMLDivElement>,
@@ -43,18 +44,22 @@ export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
       <Box minWidth="6rem" width="100%">
         {props.label && (
           <FormLabel
-            {...props.labelProps}
-            {...labelProps}
             sx={styles.inputLabel}
             position="absolute"
             paddingTop="2px"
+            id={props.labelId}
           >
             {props.label}
           </FormLabel>
         )}
         <Flex {...fieldProps} ref={ref} paddingTop="3" paddingBottom="0.5">
           {state.segments.map((segment, i) => (
-            <DateTimeSegment key={i} segment={segment} state={state} />
+            <DateTimeSegment
+              key={i}
+              segment={segment}
+              ariaLabelledby={props.labelId}
+              state={state}
+            />
           ))}
         </Flex>
         <input

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   BoxProps,
   FocusLock,
-  InputGroup,
   Popover,
   PopoverAnchor,
   PopoverArrow,
@@ -10,12 +9,13 @@ import {
   PopoverContent,
   PopoverTrigger,
   Portal,
+  InputGroup,
   ResponsiveValue,
   useFormControlContext,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
 import { DateValue } from "@internationalized/date";
-import React, { ReactNode, forwardRef, useRef } from "react";
+import React, { ReactNode, forwardRef, useId, useRef } from "react";
 import { AriaDatePickerProps, I18nProvider, useDatePicker } from "react-aria";
 import { useDatePickerState } from "react-stately";
 import { FormErrorMessage } from "..";
@@ -68,7 +68,6 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
     const internalRef = useRef<HTMLDivElement>(null);
     const ref = externalRef ?? internalRef;
     const {
-      groupProps,
       labelProps,
       fieldProps,
       buttonProps,
@@ -80,6 +79,9 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       state,
       ref as React.MutableRefObject<HTMLDivElement>,
     );
+
+    const labelId = `label-${useId()}`;
+    const inputGroupId = `input-group-${useId()}`;
 
     const styles = useMultiStyleConfig("Datepicker", { variant });
     const locale = useCurrentLocale();
@@ -118,24 +120,33 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             onClose={state.close}
             flip={false}
           >
-            <InputGroup {...groupProps} display="inline-flex">
+            <InputGroup
+              display="inline-flex"
+              id={inputGroupId}
+              aria-labelledby={labelId}
+            >
               <PopoverAnchor>
                 <StyledField
                   variant={variant}
                   onClick={onFieldClick}
                   paddingX={3}
                   minHeight={minHeight}
+                  isDisabled={props.isDisabled}
+                  ariaLabelledby={labelId}
                 >
                   <PopoverTrigger>
                     <CalendarTriggerButton
                       variant={variant}
                       ref={ref}
+                      isDisabled={props.isDisabled}
+                      ariaLabelledby={labelId}
                       {...buttonProps}
                     />
                   </PopoverTrigger>
                   <DateField
                     label={props.label}
                     labelProps={labelProps}
+                    labelId={labelId}
                     name={props.name}
                     {...fieldProps}
                   />

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -2,10 +2,12 @@ import { Box, useMultiStyleConfig } from "@chakra-ui/react";
 import React, { RefObject, forwardRef, useRef } from "react";
 import { useDateSegment } from "react-aria";
 import { DateFieldState, DateSegment } from "react-stately";
+import { createTexts, useTranslation } from "../i18n";
 
 type DateTimeSegmentProps = {
   segment: DateSegment;
   state: DateFieldState;
+  ariaLabelledby?: string;
 };
 /**
  * A date time segment is a part of a date or a time stamp.
@@ -15,9 +17,11 @@ type DateTimeSegmentProps = {
  * This component should be used with the react-aria library, and is not meant to be used directly.
  * */
 export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
-  ({ segment, state }, externalRef) => {
+  ({ segment, state, ariaLabelledby }, externalRef) => {
     const internalRef = useRef(null);
     const ref = externalRef ?? internalRef;
+
+    const { t } = useTranslation();
 
     const { segmentProps } = useDateSegment(
       segment,
@@ -42,6 +46,8 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
         borderRadius="xs"
         fontSize={["mobile.sm", "desktop.sm"]}
         sx={styles.dateTimeSegment}
+        aria-labelledby={ariaLabelledby}
+        aria-label={t(getAriaLabel(segment.type))}
       >
         {isPaddable(segment.type)
           ? segment.text.padStart(2, "0")
@@ -57,3 +63,37 @@ const isPaddable = (segmentType: DateSegment["type"]) =>
   segmentType === "hour" ||
   segmentType === "minute" ||
   segmentType === "second";
+
+const texts = createTexts({
+  day: {
+    nb: "Velg dag",
+    nn: "Vel dag",
+    sv: "Välj dag",
+    en: "Choose day",
+  },
+  month: {
+    nb: "Velg måned",
+    nn: "Vel månad",
+    sv: "Välj månad",
+    en: "Choose month",
+  },
+  year: {
+    nb: "Velg år",
+    nn: "Vel år",
+    sv: "Välj år",
+    en: "Choose year",
+  },
+});
+
+const getAriaLabel = (segmentType: DateSegment["type"]) => {
+  switch (segmentType) {
+    case "day":
+      return texts.day;
+    case "month":
+      return texts.month;
+    case "year":
+      return texts.year;
+    default:
+      return texts.day;
+  }
+};

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -2,12 +2,12 @@ import { Box, useMultiStyleConfig } from "@chakra-ui/react";
 import React, { RefObject, forwardRef, useRef } from "react";
 import { useDateSegment } from "react-aria";
 import { DateFieldState, DateSegment } from "react-stately";
-import { createTexts, useTranslation } from "../i18n";
 
 type DateTimeSegmentProps = {
   segment: DateSegment;
   state: DateFieldState;
-  ariaLabelledby?: string;
+  ariaLabel?: string;
+  ariaDescription?: string;
 };
 /**
  * A date time segment is a part of a date or a time stamp.
@@ -17,11 +17,9 @@ type DateTimeSegmentProps = {
  * This component should be used with the react-aria library, and is not meant to be used directly.
  * */
 export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
-  ({ segment, state, ariaLabelledby }, externalRef) => {
+  ({ segment, state, ariaLabel, ariaDescription }, externalRef) => {
     const internalRef = useRef(null);
     const ref = externalRef ?? internalRef;
-
-    const { t } = useTranslation();
 
     const { segmentProps } = useDateSegment(
       segment,
@@ -46,8 +44,8 @@ export const DateTimeSegment = forwardRef<HTMLDivElement, DateTimeSegmentProps>(
         borderRadius="xs"
         fontSize={["mobile.sm", "desktop.sm"]}
         sx={styles.dateTimeSegment}
-        aria-labelledby={ariaLabelledby}
-        aria-label={t(getAriaLabel(segment.type))}
+        aria-description={ariaDescription}
+        aria-labelledby={ariaLabel}
       >
         {isPaddable(segment.type)
           ? segment.text.padStart(2, "0")
@@ -63,37 +61,3 @@ const isPaddable = (segmentType: DateSegment["type"]) =>
   segmentType === "hour" ||
   segmentType === "minute" ||
   segmentType === "second";
-
-const texts = createTexts({
-  day: {
-    nb: "Velg dag",
-    nn: "Vel dag",
-    sv: "Välj dag",
-    en: "Choose day",
-  },
-  month: {
-    nb: "Velg måned",
-    nn: "Vel månad",
-    sv: "Välj månad",
-    en: "Choose month",
-  },
-  year: {
-    nb: "Velg år",
-    nn: "Vel år",
-    sv: "Välj år",
-    en: "Choose year",
-  },
-});
-
-const getAriaLabel = (segmentType: DateSegment["type"]) => {
-  switch (segmentType) {
-    case "day":
-      return texts.day;
-    case "month":
-      return texts.month;
-    case "year":
-      return texts.year;
-    default:
-      return texts.day;
-  }
-};

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -11,19 +11,25 @@ import React from "react";
 
 type StyledFieldProps = BoxProps & {
   variant: ResponsiveValue<"base" | "floating" | "ghost">;
+  isDisabled?: boolean;
+  ariaLabelledby?: string;
 };
 export const StyledField = forwardRef<StyledFieldProps, As>(
-  ({ children, variant, ...otherProps }, ref) => {
+  ({ children, variant, isDisabled, ariaLabelledby, ...otherProps }, ref) => {
     const { isInvalid } = useFormControlContext() ?? {
       isInvalid: false,
     };
+
     const styles = useMultiStyleConfig("Datepicker", { variant });
+
     return (
       <Box
         {...otherProps}
         __css={styles.wrapper}
         ref={ref}
         aria-invalid={isInvalid}
+        aria-disabled={isDisabled}
+        aria-labelledby={ariaLabelledby}
       >
         {children}
       </Box>

--- a/packages/spor-react/src/theme/components/datepicker.ts
+++ b/packages/spor-react/src/theme/components/datepicker.ts
@@ -42,6 +42,8 @@ const config = helpers.defineMultiStyleConfig({
       _disabled: {
         pointerEvents: "none",
         ...baseBackground("disabled", props),
+        ...baseBorder("disabled", props),
+        ...baseText("disabled", props),
       },
       _focusWithin: {
         ...focusVisibleStyles(props)._focusVisible,
@@ -49,15 +51,10 @@ const config = helpers.defineMultiStyleConfig({
     },
     inputLabel: {
       fontSize: "mobile.xs",
-      color: mode("darkGrey", "white")(props),
       margin: 0,
       cursor: "text",
     },
     dateTimeSegment: {
-      color: mode(
-        "darkGrey",
-        props.isPlaceholder ? "whiteAlpha.400" : "white",
-      )(props),
       _focus: {
         ...brandBackground("hover", props),
         color: "white",
@@ -68,13 +65,9 @@ const config = helpers.defineMultiStyleConfig({
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
-      borderLeftRadius: "sm",
       transitionProperty: "box-shadow, background-color",
       transitionSpeed: "fast",
       position: "relative",
-      paddingTop: 1,
-      paddingBottom: 1,
-      borderRadius: "sm",
       right: "9px",
 
       ...focusVisibleStyles(props),
@@ -173,9 +166,6 @@ const config = helpers.defineMultiStyleConfig({
         _invalid: {
           ...baseBorder("invalid", props),
         },
-        _disabled: {
-          ...baseBorder("disabled", props),
-        },
       },
     }),
     floating: (props) => ({
@@ -189,9 +179,6 @@ const config = helpers.defineMultiStyleConfig({
         },
         _invalid: {
           ...baseBorder("invalid", props),
-        },
-        _disabled: {
-          ...baseBorder("disabled", props),
         },
       },
     }),


### PR DESCRIPTION
## Background

DatePicker had a typerror on isDisabled. Also noticed made some accessibility improvements.

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)
- [x] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Go to /components/datepicker

There should be no warnings in the console and VoiceOver should work as expected with labels.
