### PR TITLE
ignore prettier commit - so it does not come up in blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Prettier codebase
+6a234ab316a41364e857418c28dae8ff98a14f69


### PR DESCRIPTION
## Background
En test på git-blame-ignore på en prettier commit

## Solution

Ignored the commit in git-blame-ignore
