### PR TITLE
z-index adjustment for deviation icon

### DIFF
--- a/.changeset/blue-adults-fetch.md
+++ b/.changeset/blue-adults-fetch.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Changed styling of LineTag deviation icons to be more similar to the design

--- a/.changeset/silver-crabs-laugh.md
+++ b/.changeset/silver-crabs-laugh.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+adjusted z-index of the TravelTag deviation icon, so that it does not end atop banners and dropdowns e.t.c

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^2.9.0",
         "@vygruppen/spor-icon-react": "^3.9.0",
-        "@vygruppen/spor-react": "^10.1.0",
+        "@vygruppen/spor-react": "^10.2.0",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "10.1.0",
+      "version": "10.2.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/theme/components/travel-tag.ts
+++ b/packages/spor-react/src/theme/components/travel-tag.ts
@@ -241,7 +241,7 @@ const getDeviationIconStyle = (props: StyleFunctionProps) => {
     top: "0",
     right: "0",
     transform: "translate(50%, -50%)",
-    zIndex: "banner",
+    zIndex: "docked",
     color:
       deviationIconColor[
         props.deviationLevel as keyof typeof deviationIconColor

--- a/packages/spor-react/src/theme/components/travel-tag.ts
+++ b/packages/spor-react/src/theme/components/travel-tag.ts
@@ -242,7 +242,6 @@ const getDeviationIconStyle = (props: StyleFunctionProps) => {
     right: "0",
     transform: "translate(50%, -50%)",
     zIndex: "banner",
-    stroke: "white",
     color:
       deviationIconColor[
         props.deviationLevel as keyof typeof deviationIconColor
@@ -252,7 +251,5 @@ const getDeviationIconStyle = (props: StyleFunctionProps) => {
 
 const deviationIconColor = {
   critical: "brightRed",
-  major: "golden",
-  minor: "golden",
   info: "ocean",
 } as const;


### PR DESCRIPTION
## Background

The TravelTag deviation icons has a very high z-index, which causes the icons to float atop banners and such

## Solution

Reduce the z-index for the TravelTag deviation icons

## UU checks

- [X] It is possible to use the keyboard to reach your changes
- [X] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [X] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)
- [ ] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/e2b0cc01-6baf-485d-b3f3-46933f6e3fb4)

