### PR TITLE
Update states for expandable Alerts and service alerts

### DIFF
--- a/.changeset/chilly-chefs-matter.md
+++ b/.changeset/chilly-chefs-matter.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+alert-expandable: made some updates in the styling for different states

--- a/.changeset/chilly-chefs-matter.md
+++ b/.changeset/chilly-chefs-matter.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-react": patch
 ---
 
-alert-expandable: made some updates in the styling for different states
+ExpandableAlert: made some updates in the styling for different states

--- a/packages/spor-react/src/theme/components/alert-expandable.ts
+++ b/packages/spor-react/src/theme/components/alert-expandable.ts
@@ -27,10 +27,14 @@ const config = helpers.defineMultiStyleConfig({
       },
       container: {
         _hover: {
+          backgroundColor: "cloudy",
           outlineColor: "sky",
         },
         _active: {
           backgroundColor: "icyBlue",
+        },
+        _focus: {
+          outlineColor: "greenHaze",
         },
       },
     },
@@ -40,10 +44,14 @@ const config = helpers.defineMultiStyleConfig({
       },
       container: {
         _hover: {
+          backgroundColor: "coralGreen",
           outlineColor: "blueGreen",
         },
         _active: {
           backgroundColor: "mint",
+        },
+        _focus: {
+          outlineColor: "greenHaze",
         },
       },
     },
@@ -53,7 +61,11 @@ const config = helpers.defineMultiStyleConfig({
       },
       container: {
         _hover: {
-          outlineColor: "sunshine",
+          backgroundColor: "primrose",
+          outlineColor: "banana",
+        },
+        _focus: {
+          outlineColor: "greenHaze",
         },
         _active: {
           backgroundColor: "cornSilk",
@@ -66,7 +78,11 @@ const config = helpers.defineMultiStyleConfig({
       },
       container: {
         _hover: {
+          backgroundColor: "burntYellow",
           outlineColor: "golden",
+        },
+        _focus: {
+          outlineColor: "greenHaze",
         },
         _active: {
           backgroundColor: "sunshine",
@@ -79,10 +95,14 @@ const config = helpers.defineMultiStyleConfig({
       },
       container: {
         _hover: {
+          backgroundColor: "salmon",
           outlineColor: "apricot",
         },
         _active: {
           backgroundColor: "pink",
+        },
+        _focus: {
+          outlineColor: "greenHaze",
         },
       },
     },

--- a/packages/spor-react/src/theme/components/alert-service.ts
+++ b/packages/spor-react/src/theme/components/alert-service.ts
@@ -65,10 +65,15 @@ const config = helpers.defineMultiStyleConfig({
     service: {
       container: {
         _hover: {
-          outlineColor: "blueGreen",
+          backgroundColor: "teal.600",
+          outlineColor: "teal.600",
+
+        },
+        _focus: {
+          outlineColor: "green.500",
         },
         _active: {
-          backgroundColor: "pine",
+          backgroundColor: "teal.400",
           outlineColor: "pine",
         },
         color: "white",

--- a/packages/spor-react/src/theme/components/alert-service.ts
+++ b/packages/spor-react/src/theme/components/alert-service.ts
@@ -67,7 +67,6 @@ const config = helpers.defineMultiStyleConfig({
         _hover: {
           backgroundColor: "teal.600",
           outlineColor: "teal.600",
-
         },
         _focus: {
           outlineColor: "green.500",


### PR DESCRIPTION
## Background

expandable alerts and service alerts had stying that had to be updated
## Solution

changed styling on each state to match the styling in figma. 
Screenshots show the alerts with focus and hover state activated before and after changes


## Screenshots

| Before | After |
| ------ | ----- |
|<img width="435" alt="image" src="https://github.com/user-attachments/assets/a60ce8ea-e31e-4bc1-8bd5-cc19074885c8">|<img width="513" alt="image" src="https://github.com/user-attachments/assets/70b36734-e57f-44e9-a55a-ed4dc3759f9e">|
