### PR TITLE
Add target slug to github action so circleci can identify the project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Trigger CircleCI pipeline
         id: github-action-trigger
-        uses: circleci/trigger_circleci_pipeline@v1.2.0
+        uses: circleci/trigger_circleci_pipeline@v1.0.5
+        with:
+          target-slug: "github/nsbno/spor"
         env:
           CCI_TOKEN: ${{ secrets.CCI_TOKEN }}


### PR DESCRIPTION
## Background
github action was unable to find circleci project

## Solution
follow circleci guide and add target_slug to github action
