### PR TITLE
Alter github action to trigger circleci after publishing to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ orbs:
   aws-cli: circleci/aws-cli@5.0.0
 
 parameters:
+  GHA_Action:
+    type: string
+    default: ""
   ecr_repo_name:
     type: string
     default: "spor"
@@ -77,6 +80,8 @@ jobs:
 workflows:
   version: 2
   build:
+    when:
+      equal: [ "github-action-trigger", << pipeline.parameters.GHA_Action >> ]
     jobs:
       - terraform/validate:
           tag: << pipeline.parameters.terraform_version >>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Trigger CircleCI pipeline
+        id: github-action-trigger
+        uses: circleci/trigger_circleci_pipeline@v1.2.0
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}


### PR DESCRIPTION
## Background

During a release, we are publishing the new version of spor to npm. While this is happening the circleci pipeline is trying to pull this version from npm. If the github action has not yet published to npm the circleci pipeline will fail

## Solution

Alter the github action to trigger our circleci pipeline after publishing to npm

