### PR TITLE
Adapt component CardSelect to new design

### DIFF
--- a/.changeset/lemon-scissors-return.md
+++ b/.changeset/lemon-scissors-return.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+CardSelect: adjust css values and component logic to adapt to new design

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^3.2.0",
         "@vygruppen/spor-icon-react": "^3.12.0",
-        "@vygruppen/spor-react": "^10.9.0",
+        "@vygruppen/spor-react": "^10.9.2",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "10.9.0",
+      "version": "10.9.2",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -122,7 +122,6 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
         <chakra.button
           type="button"
           ref={triggerRef}
-          fontWeight="bold"
           sx={styles.trigger}
           aria-label={label}
           {...buttonProps}
@@ -148,14 +147,17 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
             offset={size === "sm" ? 6 : 12}
             crossOffset={crossOffset}
             placement={placement}
+            containerPadding={0}
           >
             <StaticCard
               colorScheme="white"
-              size="lg"
+              size="md"
+              fontSize={"xs"}
               border={"sm"}
-              borderColor={"grey"}
+              borderColor={"silver"}
               sx={styles.card}
               {...overlayProps}
+              maxWidth={(triggerRef.current?.clientWidth ?? 1) * 2}
             >
               <Dialog aria-label={label}>{children}</Dialog>
             </StaticCard>

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -130,7 +130,11 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
         >
           <Flex gap={1.5} alignItems="center">
             {icon}
-            <Box as="span" display={props["aria-label"] ? "none" : "inline"}>
+            <Box
+              as="span"
+              paddingRight={state.isOpen ? 0 : 1}
+              display={props["aria-label"] ? "none" : "inline"}
+            >
               {label}
             </Box>
             {withChevron ? (

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -132,7 +132,7 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
             {icon}
             <Box
               as="span"
-              paddingRight={state.isOpen ? 0 : 1}
+              paddingRight={state.isOpen && variant === "ghost" ? 0 : "5px"}
               display={props["aria-label"] ? "none" : "inline"}
             >
               {label}

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -130,11 +130,7 @@ export const CardSelect = forwardRef<CardSelectProps, "button">(
         >
           <Flex gap={1.5} alignItems="center">
             {icon}
-            <Box
-              as="span"
-              paddingRight={state.isOpen && variant === "ghost" ? 0 : "5px"}
-              display={props["aria-label"] ? "none" : "inline"}
-            >
+            <Box as="span" display={props["aria-label"] ? "none" : "inline"}>
               {label}
             </Box>
             {withChevron ? (

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -5,6 +5,7 @@ import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { ghostBackground, ghostText } from "../utils/ghost-utils";
+import { fontWeights } from "../foundations";
 
 const parts = anatomy("card-select").parts("trigger", "card");
 
@@ -57,7 +58,7 @@ const config = helpers.defineMultiStyleConfig({
         },
         _expanded: {
           ...ghostBackground("active", props),
-          fontWeight: "bold",
+          fontWeight: fontWeights.bold,
         },
       },
     }),

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -22,8 +22,8 @@ const config = helpers.defineMultiStyleConfig({
     },
     card: {
       borderRadius: "sm",
-      boxShadow: "md",
-      padding: 3,
+      boxShadow: "xs",
+      padding: 2,
       ...baseText("default", props),
       backgroundColor: mode(
         "white",
@@ -88,7 +88,7 @@ const config = helpers.defineMultiStyleConfig({
         paddingY: 1,
         minHeight: "1.25rem",
         fontSize: "xs",
-        borderRadius: "sm",
+        borderRadius: "lg",
       },
     },
     md: {
@@ -96,8 +96,8 @@ const config = helpers.defineMultiStyleConfig({
         paddingX: 2,
         paddingY: 1.5,
         minHeight: "2.625rem",
-        fontSize: "sm",
-        borderRadius: "sm",
+        fontSize: "xs",
+        borderRadius: "lg",
       },
     },
     lg: {
@@ -106,7 +106,7 @@ const config = helpers.defineMultiStyleConfig({
         paddingY: 2,
         minHeight: "3.375rem",
         fontSize: "sm",
-        borderRadius: "sm",
+        borderRadius: "lg",
       },
     },
   },

--- a/packages/spor-react/src/theme/components/card-select.ts
+++ b/packages/spor-react/src/theme/components/card-select.ts
@@ -56,7 +56,8 @@ const config = helpers.defineMultiStyleConfig({
           ...ghostBackground("active", props),
         },
         _expanded: {
-          ...ghostBackground("selected", props),
+          ...ghostBackground("active", props),
+          fontWeight: "bold",
         },
       },
     }),

--- a/packages/spor-react/src/theme/utils/ghost-utils.ts
+++ b/packages/spor-react/src/theme/utils/ghost-utils.ts
@@ -1,5 +1,6 @@
 import { mode, StyleFunctionProps } from "@chakra-ui/theme-tools";
 import { State, Subset } from "./types";
+import { fontWeights } from "../foundations";
 
 type GhostBackgroundState = Subset<
   State,
@@ -30,8 +31,8 @@ export function ghostBackground(
     case "selected": {
       return {
         backgroundColor: mode(
-          "ghost.surface.selected.light",
-          "ghost.surface.selected.dark",
+          "ghost.surface.hover.light",
+          "ghost.surface.hover.dark",
         )(props),
       };
     }
@@ -49,6 +50,7 @@ export function ghostText(state: GhostTextState, props: StyleFunctionProps) {
     case "selected":
       return {
         color: mode("ghost.text.light", "ghost.text.dark")(props),
+        fontWeights: fontWeights.bold,
       };
     default:
       return {

--- a/packages/spor-react/src/theme/utils/ghost-utils.ts
+++ b/packages/spor-react/src/theme/utils/ghost-utils.ts
@@ -50,7 +50,6 @@ export function ghostText(state: GhostTextState, props: StyleFunctionProps) {
     case "selected":
       return {
         color: mode("ghost.text.light", "ghost.text.dark")(props),
-        fontWeights: fontWeights.bold,
       };
     default:
       return {


### PR DESCRIPTION
## Background

The design of cardSelect was updated and needed adjustment to be compliant

## Solution

Fix the code that render the components with new design

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Run application locally and check the cardSelect http://localhost:3000/components/card-select

## Screenshots

Previous design
![Skjermbilde 2024-11-19 kl  15 28 29](https://github.com/user-attachments/assets/31f0a1d3-b52c-4f2a-836d-cdb1d179113c)

Figma design
<img width="1050" alt="Skjermbilde 2024-11-19 kl  15 26 15" src="https://github.com/user-attachments/assets/b565b76a-7c4d-4052-aab8-ad7e7db04d89">


Updated design
![Skjermbilde 2024-11-19 kl  15 27 33](https://github.com/user-attachments/assets/b4457d8e-8792-42ee-8d5a-d1b3edce585b)

