### PR TITLE
LineTag: Fix type error on props

### DIFF
--- a/.changeset/dull-toes-kiss.md
+++ b/.changeset/dull-toes-kiss.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+LineTag: Fix bugs with props

--- a/packages/spor-react/src/linjetag/LineIcon.tsx
+++ b/packages/spor-react/src/linjetag/LineIcon.tsx
@@ -1,19 +1,14 @@
 import { Box, BoxProps, useMultiStyleConfig } from "@chakra-ui/react";
 import React from "react";
 import { getCorrectIcon } from "./icons";
-import { TagProps } from "./types";
+import { CustomVariantProps, TagProps } from "./types";
 
 type DefaultVariants = Exclude<TagProps["variant"], "custom">;
 
 type DefaultVariantProps = {
   variant: DefaultVariants;
 };
-type CustomVariantProps = {
-  variant: "custom";
-  customIconVariant: DefaultVariants;
-  foregroundColor: string;
-  backgroundColor: string;
-};
+
 type VariantProps = DefaultVariantProps | CustomVariantProps;
 
 export type LineIconProps = Exclude<BoxProps, "variant"> &
@@ -70,7 +65,7 @@ export const LineIcon = ({
     return null;
   }
   return (
-    <Box sx={{ ...styles.iconContainer, ...sx }} {...rest}>
+    <Box sx={{ ...styles.iconContainer, ...sx }}>
       <Icon sx={styles.icon} />
     </Box>
   );

--- a/packages/spor-react/src/linjetag/TravelTag.tsx
+++ b/packages/spor-react/src/linjetag/TravelTag.tsx
@@ -21,6 +21,9 @@ export type TravelTagProps = TagProps &
   BoxProps & {
     deviationLevel?: "critical" | "major" | "minor" | "info" | "none";
     isDisabled?: boolean;
+    foregroundColor?: string;
+    backgroundColor?: string;
+    customIconVariant?: string;
   };
 
 /**
@@ -82,6 +85,9 @@ export const TravelTag = forwardRef<TravelTagProps, As>(
       title,
       description,
       isDisabled,
+      foregroundColor,
+      backgroundColor,
+      customIconVariant,
       ...rest
     },
     ref,
@@ -90,8 +96,8 @@ export const TravelTag = forwardRef<TravelTagProps, As>(
       variant,
       size,
       deviationLevel,
-      foregroundColor: variant === "custom" ? rest.foregroundColor : undefined,
-      backgroundColor: variant === "custom" ? rest.backgroundColor : undefined,
+      foregroundColor: variant === "custom" ? foregroundColor : undefined,
+      backgroundColor: variant === "custom" ? backgroundColor : undefined,
     });
 
     const DeviationLevelIcon = getDeviationLevelIcon({ deviationLevel, size });
@@ -102,6 +108,9 @@ export const TravelTag = forwardRef<TravelTagProps, As>(
           variant={variant}
           size={size}
           sx={styles.iconContainer}
+          foregroundColor={foregroundColor}
+          backgroundColor={backgroundColor}
+          customIconVariant={customIconVariant}
           {...(rest as any)}
         />
         <Box sx={styles.textContainer}>

--- a/packages/spor-react/src/linjetag/types.ts
+++ b/packages/spor-react/src/linjetag/types.ts
@@ -25,7 +25,7 @@ export type TagProps = VariantProps & {
 type DefaultVariantProps = {
   variant: Variant;
 };
-type CustomVariantProps = {
+export type CustomVariantProps = {
   variant: "custom";
   /** When variant="custom", the foreground color of the tag */
   foregroundColor: string;


### PR DESCRIPTION
## Background

Console was complaining of errors for props. I moved the props to the right type declarations and removed props-spreading from the icon container.