### PR TITLE
ChoiceChip: Fix type error and style bug

### DIFF
--- a/.changeset/poor-geese-fry.md
+++ b/.changeset/poor-geese-fry.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+ChoiceChip: Minor bugfix on types

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.43",
+  "version": "0.0.44",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/packages/spor-react/src/input/ChoiceChip.tsx
+++ b/packages/spor-react/src/input/ChoiceChip.tsx
@@ -110,10 +110,11 @@ export const ChoiceChip = forwardRef(
               {state.isChecked ? icon.checked : icon.default}
             </chakra.span>
           )}
-
-          <chakra.span __css={styles.label} {...getCheckboxProps()}>
-            {chipType !== "icon" && children}
-          </chakra.span>
+          {chipType !== "icon" && (
+            <chakra.span __css={styles.label} {...getCheckboxProps()}>
+              {children}
+            </chakra.span>
+          )}
 
           {chipType === "filter" && state.isChecked && (
             <CloseOutline24Icon marginLeft={1.5} />

--- a/packages/spor-react/src/input/ChoiceChip.tsx
+++ b/packages/spor-react/src/input/ChoiceChip.tsx
@@ -110,11 +110,10 @@ export const ChoiceChip = forwardRef(
               {state.isChecked ? icon.checked : icon.default}
             </chakra.span>
           )}
-          {chipType !== "icon" && (
-            <chakra.span __css={styles.label} {...getCheckboxProps()}>
-              {children}
-            </chakra.span>
-          )}
+
+          <chakra.span __css={styles.label} {...getCheckboxProps()}>
+            {chipType !== "icon" && children}
+          </chakra.span>
 
           {chipType === "filter" && state.isChecked && (
             <CloseOutline24Icon marginLeft={1.5} />

--- a/packages/spor-react/src/input/ChoiceChip.tsx
+++ b/packages/spor-react/src/input/ChoiceChip.tsx
@@ -54,62 +54,73 @@ export type ChoiceChipProps = {
  * </Stack>
  * ```
  */
-export const ChoiceChip = forwardRef((props: ChoiceChipProps, ref) => {
-  const {
-    children,
-    icon,
-    isDisabled,
-    size = "sm",
-    chipType = "choice",
-    variant = "base",
-  } = props;
+export const ChoiceChip = forwardRef(
+  (
+    {
+      children,
+      icon,
+      isChecked,
+      isDisabled,
+      size = "sm",
+      chipType,
+      variant = "base",
+      ...props
+    }: ChoiceChipProps,
+    ref,
+  ) => {
+    const {
+      state,
+      getInputProps,
+      getCheckboxProps,
+      getRootProps,
+      getLabelProps,
+    } = useCheckbox(props);
+    const styles = useMultiStyleConfig("ChoiceChip", {
+      size,
+      chipType,
+      variant,
+      icon,
+      hasLabel: chipType !== "icon",
+    });
 
-  const {
-    state,
-    getInputProps,
-    getCheckboxProps,
-    getRootProps,
-    getLabelProps,
-  } = useCheckbox(props);
-  const styles = useMultiStyleConfig("ChoiceChip", {
-    size,
-    chipType,
-    variant,
-    icon,
-    hasLabel: Boolean(children),
-  });
+    const id = `choice-chip-${useId()}`;
 
-  const id = `choice-chip-${useId()}`;
-
-  return (
-    <chakra.label
-      htmlFor={id}
-      {...getRootProps()}
-      aria-label={String(children)}
-    >
-      <chakra.input {...getInputProps({}, ref)} id={id} disabled={isDisabled} />
-      <chakra.div
-        {...getLabelProps()}
-        __css={styles.container}
-        data-checked={dataAttr(state.isChecked)}
-        data-hover={dataAttr(state.isHovered)}
-        data-focus={dataAttr(state.isFocused)}
-        data-active={dataAttr(state.isActive)}
-        data-disabled={dataAttr(state.isDisabled)}
+    return (
+      <chakra.label
+        htmlFor={id}
+        {...getRootProps()}
+        aria-label={String(children)}
       >
-        {icon && (
-          <chakra.span __css={styles.icon}>
-            {state.isChecked ? icon.checked : icon.default}
-          </chakra.span>
-        )}
+        <chakra.input
+          {...getInputProps({}, ref)}
+          id={id}
+          disabled={isDisabled}
+        />
+        <chakra.div
+          {...getLabelProps()}
+          __css={styles.container}
+          data-checked={dataAttr(state.isChecked)}
+          data-hover={dataAttr(state.isHovered)}
+          data-focus={dataAttr(state.isFocused)}
+          data-active={dataAttr(state.isActive)}
+          data-disabled={dataAttr(state.isDisabled)}
+        >
+          {icon && (
+            <chakra.span __css={styles.icon}>
+              {state.isChecked ? icon.checked : icon.default}
+            </chakra.span>
+          )}
+          {chipType !== "icon" && (
+            <chakra.span __css={styles.label} {...getCheckboxProps()}>
+              {children}
+            </chakra.span>
+          )}
 
-        <chakra.span __css={styles.label} {...getCheckboxProps()}>
-          {chipType !== "icon" && children}
-        </chakra.span>
-        {chipType === "filter" && state.isChecked && (
-          <CloseOutline24Icon marginLeft={1.5} />
-        )}
-      </chakra.div>
-    </chakra.label>
-  );
-});
+          {chipType === "filter" && state.isChecked && (
+            <CloseOutline24Icon marginLeft={1.5} />
+          )}
+        </chakra.div>
+      </chakra.label>
+    );
+  },
+);

--- a/packages/spor-react/src/input/ChoiceChip.tsx
+++ b/packages/spor-react/src/input/ChoiceChip.tsx
@@ -62,7 +62,7 @@ export const ChoiceChip = forwardRef(
       isChecked,
       isDisabled,
       size = "sm",
-      chipType,
+      chipType = "choice",
       variant = "base",
       ...props
     }: ChoiceChipProps,


### PR DESCRIPTION
## Background

There was an error in console on props for ChoiceChip

## Solution

- Moved props from variable to function parameters
- Added a condition to hasLabel

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)
- [x] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Go to components/choice-chip

No error in the console :)
