### PR TITLE
Added floating variant to input

### DIFF
--- a/.changeset/gorgeous-eagles-hope.md
+++ b/.changeset/gorgeous-eagles-hope.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Added variant floating to input component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^2.9.0",
         "@vygruppen/spor-icon-react": "^3.9.0",
-        "@vygruppen/spor-react": "^10.0.0",
+        "@vygruppen/spor-react": "^10.1.0",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "10.0.0",
+      "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/react";
 import React, { useId } from "react";
 
-export type InputProps = Omit<ChakraInputProps, "variant" | "size"> & {
+export type InputProps = Omit<ChakraInputProps, "size"> & {
   /** The input's label */
   label: string;
   /** Icon that shows up to the left */
@@ -31,6 +31,12 @@ export type InputProps = Omit<ChakraInputProps, "variant" | "size"> & {
  *
  * ```tsx
  * <Input label="E-mail" leftIcon={<EmailOutline24Icon />} />
+ * ```
+ *
+ * Input has two variants base, and floating.
+ *
+ * ```tsx
+ * <Input label="E-mail" leftIcon={<EmailOutline24Icon />} variant="floating" />
  * ```
  */
 export const Input = forwardRef<InputProps, "input">(

--- a/packages/spor-react/src/theme/components/input.ts
+++ b/packages/spor-react/src/theme/components/input.ts
@@ -1,16 +1,9 @@
-// import { inputAnatomy as parts } from "@chakra-ui/anatomy";
-import { anatomy } from "@chakra-ui/anatomy";
+import { inputAnatomy as parts } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
 import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { surface } from "../utils/surface-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
-
-const parts = anatomy("Input").parts(
-  "field",
-  "element",
-  "group"
-)
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
@@ -83,14 +76,14 @@ const config = helpers.defineMultiStyleConfig({
       field: {
         ...baseBackground("default", props),
         ...baseBorder("default", props),
-      }
+      },
     }),
     floating: (props) => ({
       field: {
         boxShadow: "sm",
         ...floatingBackground("default", props),
         ...floatingBorder("default", props),
-        
+
         _hover: {
           ...floatingBorder("hover", props),
           ...floatingBackground("hover", props),
@@ -102,13 +95,13 @@ const config = helpers.defineMultiStyleConfig({
         _selected: {
           ...floatingBorder("selected", props),
           ...floatingBackground("selected", props),
-        }
+        },
       },
     }),
   },
   defaultProps: {
-    variant: "base"
-  }
+    variant: "base",
+  },
 });
 
 export default config;

--- a/packages/spor-react/src/theme/components/input.ts
+++ b/packages/spor-react/src/theme/components/input.ts
@@ -1,8 +1,16 @@
-import { inputAnatomy as parts } from "@chakra-ui/anatomy";
+// import { inputAnatomy as parts } from "@chakra-ui/anatomy";
+import { anatomy } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
 import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { surface } from "../utils/surface-utils";
+import { floatingBackground, floatingBorder } from "../utils/floating-utils";
+
+const parts = anatomy("Input").parts(
+  "field",
+  "element",
+  "group"
+)
 
 const helpers = createMultiStyleConfigHelpers(parts.keys);
 
@@ -20,9 +28,6 @@ const config = helpers.defineMultiStyleConfig({
       paddingX: 3,
       height: 8,
       fontSize: "mobile.md",
-      ...baseBackground("default", props),
-
-      ...baseBorder("default", props),
       _hover: {
         ...baseBorder("hover", props),
       },
@@ -73,6 +78,37 @@ const config = helpers.defineMultiStyleConfig({
       },
     },
   }),
+  variants: {
+    base: (props) => ({
+      field: {
+        ...baseBackground("default", props),
+        ...baseBorder("default", props),
+      }
+    }),
+    floating: (props) => ({
+      field: {
+        boxShadow: "sm",
+        ...floatingBackground("default", props),
+        ...floatingBorder("default", props),
+        
+        _hover: {
+          ...floatingBorder("hover", props),
+          ...floatingBackground("hover", props),
+        },
+        _active: {
+          ...floatingBorder("active", props),
+          ...floatingBackground("active", props),
+        },
+        _selected: {
+          ...floatingBorder("selected", props),
+          ...floatingBackground("selected", props),
+        }
+      },
+    }),
+  },
+  defaultProps: {
+    variant: "base"
+  }
 });
 
 export default config;


### PR DESCRIPTION
## Background

Floating variant for component input is made in the component library in Figma, but not yet implemented.

https://www.figma.com/design/Tmr2URVX2vNkyRLqKhNRQA/Vy_komponentbibliotek?node-id=607-0&t=4fQsGIk3cx9YZ6eG-0

## Solution

Add functionality to set variant for input component, and add styling for variant _floating_.

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)
- [ ] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Desribe how code reviewer may test your solution (what page, expected result).

## Screenshots

| Before | After |
| ------ | ----- |
| ![bilde](https://github.com/nsbno/spor/assets/155733601/57863218-b33b-4897-8268-7b40dc13ba2a)|![bilde](https://github.com/nsbno/spor/assets/155733601/59f0177b-869f-4321-8b04-3e27da341620)|
