### PR TITLE
Add aria attributes to introduce the skeleotons component

### DIFF
--- a/.changeset/green-suns-exercise.md
+++ b/.changeset/green-suns-exercise.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Skeletons: add aria attributes and role

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -12,5 +12,11 @@ export type SkeletonProps = BoxProps & {
  * Skeleton renders a loading animation for a given box. It works great as a placeholder to avoid layout shifts.
  */
 export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => (
-  <ChakraSkeleton {...props} ref={ref} />
+  <ChakraSkeleton
+    {...props}
+    ref={ref}
+    aria-busy="true"
+    aria-hidden="true"
+    role="alert"
+  />
 ));


### PR DESCRIPTION
## Background

Skeletons component, even if it is handle as not focusable element, had not aria attributes to  introduce the component to screen readers

## Solution

It may looks overkill since the component is not focusable but to ensure all screenreader avoid consider this element adding these attributes will help

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Run application locally and check http://localhost:3000/components/skeletons 

