### PR TITLE
Remove SpaceProps from ButtonProps

### DIFF
--- a/.changeset/khaki-falcons-drum.md
+++ b/.changeset/khaki-falcons-drum.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": major
+---
+
+The Button component has been updated to remove SpaceProps from its ButtonProps interface. This change eliminates direct support for spacing-related properties (e.g., margin, padding).

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -4,6 +4,7 @@ import {
   ButtonProps as ChakraButtonProps,
   Flex,
   forwardRef,
+  SpaceProps,
   useButtonGroup,
   useStyleConfig,
 } from "@chakra-ui/react";
@@ -11,9 +12,12 @@ import React from "react";
 import { createTexts, useTranslation } from "../i18n";
 import { ColorInlineLoader } from "../loader";
 
-export type ButtonProps = Exclude<
-  ChakraButtonProps,
-  "colorScheme" | "loadingText" | "size" | "variant"
+export type ButtonProps = Omit<
+  Exclude<
+    ChakraButtonProps,
+    "colorScheme" | "loadingText" | "size" | "variant"
+  >,
+  keyof SpaceProps
 > & {
   /**
    * The size of the button.

--- a/packages/spor-react/src/modal/FullScreenDrawer.tsx
+++ b/packages/spor-react/src/modal/FullScreenDrawer.tsx
@@ -163,7 +163,6 @@ const DrawerCloseButton = () => {
         onClick={onClose}
         aria-label={t(texts.close)}
         width="fit-content"
-        marginLeft="auto"
       >
         {t(texts.close)}
       </Button>
@@ -196,7 +195,6 @@ const DrawerBackButton = () => {
         onClick={onClose}
         aria-label={t(texts.backAriaLabel)}
         width="fit-content"
-        marginLeft="auto"
       >
         {t(texts.back)}
       </Button>


### PR DESCRIPTION
## Background

One primary reason is that styles defined via SpaceProps were not being applied to the Button component, leading to confusion and unexpected behavior for developers using the component.

## Solution

The Button component has been updated to remove SpaceProps from its ButtonProps interface. This change eliminates direct support for spacing-related properties (e.g., margin, padding).

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

try to add `margin` or `padding` on Button component. Make sure space props does not appear and is not supported.
