### PR TITLE
Switch: Small change for accessibility

### DIFF
--- a/.changeset/pink-walls-prove.md
+++ b/.changeset/pink-walls-prove.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Switch: Update accessibility

--- a/apps/docs/app/root/layout/SiteSettings.tsx
+++ b/apps/docs/app/root/layout/SiteSettings.tsx
@@ -46,8 +46,11 @@ export const SiteSettings = ({ showLabel }: SiteSettingsProps) => {
           <Stack gap={3}>
             <BrandSwitcher />
             <FormControl display="flex" alignItems="center" gap={3}>
-              <FormLabel margin="0">Dark mode</FormLabel>
+              <FormLabel margin="0" htmlFor="site-settings-dark-mode">
+                Dark mode
+              </FormLabel>
               <Switch
+                id="site-settings-dark-mode"
                 size="sm"
                 onChange={() => toggleColorMode()}
                 defaultChecked={colorMode === "dark"}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.44",
+  "version": "0.0.45",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/packages/spor-react/src/input/Switch.tsx
+++ b/packages/spor-react/src/input/Switch.tsx
@@ -32,6 +32,6 @@ export type SwitchProps = Omit<ChakraSwitchProps, "colorScheme" | "variant"> & {
  */
 export const Switch = forwardRef<SwitchProps, "input">(
   ({ size = "md", ...props }: SwitchProps, ref) => {
-    return <ChakraSwitch size={size} {...props} ref={ref} />;
+    return <ChakraSwitch as="div" size={size} {...props} ref={ref} />;
   },
 );

--- a/packages/spor-react/src/input/Switch.tsx
+++ b/packages/spor-react/src/input/Switch.tsx
@@ -1,4 +1,5 @@
 import {
+  As,
   Switch as ChakraSwitch,
   SwitchProps as ChakraSwitchProps,
   forwardRef,
@@ -7,6 +8,7 @@ import React from "react";
 
 export type SwitchProps = Omit<ChakraSwitchProps, "colorScheme" | "variant"> & {
   size?: "sm" | "md" | "lg";
+  as?: As;
 };
 
 /**
@@ -31,7 +33,7 @@ export type SwitchProps = Omit<ChakraSwitchProps, "colorScheme" | "variant"> & {
  * ```
  */
 export const Switch = forwardRef<SwitchProps, "input">(
-  ({ size = "md", ...props }: SwitchProps, ref) => {
-    return <ChakraSwitch as="div" size={size} {...props} ref={ref} />;
+  ({ size = "md", as = "div", ...props }: SwitchProps, ref) => {
+    return <ChakraSwitch as={as} size={size} {...props} ref={ref} />;
   },
 );


### PR DESCRIPTION
## Background

An empty label-tag was floating from Chakra UI component.

## Solution

Changed component to take in  as-prop. This defaults to div. Will probably not be necessary to use anything else but it's possible to change.

## UU checks

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)
- [ ] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Run Wave on /components/switch. Should be 7 errors for the 7 components without label.

