### PR TITLE
Export type TranslationObject

### DIFF
--- a/.changeset/large-rice-buy.md
+++ b/.changeset/large-rice-buy.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Exports type TranslationObject

--- a/packages/spor-react/src/i18n/index.tsx
+++ b/packages/spor-react/src/i18n/index.tsx
@@ -7,7 +7,7 @@ export enum Language {
   English = "en",
 }
 
-type TranslationObject = {
+export type TranslationObject = {
   [key in Language]: string | React.ReactElement;
 };
 type TranslationFunction = (
@@ -24,6 +24,7 @@ type LanguageProviderProps = {
   language: Language;
   children: React.ReactElement;
 };
+
 /**
  * A language provider component.
  *


### PR DESCRIPTION
## Background

Different methods using TranslationObjet is exposed and used by frontend, but they have to define their own version of TranslationObject.

## Solution

Export the actual type used in spor to be able for frontend to use the correct type.


Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package
