### PR TITLE
Add h1 tag to title

### DIFF
--- a/.changeset/bright-walls-exist.md
+++ b/.changeset/bright-walls-exist.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Modal: Add h1 tag to title

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^2.9.0",
         "@vygruppen/spor-icon-react": "^3.9.0",
-        "@vygruppen/spor-react": "^10.0.0",
+        "@vygruppen/spor-react": "^10.1.0",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "10.0.0",
+      "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/modal/ModalHeader.tsx
+++ b/packages/spor-react/src/modal/ModalHeader.tsx
@@ -26,6 +26,6 @@ export const ModalHeader = forwardRef<ModalHeaderProps, "header">(
           ? "center"
           : ("left" as ChakraModalHeaderProps["textAlign"]),
     };
-    return <ChakraModalHeader {...props} ref={ref} {...styles} />;
+    return <ChakraModalHeader as={"h1"} {...props} ref={ref} {...styles} />;
   },
 );


### PR DESCRIPTION
## Background

Accessibility says the title should be h1, not header tag.

## Solution

Added header tag.

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)
- [ ] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

/components/modal
