### PR TITLE
Added type declaration for chakra

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,5 +1,11 @@
 {
-  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", "vite.config.mts"],
+  "include": [
+    "env.d.ts",
+    "types.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "vite.config.mts"
+  ],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2019"],
     "isolatedModules": true,

--- a/apps/docs/types.d.ts
+++ b/apps/docs/types.d.ts
@@ -1,0 +1,3 @@
+declare module "@chakra-ui/system/dist/system.types" {
+  export * from "@chakra-ui/react";
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^2.9.0",
         "@vygruppen/spor-icon-react": "^3.9.0",
-        "@vygruppen/spor-react": "^10.4.1",
+        "@vygruppen/spor-react": "^10.6.0",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "10.4.1",
+      "version": "10.6.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",


### PR DESCRIPTION
## Background
There is a weird bug when you have moduleResolution set to bundler, causing modules that use a more direct import style to become unresolvable. The solution for this wasn’t obvious.

The reason turned out to be related to our spor-react library, where we use Chakra’s forwardRef. The definition is specified to be within some dist folder in Chakra.

I suppose there might be some tricks to work around this by importing it differently, but it has become too time-consuming to chase this any further, especially since we might switch to another component library later on.

The problem doesn’t occur if you set moduleResolution to node.

Describe the background for this task, why it emerged and why it must be solved.

## Solution

Created a type declaration file that correct the reference.