### PR TITLE
use cdn by default

### DIFF
--- a/apps/docs/app/utils/sanity/config.ts
+++ b/apps/docs/app/utils/sanity/config.ts
@@ -2,5 +2,5 @@ export const sanityConfig = {
   apiVersion: "2022-02-25",
   projectId: "tbpd14t4",
   dataset: "production",
-  useCdn: false,
+  useCdn: true,
 };


### PR DESCRIPTION
## Background

We had propbaly a mini-dos attack, leading us to nearly use up our sanity quota. Due to not using cdn for sanity requests.

## Solution

Use CDN for sanity requests
