### PR TITLE
Input: Rearrange accessibility labels

### DIFF
--- a/.changeset/heavy-jokes-juggle.md
+++ b/.changeset/heavy-jokes-juggle.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Input: Rearranging the accessibility labels

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -38,7 +38,7 @@ export const Input = forwardRef<InputProps, "input">(
     const formControlProps = useFormControlContext();
     const fallbackId = `input-${useId()}`;
     const inputId = id ?? formControlProps?.id ?? fallbackId;
-
+    const labelId = `${useId()}-label`;
     return (
       <InputGroup position="relative">
         {leftIcon && (
@@ -50,10 +50,13 @@ export const Input = forwardRef<InputProps, "input">(
           paddingRight={rightIcon ? 7 : undefined}
           {...props}
           id={inputId}
+          aria-labelledby={labelId}
           ref={ref}
           placeholder=" " // This is needed to make the label work as expected
         />
-        <FormLabel htmlFor={inputId}>{label}</FormLabel>
+        <FormLabel htmlFor={inputId} id={labelId}>
+          {label}
+        </FormLabel>
         {rightIcon && (
           <InputRightElement pointerEvents="none">
             {rightIcon}

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -38,6 +38,7 @@ export const Input = forwardRef<InputProps, "input">(
     const formControlProps = useFormControlContext();
     const fallbackId = `input-${useId()}`;
     const inputId = id ?? formControlProps?.id ?? fallbackId;
+
     return (
       <InputGroup position="relative">
         {leftIcon && (
@@ -49,7 +50,6 @@ export const Input = forwardRef<InputProps, "input">(
           paddingRight={rightIcon ? 7 : undefined}
           {...props}
           id={inputId}
-          aria-labelledby={inputId}
           ref={ref}
           placeholder=" " // This is needed to make the label work as expected
         />


### PR DESCRIPTION
## Background

Some confusion with aria-labels on Input.

## Solution

- Added new id for label. Set id to label. Change aria-label on input to label id.

