### PR TITLE
Update version for remote docker in circleCi config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
     working_directory: /tmp/workspace/apps/docs
     steps:
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker24
           docker_layer_caching: true
       - checkout:
           path: ../../


### PR DESCRIPTION
## Background

CircleCi announced that older remote image versions will receive a 24-hour brownout period on August 28th, pending EOL on September 30th.

## Solution

Update version for remote docker in circleCi config, as specified in their support article