### PR TITLE
Change icon size for Alert Cards

### DIFF
--- a/.changeset/wet-cheetahs-reflect.md
+++ b/.changeset/wet-cheetahs-reflect.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Changed the icon size for alert cards to be 18

--- a/packages/spor-react/src/alert/AlertIcon.tsx
+++ b/packages/spor-react/src/alert/AlertIcon.tsx
@@ -1,8 +1,13 @@
 import {
+  AltTransportOutline18Icon,
   AltTransportOutline24Icon,
+  ErrorOutline18Icon,
   ErrorOutline24Icon,
+  InformationOutline18Icon,
   InformationOutline24Icon,
+  SuccessOutline18Icon,
   SuccessOutline24Icon,
+  WarningOutline18Icon,
   WarningOutline24Icon,
 } from "@vygruppen/spor-icon-react";
 import React from "react";
@@ -29,15 +34,15 @@ export const AlertIcon = ({ variant }: AlertIconProps) => {
 const getIcon = (variant: BaseAlertProps["variant"]) => {
   switch (variant) {
     case "info":
-      return InformationOutline24Icon;
+      return InformationOutline18Icon;
     case "success":
-      return SuccessOutline24Icon;
+      return SuccessOutline18Icon;
     case "warning":
-      return WarningOutline24Icon;
+      return WarningOutline18Icon;
     case "alt-transport":
-      return AltTransportOutline24Icon;
+      return AltTransportOutline18Icon;
     case "error":
-      return ErrorOutline24Icon;
+      return ErrorOutline18Icon;
   }
 };
 

--- a/packages/spor-react/src/alert/AlertIcon.tsx
+++ b/packages/spor-react/src/alert/AlertIcon.tsx
@@ -1,14 +1,9 @@
 import {
   AltTransportOutline18Icon,
-  AltTransportOutline24Icon,
   ErrorOutline18Icon,
-  ErrorOutline24Icon,
   InformationOutline18Icon,
-  InformationOutline24Icon,
   SuccessOutline18Icon,
-  SuccessOutline24Icon,
   WarningOutline18Icon,
-  WarningOutline24Icon,
 } from "@vygruppen/spor-icon-react";
 import React from "react";
 import { createTexts, useTranslation } from "../i18n";
@@ -26,6 +21,7 @@ export const AlertIcon = ({ variant }: AlertIconProps) => {
       flexShrink={0}
       aria-label={t(texts[variant])}
       marginRight={1}
+      marginTop={0.5}
       color="darkGrey"
     />
   );


### PR DESCRIPTION
## Background

The icon for the AlertCards are as of now to large at 24, when they should be 18, as seen in the desing
https://www.figma.com/design/Tmr2URVX2vNkyRLqKhNRQA/Vy_komponentbibliotek?node-id=12418-187466&m=dev

## Solution

Change the icon size for the AlertCards to 18

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)
- [ ] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Launch spor locally and paste the following code in the live editor:
``` 
<StaticAlert variant="info">
  Det er arbeid på strekningen Oslo - Drammen, som kan føre til ekstra mye å se på om man har vindusplass.
</StaticAlert>
```
## Screenshots

| Before | After |
| ------ | ----- |
|        |         |
