### PR TITLE
Add box props to ClosableAlert

### DIFF
--- a/.changeset/stupid-sloths-clap.md
+++ b/.changeset/stupid-sloths-clap.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add boxProps to ClosaleAlert"

--- a/packages/spor-react/src/alert/ClosableAlert.tsx
+++ b/packages/spor-react/src/alert/ClosableAlert.tsx
@@ -42,6 +42,7 @@ export const ClosableAlert = ({
   title,
   children,
   onClose: externalOnClose = () => {},
+  ...boxProps
 }: ClosableAlertProps) => {
   const { isOpen, onClose } = useDisclosure({ defaultIsOpen: true });
   const styles = useMultiStyleConfig("Alert", { variant });
@@ -56,7 +57,7 @@ export const ClosableAlert = ({
   };
 
   return (
-    <BaseAlert variant={variant}>
+    <BaseAlert variant={variant} {...boxProps}>
       <IconButton
         variant="ghost"
         size="sm"


### PR DESCRIPTION
## Background

ClosableAlert has BoxProps in its props, but they were not used.

## Solution

Sent the boxProps to the BaseAlert the same way ExpandableAlert did.

## How to test

Add some boxProps to a ClosableAlert. Should now be applied to the component.

## Screenshots

| Before | After |
| ------ | ----- |
|    <img width="972" alt="image" src="https://github.com/user-attachments/assets/fcb94820-9b87-4922-ad08-7e227db5f087" />    |    <img width="986" alt="image" src="https://github.com/user-attachments/assets/341a5563-8376-4feb-a4a9-1fb091b51bc1" />   |
