### PR TITLE
Divider: Update styling for dashed variant

### DIFF
--- a/.changeset/tough-feet-give.md
+++ b/.changeset/tough-feet-give.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Divider: Update styling for dashed variant

--- a/packages/spor-react/src/theme/components/divider.ts
+++ b/packages/spor-react/src/theme/components/divider.ts
@@ -1,5 +1,8 @@
 import { defineStyleConfig } from "@chakra-ui/styled-system";
-import { mode } from "@chakra-ui/theme-tools";
+import { mode, StyleFunctionProps } from "@chakra-ui/theme-tools";
+
+const isSolid = (props: StyleFunctionProps) => props.variant === "solid";
+const isDashed = (props: StyleFunctionProps) => props.variant === "dashed";
 
 export default defineStyleConfig({
   baseStyle: (props) => ({
@@ -20,19 +23,19 @@ export default defineStyleConfig({
   },
   sizes: {
     sm: (props) => ({
-      borderWidth: props.variant === "solid" ? "1px" : undefined,
-      borderRadius: props.variant === "solid" ? "0.5px" : undefined,
-      height: props.variant === "dashed" ? "1px" : undefined,
+      borderWidth: isSolid(props) ? "1px" : undefined,
+      borderRadius: isSolid(props) ? "0.5px" : undefined,
+      height: isDashed(props) ? "1px" : undefined,
     }),
     md: (props) => ({
-      borderWidth: props.variant === "solid" ? "2px" : undefined,
-      borderRadius: props.variant === "solid" ? "1px" : "10px",
-      height: props.variant === "dashed" ? "2px" : undefined,
+      borderWidth: isSolid(props) ? "2px" : undefined,
+      borderRadius: isSolid(props) ? "1px" : "10px",
+      height: isDashed(props) ? "2px" : undefined,
     }),
     lg: (props) => ({
-      borderWidth: props.variant === "solid" ? "3px" : undefined,
-      borderRadius: props.variant === "solid" ? "1.5px" : undefined,
-      height: props.variant === "dashed" ? "3px" : undefined,
+      borderWidth: isSolid(props) ? "3px" : undefined,
+      borderRadius: isSolid(props) ? "1.5px" : undefined,
+      height: isDashed(props) ? "3px" : undefined,
     }),
   },
   defaultProps: {

--- a/packages/spor-react/src/theme/components/divider.ts
+++ b/packages/spor-react/src/theme/components/divider.ts
@@ -1,42 +1,40 @@
-import { defineStyle, defineStyleConfig } from "@chakra-ui/styled-system";
+import { defineStyleConfig } from "@chakra-ui/styled-system";
 import { mode } from "@chakra-ui/theme-tools";
 
-const baseStyle = defineStyle((props) => ({
-  borderColor: mode("blackAlpha.300", "whiteAlpha.300")(props),
-}));
-
-const variantSolid = defineStyle({
-  borderStyle: "solid",
-});
-
-const variantDashed = defineStyle({
-  borderStyle: "dashed",
-});
-
-const variants = {
-  solid: variantSolid,
-  dashed: variantDashed,
-};
-
-const sizes = {
-  sm: {
-    borderWidth: "1px",
-    borderRadius: "0.5px",
-  },
-  md: {
-    borderWidth: "2px",
-    borderRadius: "1px",
-  },
-  lg: {
-    borderWidth: "3px",
-    borderRadius: "1.5px",
-  },
-};
-
 export default defineStyleConfig({
-  baseStyle,
-  variants,
-  sizes,
+  baseStyle: (props) => ({
+    borderColor: mode("blackAlpha.300", "whiteAlpha.300")(props),
+  }),
+  variants: {
+    solid: {
+      borderStyle: "solid",
+    },
+    dashed: (props) => ({
+      backgroundImage: `repeating-linear-gradient(90deg, ${mode("blackAlpha.300", "whiteAlpha.300")(props)}, ${mode("blackAlpha.300", "whiteAlpha.300")(props)} 4px, transparent 4px, transparent 10px)`,
+      backgroundPosition: "left bottom",
+      backgroundRepeat: "repeat-x",
+      backgroundSize: "100% 3px",
+      borderRadius:
+        props.size === "sm" ? "0.5px" : props.size === "md" ? "1px" : "1.5px",
+    }),
+  },
+  sizes: {
+    sm: (props) => ({
+      borderWidth: props.variant === "solid" ? "1px" : undefined,
+      borderRadius: props.variant === "solid" ? "0.5px" : undefined,
+      height: props.variant === "dashed" ? "1px" : undefined,
+    }),
+    md: (props) => ({
+      borderWidth: props.variant === "solid" ? "2px" : undefined,
+      borderRadius: props.variant === "solid" ? "1px" : "10px",
+      height: props.variant === "dashed" ? "2px" : undefined,
+    }),
+    lg: (props) => ({
+      borderWidth: props.variant === "solid" ? "3px" : undefined,
+      borderRadius: props.variant === "solid" ? "1.5px" : undefined,
+      height: props.variant === "dashed" ? "3px" : undefined,
+    }),
+  },
   defaultProps: {
     variant: "solid",
     size: "md",


### PR DESCRIPTION
## Background

One could barely see that the dash was dashed. 

## Solution

I've added new styling that allows for more spacing between the dashes.

## How to test

Check the Divider component. 

## Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/c605538d-7c00-49b4-8a4f-e0840123514a) | ![image](https://github.com/user-attachments/assets/be2951b5-e4b1-473d-a334-a3e430d373b8) |
