### PR TITLE
Fix input label style bug caused by LastPass extension

### DIFF
--- a/.changeset/fast-carrots-raise.md
+++ b/.changeset/fast-carrots-raise.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix input label style bug caused by LastPass extension

--- a/packages/spor-react/src/theme/utils/input-utils.ts
+++ b/packages/spor-react/src/theme/utils/input-utils.ts
@@ -90,7 +90,7 @@ export const inputBaseStyle = (props: StyleFunctionProps) => ({
         ...baseBorder("hover", props),
       },
     },
-    " + label": {
+    " + label, + div[data-lastpass-icon-root] + label": {
       fontSize: ["mobile.sm", "desktop.sm"],
       top: "2px",
       left: props.paddingLeft || props.pl || 3,
@@ -103,7 +103,7 @@ export const inputBaseStyle = (props: StyleFunctionProps) => ({
     },
     "&:not(:placeholder-shown)": {
       paddingTop: "1rem",
-      "& + label": {
+      "& + label, & + div[data-lastpass-icon-root] + label": {
         transform: "scale(0.825) translateY(-10px)",
       },
     },


### PR DESCRIPTION
## Background

When using the LastPass browser extension input labels are not styled correctly. This happens because LastPass injects HTML between the `<input>` and `<label>` elements causing this CSS selector to not fire: `input + label { ... }`.

## Solution

Updated inputBaseStyle to ensure `input + label { ... }` styling is applied when using LastPass extension.

## UU checks

- [x] It works in both Chrome, Safari and Firefox

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Check that inputs with autocomplete have correct styling when using the LastPass browser extension.

## Screenshots

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-10-22 at 16 36 33](https://github.com/user-attachments/assets/df04f045-194d-4069-937a-6005feffc41c) | ![Screenshot 2024-10-22 at 16 36 05](https://github.com/user-attachments/assets/46e0ea08-d494-4f20-b462-c7532539860d) |
