### PR TITLE
ProgressBar: New isActive prop

### DIFF
--- a/.changeset/orange-walls-camp.md
+++ b/.changeset/orange-walls-camp.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-react": minor
 ---
 
-ProgressBar: New isDisabled prop
+ProgressBar: New isActive prop

--- a/.changeset/orange-walls-camp.md
+++ b/.changeset/orange-walls-camp.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+ProgressBar: New isDisabled prop

--- a/packages/spor-react/src/loader/ProgressBar.tsx
+++ b/packages/spor-react/src/loader/ProgressBar.tsx
@@ -31,6 +31,7 @@ type ProgressBarProps = BoxProps & {
    * Defaults to 5000 (5 seconds).
    */
   labelRotationDelay?: number;
+  
   /** Pass to disable the color of the component */
   isDisabled?: boolean;
 };

--- a/packages/spor-react/src/loader/ProgressBar.tsx
+++ b/packages/spor-react/src/loader/ProgressBar.tsx
@@ -33,7 +33,7 @@ type ProgressBarProps = BoxProps & {
   labelRotationDelay?: number;
 
   /** Pass to disable the color of the component */
-  isDisabled?: boolean;
+  isActive?: boolean;
 };
 
 /**
@@ -70,7 +70,7 @@ export const ProgressBar = ({
   height = "0.5rem",
   width = "100%",
   "aria-label": ariaLabel,
-  isDisabled = false,
+  isActive = true,
   ...rest
 }: ProgressBarProps) => {
   const { t } = useTranslation();
@@ -83,7 +83,7 @@ export const ProgressBar = ({
     value,
     "aria-label": ariaLabel || t(texts.label(value)),
   });
-  const styles = useMultiStyleConfig("ProgressBar", { isDisabled });
+  const styles = useMultiStyleConfig("ProgressBar", { isActive });
   return (
     <>
       <Box
@@ -96,7 +96,7 @@ export const ProgressBar = ({
           <Box
             __css={styles.progress}
             height={height}
-            width={isDisabled ? "100%" : `${value}%`}
+            width={isActive ? `${value}%` : "100%"}
           />
         </Box>
         {currentLoadingText && (

--- a/packages/spor-react/src/loader/ProgressBar.tsx
+++ b/packages/spor-react/src/loader/ProgressBar.tsx
@@ -31,6 +31,8 @@ type ProgressBarProps = BoxProps & {
    * Defaults to 5000 (5 seconds).
    */
   labelRotationDelay?: number;
+  /** Pass to disable the color of the component */
+  isDisabled?: boolean;
 };
 
 /**
@@ -67,6 +69,7 @@ export const ProgressBar = ({
   height = "0.5rem",
   width = "100%",
   "aria-label": ariaLabel,
+  isDisabled = false,
   ...rest
 }: ProgressBarProps) => {
   const { t } = useTranslation();
@@ -79,7 +82,7 @@ export const ProgressBar = ({
     value,
     "aria-label": ariaLabel || t(texts.label(value)),
   });
-  const styles = useMultiStyleConfig("ProgressBar", {});
+  const styles = useMultiStyleConfig("ProgressBar", { isDisabled });
   return (
     <>
       <Box
@@ -89,7 +92,11 @@ export const ProgressBar = ({
         {...rest}
       >
         <Box width={width} __css={styles.background}>
-          <Box __css={styles.progress} height={height} width={`${value}%`} />
+          <Box
+            __css={styles.progress}
+            height={height}
+            width={isDisabled ? "100%" : `${value}%`}
+          />
         </Box>
         {currentLoadingText && (
           <Text sx={styles.description} {...labelProps}>

--- a/packages/spor-react/src/loader/ProgressBar.tsx
+++ b/packages/spor-react/src/loader/ProgressBar.tsx
@@ -31,7 +31,7 @@ type ProgressBarProps = BoxProps & {
    * Defaults to 5000 (5 seconds).
    */
   labelRotationDelay?: number;
-  
+
   /** Pass to disable the color of the component */
   isDisabled?: boolean;
 };

--- a/packages/spor-react/src/theme/components/progress-bar.ts
+++ b/packages/spor-react/src/theme/components/progress-bar.ts
@@ -17,19 +17,20 @@ const config = helpers.defineMultiStyleConfig({
     },
     background: {
       display: "flex",
-      backgroundColor: mode(
-        "brand.surface.default.dark",
-        "brand.surface.default.light",
-      )(props),
+      backgroundColor: !props.isDisabled
+        ? mode(
+            "brand.surface.default.dark",
+            "brand.surface.default.light",
+          )(props)
+        : undefined,
       borderRadius: "sm",
       justifyContent: "flex-start",
       marginX: "auto",
     },
     progress: {
-      backgroundColor: mode(
-        "brand.surface.active.light",
-        "brand.surface.active.dark",
-      )(props),
+      backgroundColor: !props.isDisabled
+        ? mode("brand.surface.active.light", "brand.surface.active.dark")(props)
+        : mode("icon.disabled.light", "icon.disabled.dark")(props),
       borderRadius: "sm",
       maxWidth: "100%",
       transition: "width .2s ease-out",

--- a/packages/spor-react/src/theme/components/progress-bar.ts
+++ b/packages/spor-react/src/theme/components/progress-bar.ts
@@ -17,7 +17,7 @@ const config = helpers.defineMultiStyleConfig({
     },
     background: {
       display: "flex",
-      backgroundColor: !props.isDisabled
+      backgroundColor: props.isActive
         ? mode(
             "brand.surface.default.dark",
             "brand.surface.default.light",
@@ -28,7 +28,7 @@ const config = helpers.defineMultiStyleConfig({
       marginX: "auto",
     },
     progress: {
-      backgroundColor: !props.isDisabled
+      backgroundColor: props.isActive
         ? mode("brand.surface.active.light", "brand.surface.active.dark")(props)
         : mode("icon.disabled.light", "icon.disabled.dark")(props),
       borderRadius: "sm",


### PR DESCRIPTION
## Background

For easy access to change the color, a isActive prop is added to the component.

<img width="927" alt="image" src="https://github.com/user-attachments/assets/9ff91127-e1ba-4ba8-98fe-956b263b6d67">
