### PR TITLE
Update branch filter to main, after migrating to common services

### DIFF
--- a/.deployment/config.yaml
+++ b/.deployment/config.yaml
@@ -1,9 +1,9 @@
 artifacts:
   - name: spor-tf
-    branch: migrate-to-common-services
+    branch: main
     location: s3
   - name: spor
-    branch: migrate-to-common-services
+    branch: main
     location: ecr
 
 steps:


### PR DESCRIPTION
## Background

When migrating to the new account we used a branch filter to deploy the specified branch.

## Solution

Update branch filter to deploy from main branch again
