### PR TITLE
Change Icons to Stars in docs

### DIFF
--- a/apps/docs/app/routes/_index/ActionLinks.tsx
+++ b/apps/docs/app/routes/_index/ActionLinks.tsx
@@ -3,7 +3,7 @@ import {
   ComponentsOutline30Icon,
   GuidelinesOutline30Icon,
   HomeOutline30Icon,
-  IconsOutline30Icon,
+  StarsOutline30Icon,
   TokensOutline30Icon,
   TrainOutline30Icon,
 } from "@vygruppen/spor-icon-react";
@@ -64,7 +64,7 @@ const links: LinkItem[] = [
     to: "/resources/icon-library",
     title: "Icons",
     description: "Explore Spor's custom icon library",
-    icon: IconsOutline30Icon,
+    icon: StarsOutline30Icon,
     iconColor: "primrose",
   },
   {
@@ -77,10 +77,6 @@ const links: LinkItem[] = [
 ];
 
 export function ActionLinks() {
-  const backgroundColor = useColorModeValue(
-    "bg.default.light",
-    "bg.default.dark",
-  );
   return (
     <Container maxWidth="container.lg">
       <SimpleGrid

--- a/apps/docs/app/routes/_index/ActionLinks.tsx
+++ b/apps/docs/app/routes/_index/ActionLinks.tsx
@@ -112,7 +112,7 @@ type ActionLinkCardProps = {
 };
 function ActionLinkCard({ to, children }: ActionLinkCardProps) {
   const linkProps = to.match(/^https?:\/\//)
-    ? { as: "a", href: to, target: "_blank", rel: "noopener noreferrer" }
+    ? { href: to, target: "_blank", rel: "noopener noreferrer" }
     : { as: Link, to };
 
   return (

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.47",
+  "version": "0.0.48",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",


### PR DESCRIPTION
## Background

A major change in the spor-icons package changed the same of Icons to Stars.

This is being used for icons on the frontpage.

Also removed unused code and fixed a type error in the same file.