### PR TITLE
Update container values to match breakpoint token values

### DIFF
--- a/.changeset/green-books-brake.md
+++ b/.changeset/green-books-brake.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Updated container tokens to follow the correct sizes from breakpoints

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^3.2.0",
         "@vygruppen/spor-icon-react": "^3.12.0",
-        "@vygruppen/spor-react": "^10.9.0",
+        "@vygruppen/spor-react": "^10.9.2",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "10.9.0",
+      "version": "10.9.2",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/theme/foundations/sizes.ts
+++ b/packages/spor-react/src/theme/foundations/sizes.ts
@@ -1,3 +1,4 @@
+import tokens from "@vygruppen/spor-design-tokens";
 import { spacing } from "./spacing";
 
 const largeSizes = {
@@ -21,10 +22,11 @@ const largeSizes = {
 };
 
 const container = {
-  sm: "640px",
-  md: "768px",
-  lg: "1024px",
-  xl: "1280px",
+  base: "0px",
+  sm: tokens.size.breakpoint.sm,
+  md: tokens.size.breakpoint.md,
+  lg: tokens.size.breakpoint.lg,
+  xl: tokens.size.breakpoint.xl,
 };
 
 export const sizes = {


### PR DESCRIPTION
## Background

The container sizes did not match what is defined in breakpoints and Figma. Updated these. 

## Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/cd0272f0-e293-4075-90aa-18f6b68ba859) | ![image](https://github.com/user-attachments/assets/cafee700-b38d-4b37-8d0e-8a1f5d55b7b8) |
