### PR TITLE
Fix double workspaces for chackra 3 og 2 med spor 1 og 2

### DIFF
--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -6,53 +6,80 @@ import VyLogo from "./components/VyLogo";
 import { structure } from "./desk/structure";
 import { schemaTypes } from "./schemas";
 
-export default defineConfig({
-  name: "default",
-  title: "Spor",
-  projectId: "tbpd14t4",
-  dataset: "production",
-  plugins: [structureTool({ structure }), visionTool(), codeInput()],
-  studio: {
-    components: {
-      logo: VyLogo,
-    },
-  },
-  document: {
-    productionUrl: async (prev, { document, getClient }) => {
-      try {
-        const configuredClient = getClient({ apiVersion: "2022-10-06" });
-        const host = window.location.href?.includes("localhost")
-          ? "http://localhost:3000"
-          : "https://spor.vy.no";
+const projectId = "tbpd14t4";
 
-        if (document._type === "article") {
-          if (!document.category) {
-            return host;
-          }
-          const category = await configuredClient.fetch(
-            `*[_id == $id] { "slug": slug.current }[0]`,
-            { id: (document.category as any)?._ref },
-          );
+const documentConfig = {
+  productionUrl: async (
+    prev: string | undefined,
+    { document, getClient }: { document: any; getClient: any },
+  ) => {
+    try {
+      const configuredClient = getClient({ apiVersion: "2022-10-06" });
+      const host = window.location.href?.includes("localhost")
+        ? "http://localhost:3000"
+        : "https://spor.vy.no";
 
-          if (!category) {
-            return host;
-          }
-
-          const params = new URLSearchParams();
-          params.set("preview", import.meta.env.SANITY_STUDIO_PREVIEW_SECRET);
-
-          return `${host}/${category.slug}/${
-            (document?.slug as any)?.current
-          }?${params}`;
+      if (document._type === "article") {
+        if (!document.category) {
+          return host;
         }
-      } catch (e) {
-        console.error(e);
+        const category = await configuredClient.fetch(
+          `*[_id == $id] { "slug": slug.current }[0]`,
+          { id: document.category?._ref },
+        );
+
+        if (!category) {
+          return host;
+        }
+
+        const params = new URLSearchParams();
+        params.set("preview", import.meta.env.SANITY_STUDIO_PREVIEW_SECRET);
+
+        return `${host}/${category.slug}/${document?.slug.current}?${params}`;
       }
-      return prev;
+    } catch (e) {
+      console.error(e);
+    }
+    return prev;
+  },
+};
+
+export default defineConfig([
+  {
+    name: "default",
+    title: "Spor 2",
+    subtitle: "New version based on Chakra 3.0",
+    projectId: projectId,
+    dataset: "production-v2",
+    basePath: "/production-v2",
+    plugins: [structureTool({ structure }), visionTool(), codeInput()],
+    studio: {
+      components: {
+        logo: VyLogo,
+      },
+    },
+    document: documentConfig,
+    schema: {
+      types: schemaTypes,
     },
   },
+  {
+    name: "sporV1",
+    title: "Spor 1",
+    subtitle: "First version based on Chakra 2.0",
+    projectId: projectId,
+    dataset: "production",
+    basePath: "/production",
+    plugins: [structureTool({ structure }), visionTool(), codeInput()],
+    studio: {
+      components: {
+        logo: VyLogo,
+      },
+    },
+    document: documentConfig,
 
-  schema: {
-    types: schemaTypes,
+    schema: {
+      types: schemaTypes,
+    },
   },
-});
+]);


### PR DESCRIPTION
## Background

In order to update the chakra 3 version documentation and keep the previous version at the same time we needed to split workspaces in two

## Solution

Use the second available dataset copy the content from the production to the new one and add a new workspace to handle the new dataset content

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Desribe how code reviewer may test your solution (what page, expected result).

## Screenshots

![Skjermbilde 2024-12-19 kl  13 45 18](https://github.com/user-attachments/assets/2e7cba94-3475-4aef-9f87-da8d40ef5040)

