### PR TITLE
Dashed divider like figma

### DIFF
--- a/.changeset/chilly-cows-whisper.md
+++ b/.changeset/chilly-cows-whisper.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Update styling for dashed divider

--- a/packages/spor-react/src/theme/components/divider.ts
+++ b/packages/spor-react/src/theme/components/divider.ts
@@ -1,42 +1,47 @@
 import { defineStyleConfig } from "@chakra-ui/styled-system";
-import { mode, StyleFunctionProps } from "@chakra-ui/theme-tools";
+import { mode } from "@chakra-ui/theme-tools";
 
-const isSolid = (props: StyleFunctionProps) => props.variant === "solid";
-const isDashed = (props: StyleFunctionProps) => props.variant === "dashed";
+const borderColor = mode("blackAlpha.300", "whiteAlpha.300");
+
+function getSizes(size: string) {
+  const sizes: Record<string, { height: string; dash: string; gap: string }> = {
+    sm: {
+      height: "1px",
+      dash: "1px",
+      gap: "4px",
+    },
+    md: {
+      height: "2px",
+      dash: "3px",
+      gap: "6px",
+    },
+    lg: {
+      height: "3px",
+      dash: "3px",
+      gap: "9px",
+    },
+  };
+  return sizes[size] || sizes["md"];
+}
 
 export default defineStyleConfig({
   baseStyle: (props) => ({
-    borderColor: mode("blackAlpha.300", "whiteAlpha.300")(props),
+    borderColor: borderColor(props),
   }),
   variants: {
     solid: {
       borderStyle: "solid",
     },
-    dashed: (props) => ({
-      backgroundImage: `repeating-linear-gradient(90deg, ${mode("blackAlpha.300", "whiteAlpha.300")(props)}, ${mode("blackAlpha.300", "whiteAlpha.300")(props)} 4px, transparent 4px, transparent 10px)`,
-      backgroundPosition: "left bottom",
-      backgroundRepeat: "repeat-x",
-      backgroundSize: "100% 3px",
-      borderRadius:
-        props.size === "sm" ? "0.5px" : props.size === "md" ? "1px" : "1.5px",
-    }),
-  },
-  sizes: {
-    sm: (props) => ({
-      borderWidth: isSolid(props) ? "1px" : undefined,
-      borderRadius: isSolid(props) ? "0.5px" : undefined,
-      height: isDashed(props) ? "1px" : undefined,
-    }),
-    md: (props) => ({
-      borderWidth: isSolid(props) ? "2px" : undefined,
-      borderRadius: isSolid(props) ? "1px" : "10px",
-      height: isDashed(props) ? "2px" : undefined,
-    }),
-    lg: (props) => ({
-      borderWidth: isSolid(props) ? "3px" : undefined,
-      borderRadius: isSolid(props) ? "1.5px" : undefined,
-      height: isDashed(props) ? "3px" : undefined,
-    }),
+    dashed: (props) => {
+      const { height, dash, gap } = getSizes(props.size);
+      return {
+        height: height,
+        backgroundImage: `linear-gradient(90deg, ${borderColor(props)}, ${borderColor(props)} ${dash}, transparent ${dash}, transparent ${gap})`,
+        backgroundPosition: "left bottom",
+        backgroundRepeat: "repeat-x",
+        backgroundSize: `${gap} ${height}`,
+      };
+    },
   },
   defaultProps: {
     variant: "solid",


### PR DESCRIPTION
## Background

The dashed divider looked weird and not like in figma.
<img width="979" alt="image" src="https://github.com/user-attachments/assets/25738508-cb89-4d4c-8f74-5b26de6b5426">


## Solution

Updated the styling for the dashed divider to look like the divider in figma.
The rounded corners where not included this time.

## UU checks

Only visual changes.

## How to test

Look at the dividers with `variant="dashed"`

## Screenshots

| Before | After |
| ------ | ----- |
|    <img width="863" alt="image" src="https://github.com/user-attachments/assets/4f73f468-6b5d-40bc-822f-23b969e25e84">    |    <img width="813" alt="image" src="https://github.com/user-attachments/assets/296dd6d8-b898-45f4-8d3f-b3e2ff6ab63f">   |
