### PR TITLE
Adjust deviation icons for line tags, to make them more inline with figma

### DIFF
--- a/.changeset/blue-adults-fetch.md
+++ b/.changeset/blue-adults-fetch.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Changed styling of LineTag deviation icons to be more similar to the design

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^2.9.0",
         "@vygruppen/spor-icon-react": "^3.9.0",
-        "@vygruppen/spor-react": "^10.1.0",
+        "@vygruppen/spor-react": "^10.2.0",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "10.1.0",
+      "version": "10.2.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/theme/components/travel-tag.ts
+++ b/packages/spor-react/src/theme/components/travel-tag.ts
@@ -242,7 +242,6 @@ const getDeviationIconStyle = (props: StyleFunctionProps) => {
     right: "0",
     transform: "translate(50%, -50%)",
     zIndex: "banner",
-    stroke: "white",
     color:
       deviationIconColor[
         props.deviationLevel as keyof typeof deviationIconColor
@@ -252,7 +251,5 @@ const getDeviationIconStyle = (props: StyleFunctionProps) => {
 
 const deviationIconColor = {
   critical: "brightRed",
-  major: "golden",
-  minor: "golden",
   info: "ocean",
 } as const;


### PR DESCRIPTION
## Background

There was a rather large difference in how the deviation icons for the line tags was styled in spor compared to figma.
Confering with designers, it was said that the icons in the App looked to be correct

## Solution

Removed stroke from deviationIconStyle and removed golden color for minor and major for color from deviationIconColor, in order to use "default" svg color

This makes it more inline to how the icons are used in the travelTag in the App:
https://github.com/nsbno/salgsapp-react-native/blob/aed64cd14564d7ea3e7f6899ac8e8846b361e256/app/spor/linetag/TravelTag.tsx#L89

## UU checks

- [X] It is possible to use the keyboard to reach your changes
- [X] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)
- [ ] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Paste this code in playground when running spor locally:

```
<Flex gap={1} flexWrap="wrap">
  <TravelTag 
    variant="local-train" 
    title="L1" 
    description="Lillestrøm"
    deviationLevel="critical"
  />
  <TravelTag 
    variant="local-train" 
    title="L1" 
    description="Lillestrøm"
    deviationLevel="major"
  />
  <TravelTag 
    variant="local-train" 
    title="L1" 
    description="Lillestrøm"
    deviationLevel="minor"
  />
  <TravelTag 
    variant="local-train" 
    title="L1" 
    description="Lillestrøm"
    deviationLevel="info"
  />
</Flex>
```

## Screenshots
| Before | After |
| ------ | ----- |
| <img width="598" alt="image" src="https://github.com/user-attachments/assets/a7f23bb2-98b4-464a-9c83-5651f8486fad">|<img width="596" alt="image" src="https://github.com/user-attachments/assets/38a7c089-5f7f-4d16-a098-bf3646694d07">|
