### PR TITLE
Updated realtime icons due to bad contrast

### DIFF
--- a/.changeset/ninety-snakes-kneel.md
+++ b/.changeset/ninety-snakes-kneel.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon": patch
+---
+
+Updated realtime icons to have better contrast

--- a/packages/spor-icon/svg/feedback/realtime-cancelled-12x12.svg
+++ b/packages/spor-icon/svg/feedback/realtime-cancelled-12x12.svg
@@ -1,4 +1,4 @@
 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="6" cy="6.00004" r="4.66667" fill="#FBCCCC"/>
+<circle cx="5.99992" cy="6.00004" r="4.66667" fill="#FBCCCC"/>
 <circle cx="6" cy="6" r="2" fill="#ED0000"/>
 </svg>

--- a/packages/spor-icon/svg/feedback/realtime-delay-12x12.svg
+++ b/packages/spor-icon/svg/feedback/realtime-delay-12x12.svg
@@ -1,4 +1,4 @@
 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle r="4.66667" transform="matrix(1 0 0 -1 6 5.99996)" fill="#FDF3BA"/>
-<circle r="2" transform="matrix(1 0 0 -1 6 6)" fill="#F1C400"/>
+  <circle cx="4.66667" cy="4.66667" r="4.66667" transform="matrix(1 0 0 -1 1.33325 10.6666)" fill="#FAE053"/>
+  <circle cx="2" cy="2" r="2" transform="matrix(1 0 0 -1 4 8)" fill="#DF8200"/>
 </svg>

--- a/packages/spor-icon/svg/feedback/realtime-delay-18x18.svg
+++ b/packages/spor-icon/svg/feedback/realtime-delay-18x18.svg
@@ -1,4 +1,4 @@
 <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle r="7" transform="matrix(1 0 0 -1 9 9)" fill="#FDF3BA"/>
-<circle r="3" transform="matrix(1 0 0 -1 9 9)" fill="#F1C400"/>
+<circle cx="7" cy="7" r="7" transform="matrix(1 0 0 -1 2 16)" fill="#FAE053"/>
+<circle cx="3" cy="3" r="3" transform="matrix(1 0 0 -1 6 12)" fill="#DF8200"/>
 </svg>

--- a/packages/spor-icon/svg/feedback/realtime-not started-12x12.svg
+++ b/packages/spor-icon/svg/feedback/realtime-not started-12x12.svg
@@ -1,4 +1,4 @@
 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="6" cy="6.00004" r="4.66667" fill="#D7D8D9"/>
+<circle cx="5.99992" cy="6.00004" r="4.66667" fill="#D7D8D9"/>
 <circle cx="6" cy="6" r="2" fill="#888B8E"/>
 </svg>

--- a/packages/spor-icon/svg/feedback/realtime-on route-12x12.svg
+++ b/packages/spor-icon/svg/feedback/realtime-on route-12x12.svg
@@ -1,4 +1,4 @@
 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="6" cy="6.00004" r="4.66667" fill="#B2DFD7"/>
+<circle cx="5.99992" cy="6.00004" r="4.66667" fill="#B2DFD7"/>
 <circle cx="6" cy="6" r="2" fill="#00957A"/>
 </svg>


### PR DESCRIPTION
## Background
https://trello.com/c/TewSXLVA

The contrast in the realtime icon has been too low, so it has been updated. It needs to be updated in Spor and in the spor library.

## Solution
Update the icons

## How to test

Open spor docs, navigate to http://localhost:3000/resources/icon-library select x18 size and search for it.

## Screenshots

before:
![image](https://github.com/user-attachments/assets/9b2c99cb-4fc6-4439-8a7f-dc7a15831ff6)

after:
![image](https://github.com/user-attachments/assets/84360cca-a930-4756-ba8e-db16f414919a)

