### PR TITLE
Buggy label logic in phone number input

### DIFF
--- a/.changeset/lovely-tools-serve.md
+++ b/.changeset/lovely-tools-serve.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fixed buggy label logic for PhoneNumberInput

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -59,9 +59,7 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
   ) => {
     const { t } = useTranslation();
     const label =
-      externalLabel ?? isOptional
-        ? t(texts.phoneNumberOptional)
-        : t(texts.phoneNumber);
+      externalLabel ?? (isOptional ? t(texts.phoneNumberOptional) : t(texts.phoneNumber));
     const [value, onChange] = useControllableState({
       value: externalValue,
       onChange: externalOnChange,

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -59,7 +59,8 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
   ) => {
     const { t } = useTranslation();
     const label =
-      externalLabel ?? (isOptional ? t(texts.phoneNumberOptional) : t(texts.phoneNumber));
+      externalLabel ??
+      (isOptional ? t(texts.phoneNumberOptional) : t(texts.phoneNumber));
     const [value, onChange] = useControllableState({
       value: externalValue,
       onChange: externalOnChange,


### PR DESCRIPTION
## Background

The label logic was wrong. It always ignored externalLabel.
https://nsb-utvikling.slack.com/archives/CM9H2N39U/p1729836807225179

## Solution

Wrapped the logic in parentheses.

## UU checks

N/A

## How to test

Run locally. Go to `http://localhost:3000/components/phone-number-input`. Scroll down to the fourth and last example. See that the inputs has labels "Base" and "Variant" instead of the default values.