### PR TITLE
Added overflow=hidden to <Input/>

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.46",
+  "version": "0.0.47",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/docs": {
       "name": "@vygruppen/docs",
-      "version": "0.0.46",
+      "version": "0.0.47",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/docs": {
       "name": "@vygruppen/docs",
-      "version": "0.0.45",
+      "version": "0.0.46",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^2.9.0",
         "@vygruppen/spor-icon-react": "^3.9.0",
-        "@vygruppen/spor-react": "^10.3.0",
+        "@vygruppen/spor-react": "^10.4.1",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "10.3.0",
+      "version": "10.4.1",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -46,7 +46,7 @@ export const Input = forwardRef<InputProps, "input">(
     const inputId = id ?? formControlProps?.id ?? fallbackId;
     const labelId = `${useId()}-label`;
     return (
-      <InputGroup position="relative" overflow="hidden" padding="1px">
+      <InputGroup position="relative">
         {leftIcon && (
           <InputLeftElement pointerEvents="none">{leftIcon}</InputLeftElement>
         )}
@@ -58,6 +58,7 @@ export const Input = forwardRef<InputProps, "input">(
           id={inputId}
           aria-labelledby={labelId}
           ref={ref}
+          overflow="hidden"
           placeholder=" " // This is needed to make the label work as expected
         />
         <FormLabel htmlFor={inputId} id={labelId}>

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -6,7 +6,7 @@ import {
   InputLeftElement,
   InputRightElement,
   forwardRef,
-  useFormControlContext,
+  useFormControlContext
 } from "@chakra-ui/react";
 import React, { useId } from "react";
 
@@ -46,7 +46,7 @@ export const Input = forwardRef<InputProps, "input">(
     const inputId = id ?? formControlProps?.id ?? fallbackId;
     const labelId = `${useId()}-label`;
     return (
-      <InputGroup position="relative">
+      <InputGroup position="relative" overflow="hidden" padding="1px">
         {leftIcon && (
           <InputLeftElement pointerEvents="none">{leftIcon}</InputLeftElement>
         )}

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -6,7 +6,7 @@ import {
   InputLeftElement,
   InputRightElement,
   forwardRef,
-  useFormControlContext
+  useFormControlContext,
 } from "@chakra-ui/react";
 import React, { useId } from "react";
 


### PR DESCRIPTION
## Background
https://trello.com/c/DQAfaqop/6525-oppdatere-inputgroup-spor-komponent-for-react-til-%C3%A5-ha-overflowhidden

Long labels ran outside the input field.

## Solution

Added `overflow="hidden"` to `ChakraInput`

## UU checks

- [x] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Writing a long text in an inputField should be contained inside the input field
