### PR TITLE
Fix isDisabled in RadioCard and ChoiceChip

### DIFF
--- a/.changeset/nasty-apples-search.md
+++ b/.changeset/nasty-apples-search.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix isDisabled for RadioCard and ChoiceChip

--- a/packages/spor-react/src/input/ChoiceChip.tsx
+++ b/packages/spor-react/src/input/ChoiceChip.tsx
@@ -93,7 +93,7 @@ export const ChoiceChip = forwardRef(
         <chakra.input
           {...getInputProps({}, ref)}
           id={id}
-          disabled={isDisabled}
+          disabled={isDisabled || state.isDisabled}
         />
         <chakra.div
           {...getLabelProps()}

--- a/packages/spor-react/src/input/ChoiceChip.tsx
+++ b/packages/spor-react/src/input/ChoiceChip.tsx
@@ -102,7 +102,7 @@ export const ChoiceChip = forwardRef(
           data-hover={dataAttr(state.isHovered)}
           data-focus={dataAttr(state.isFocused)}
           data-active={dataAttr(state.isActive)}
-          data-disabled={dataAttr(state.isDisabled)}
+          data-disabled={dataAttr(isDisabled || state.isDisabled)}
         >
           {icon && (
             <chakra.span __css={styles.icon}>

--- a/packages/spor-react/src/layout/RadioCard.tsx
+++ b/packages/spor-react/src/layout/RadioCard.tsx
@@ -7,6 +7,7 @@ import {
 } from "@chakra-ui/react";
 import React, { useContext, useEffect, useId, useState } from "react";
 import { RadioCardGroupContext } from "./RadioCardGroup";
+import { dataAttr } from "@chakra-ui/utils";
 
 /**
  * Radio cards are used to present a set of options where only one option can be selected.
@@ -107,9 +108,9 @@ export const RadioCard = forwardRef(
           as="label"
           name={name}
           htmlFor={inputId}
-          aria-checked={isChecked}
-          data-checked={isChecked}
-          data-disabled={isDisabled}
+          aria-checked={dataAttr(isChecked)}
+          data-checked={dataAttr(isChecked)}
+          data-disabled={dataAttr(isDisabled)}
           {...props}
           __css={{
             ...styles.container,


### PR DESCRIPTION
## Background

(Ref: https://nsb-utvikling.slack.com/archives/C069ZRN84JY/p1730723548773359)

Setting `isDisabled=false` on RadioCard sets the RadioCard state to disabled. 

## Solution

Fixed isDisabled behaviour in RadioCard.
Also fixed a similar issue in ChoiceChip as I noticed it didn't have correct style when using isDisabled.

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver

## How to test

Check that using `isDisabled` and `disabled` works correctly for RadioCard and ChoiceChip.

## Screenshots

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-12-12 at 12 31 19](https://github.com/user-attachments/assets/5f6f3f9c-09dd-48ff-b5a1-b5d72f310363) | ![Screenshot 2024-12-12 at 12 30 37](https://github.com/user-attachments/assets/4eefe18f-0a27-44ba-93fd-4b03f1dfd0b7) |
