### PR TITLE
Added context prop to nummeric stepper to improve voiceover support

### DIFF
--- a/.changeset/chilled-rockets-accept.md
+++ b/.changeset/chilled-rockets-accept.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Added input field ariaLabelContext to NummericStepper to improve functionality with screen readers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^2.9.0",
         "@vygruppen/spor-icon-react": "^3.9.0",
-        "@vygruppen/spor-react": "^10.1.0",
+        "@vygruppen/spor-react": "^10.2.0",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "10.1.0",
+      "version": "10.2.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -35,6 +35,8 @@ type NumericStepperProps = {
   stepSize?: number;
   /** Whether to show the number input when value is zero  */
   showZero?: boolean;
+  /** Name added to the aria-label of subtract and add buttons. */
+  ariaLabelContext?: { singular: string; plural: string };
 } & Omit<BoxProps, "onChange">;
 /** A simple stepper component for integer values
  *
@@ -72,6 +74,7 @@ export function NumericStepper({
   withInput = true,
   stepSize = 1,
   showZero = false,
+  ariaLabelContext = { singular: "", plural: "" },
   ...boxProps
 }: NumericStepperProps) {
   const { t } = useTranslation();
@@ -88,7 +91,12 @@ export function NumericStepper({
     <Flex __css={styles.container} {...boxProps}>
       <VerySmallButton
         icon={<SubtractIcon stepLabel={clampedStepSize} />}
-        aria-label={t(texts.decrementButtonAriaLabel(clampedStepSize))}
+        aria-label={t(
+          texts.decrementButtonAriaLabel(
+            clampedStepSize,
+            stepSize == 1 ? ariaLabelContext.singular : ariaLabelContext.plural,
+          ),
+        )}
         onClick={() => onChange(Math.max(value - clampedStepSize, minValue))}
         visibility={value <= minValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
@@ -107,7 +115,10 @@ export function NumericStepper({
           width={`${Math.max(value.toString().length + 1, 3)}ch`}
           visibility={!showZero && value === 0 ? "hidden" : "visible"}
           aria-live="assertive"
-          aria-label={value.toString()}
+          aria-label={
+            value.toString() +
+            ` ${value == 1 ? ariaLabelContext.singular : ariaLabelContext.plural}`
+          }
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             const numericInput = Number(e.target.value);
             if (Number.isNaN(numericInput)) {
@@ -120,14 +131,22 @@ export function NumericStepper({
         <chakra.text
           sx={styles.text}
           visibility={!showZero && value === 0 ? "hidden" : "visible"}
-          aria-label={value.toString()}
+          aria-label={
+            value.toString() +
+            ` ${value == 1 ? ariaLabelContext.singular : ariaLabelContext.plural}`
+          }
         >
           {value}
         </chakra.text>
       )}
       <VerySmallButton
         icon={<AddIcon stepLabel={clampedStepSize} />}
-        aria-label={t(texts.incrementButtonAriaLabel(clampedStepSize))}
+        aria-label={t(
+          texts.incrementButtonAriaLabel(
+            clampedStepSize,
+            stepSize == 1 ? ariaLabelContext.singular : ariaLabelContext.plural,
+          ),
+        )}
         onClick={() => onChange(Math.min(value + clampedStepSize, maxValue))}
         visibility={value >= maxValue ? "hidden" : "visible"}
         isDisabled={formControlProps.disabled}
@@ -221,20 +240,20 @@ const AddIcon = ({ stepLabel, ...props }: IconPropTypes) => (
 );
 
 const texts = createTexts({
-  decrementButtonAriaLabel(stepSize) {
+  decrementButtonAriaLabel(stepSize, ariaContext) {
     return {
-      nb: `Trekk fra ${stepSize}`,
-      en: `Subtract ${stepSize}`,
-      nn: `Trekk frå ${stepSize}`,
-      sv: `Subtrahera ${stepSize}`,
+      nb: `Trekk fra ${stepSize} ${ariaContext}`,
+      en: `Subtract ${stepSize} ${ariaContext}`,
+      nn: `Trekk frå ${stepSize} ${ariaContext}`,
+      sv: `Subtrahera ${stepSize} ${ariaContext}`,
     };
   },
-  incrementButtonAriaLabel(stepSize) {
+  incrementButtonAriaLabel(stepSize, ariaContext) {
     return {
-      nb: `Legg til ${stepSize}`,
-      en: `Add ${stepSize}`,
-      nn: `Legg til ${stepSize}`,
-      sv: `Lägg till ${stepSize}`,
+      nb: `Legg til ${stepSize} ${ariaContext}`,
+      en: `Add ${stepSize} ${ariaContext}`,
+      nn: `Legg til ${stepSize} ${ariaContext}`,
+      sv: `Lägg till ${stepSize} ${ariaContext}`,
     };
   },
 });

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -125,7 +125,11 @@ export function NumericStepper({
           width={`${Math.max(value.toString().length + 1, 3)}ch`}
           visibility={!showZero && value === 0 ? "hidden" : "visible"}
           aria-live="assertive"
-          aria-label={t(texts.currentNumberAriaLabel(ariaLabelContext.plural))}
+          aria-label={
+            ariaLabelContext.plural !== ""
+              ? t(texts.currentNumberAriaLabel(ariaLabelContext.plural))
+              : ""
+          }
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             const numericInput = Number(e.target.value);
             if (Number.isNaN(numericInput)) {
@@ -145,7 +149,11 @@ export function NumericStepper({
           sx={styles.text}
           visibility={!showZero && value === 0 ? "hidden" : "visible"}
           aria-live="assertive"
-          aria-label={t(texts.currentNumberAriaLabel(ariaLabelContext.plural))}
+          aria-label={
+            ariaLabelContext.plural !== ""
+              ? t(texts.currentNumberAriaLabel(ariaLabelContext.plural))
+              : ""
+          }
         >
           {value}
         </chakra.text>
@@ -261,7 +269,7 @@ const texts = createTexts({
   currentNumberAriaLabel(ariaContext) {
     return {
       nb: `Valgt antall ${ariaContext}`,
-      en: `Chosen number of ${ariaContext || "elements"}`,
+      en: `Chosen number of ${ariaContext}`,
       nn: `Valgt antall ${ariaContext}`,
       sv: `Valgt antall ${ariaContext}`,
     };

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -93,11 +93,7 @@ export function NumericStepper({
   };
 
   return (
-    <Flex
-      __css={styles.container}
-      {...boxProps}
-      // aria-label={t(texts.groupAriaLabel(ariaLabelContext.plural, value))}
-    >
+    <Flex __css={styles.container} {...boxProps}>
       <VerySmallButton
         icon={<SubtractIcon stepLabel={clampedStepSize} />}
         aria-label={t(
@@ -128,6 +124,7 @@ export function NumericStepper({
           sx={styles.input}
           width={`${Math.max(value.toString().length + 1, 3)}ch`}
           visibility={!showZero && value === 0 ? "hidden" : "visible"}
+          aria-live="assertive"
           aria-label={t(texts.currentNumberAriaLabel(ariaLabelContext.plural))}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             const numericInput = Number(e.target.value);
@@ -147,6 +144,7 @@ export function NumericStepper({
         <chakra.text
           sx={styles.text}
           visibility={!showZero && value === 0 ? "hidden" : "visible"}
+          aria-live="assertive"
           aria-label={t(texts.currentNumberAriaLabel(ariaLabelContext.plural))}
         >
           {value}
@@ -260,14 +258,6 @@ const AddIcon = ({ stepLabel, ...props }: IconPropTypes) => (
 );
 
 const texts = createTexts({
-  groupAriaLabel(ariaContext, value) {
-    return {
-      nb: `Legg til eller fjern antall ${ariaContext || "elementer"}. Verdien er nå ${value}.`,
-      en: `Add or remove number of ${ariaContext || "elements"}. Current value is ${value}.`,
-      nn: `Legg til eller fjern antall ${ariaContext || "elementer"}. Nå er verdien ${value}.`,
-      sv: `Lägg till eller fjern antall ${ariaContext || "elementer"}. Nu er verdien ${value}.`,
-    };
-  },
   currentNumberAriaLabel(ariaContext) {
     return {
       nb: `Valgt antall ${ariaContext}`,


### PR DESCRIPTION
## Background

Using screen readers with today's solution reads out add 1 and subtract 1, but does not allow us to provide any context to what to add 1 of.

In addition, when navigation using only keyboard there was an issue with focus changes. When we press the minus button so that the value goes to zero, the button disapears, moving the focus to the top of the page.

## Solution

Added a new input parameter and updated the aria-labels to allow us to provide a context in both singular and plural form.

Additionally, added functionality to move the focus to the plus-button when the minus button disapears.

## UU checks

- [x] It works with VoiceOver
- [x] Sanity documentation has been / will be updated (if neccessary)
- [x] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Test the component in playground using screen reader.
Not including the new prop should yield no changes. E.g. `<NumericStepper />`
Including the new prop should add more information to the minus- and plus button, and to the number. E.g. `<NumericStepper ariaContext={{singular: "adult", plural: "adults"}}/>`
