### PR TITLE
Fix resizing in small screen for site settings menu

### DIFF
--- a/apps/docs/app/root/layout/SiteSettings.tsx
+++ b/apps/docs/app/root/layout/SiteSettings.tsx
@@ -33,8 +33,14 @@ export const SiteSettings = ({ showLabel }: SiteSettingsProps) => {
         withChevron={false}
         fontWeight="bold"
         {...labelProps}
+        position={"relative"}
       >
-        <Flex gap={4} flexDirection="column" maxWidth="30ch">
+        <Flex
+          gap={4}
+          flexDirection="column"
+          maxWidth="30ch"
+          width={["100%", "30ch"]}
+        >
           <Box>
             <Heading as="h2" variant="md">
               Site settings


### PR DESCRIPTION
## Background

The settings modal of the documentation website had problems in minor size screen (see video below)

## Solution

Add a fixed width to modal element 

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

run application locally and reduce the size of the screen to a mobile size then test the settings menu item

## Screenshots

before 

https://github.com/user-attachments/assets/aeaefec0-8714-4d26-8a9f-d7d02bef2b8a

after

https://github.com/user-attachments/assets/beec1ccd-71f2-4583-81f5-fdc9f9da1f97



