### PR TITLE
Added the option to display optional phone number

### DIFF
--- a/.changeset/chilled-cheetahs-applaud.md
+++ b/.changeset/chilled-cheetahs-applaud.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-react": minor
 ---
 
-Added the option to display phonenumber as optional
+PhoneNumberInput: Added the option to display the input as optional

--- a/.changeset/chilled-cheetahs-applaud.md
+++ b/.changeset/chilled-cheetahs-applaud.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Added the option to display phonenumber as optional

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.47",
+  "version": "0.0.48",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.48",
+  "version": "0.0.47",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -25,6 +25,7 @@ type PhoneNumberInputProps = Omit<BoxProps, "onChange"> & {
   /** The optional value of the country code and phone number */
   value?: CountryCodeAndPhoneNumber;
   variant?: "base" | "floating";
+  isOptional?: boolean;
 };
 /**
  * A component for entering phone numbers.
@@ -51,12 +52,13 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
       value: externalValue,
       onChange: externalOnChange,
       variant,
+      isOptional,
       ...boxProps
     },
     ref,
   ) => {
     const { t } = useTranslation();
-    const label = externalLabel ?? t(texts.phoneNumber);
+    const label = externalLabel ?? isOptional ? t(texts.phoneNumberOptional) : t(texts.phoneNumber);
     const [value, onChange] = useControllableState({
       value: externalValue,
       onChange: externalOnChange,
@@ -124,6 +126,12 @@ const texts = createTexts({
     nn: "Telefonnummer",
     en: "Phone number",
     sv: "Telefonnummer",
+  },
+  phoneNumberOptional: {
+    nb: "Telefonnummer (valgfritt)",
+    nn: "Telefonnummer (valgfritt)",
+    en: "Phone number (optional)",
+    sv: "Telefonnummer (valfritt)",
   },
   countryCodeLabel: {
     nb: "Landskode",

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -58,7 +58,10 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
     ref,
   ) => {
     const { t } = useTranslation();
-    const label = externalLabel ?? isOptional ? t(texts.phoneNumberOptional) : t(texts.phoneNumber);
+    const label =
+      externalLabel ?? isOptional
+        ? t(texts.phoneNumberOptional)
+        : t(texts.phoneNumber);
     const [value, onChange] = useControllableState({
       value: externalValue,
       onChange: externalOnChange,


### PR DESCRIPTION
## Background

The phoneNumberInput at the Swedish payment page are optional for not-main travellers, but currently not visible for the user that it is

## Solution

Add prop to be able to show that the field is optional

## UU checks

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)
- [ ] Documentation version has been bumped (package.json in docs)

Note: To trigger pipeline for the documentation site (spor.vy.no) you need to bump the version.

## How to test

Technical change. No change on current inputs, but able to add the prop `isOptional={true}` to see the new text

## Screenshots

| Before | After |
| ------ | ----- |
|    <img width="862" alt="image" src="https://github.com/user-attachments/assets/cb0ff041-f542-4637-81c5-70e1955e5213">    |   <img width="881" alt="image" src="https://github.com/user-attachments/assets/7a39d85a-29b5-4100-af49-0840bd4f0268">    |
|          |     <img width="867" alt="image" src="https://github.com/user-attachments/assets/5a33b3ea-e009-4b02-9579-fbf80bbab861">     |
