### PR TITLE
Move aria-label to improve ChoiceChip voiceover

### DIFF
--- a/packages/spor-react/src/input/ChoiceChip.tsx
+++ b/packages/spor-react/src/input/ChoiceChip.tsx
@@ -85,15 +85,12 @@ export const ChoiceChip = forwardRef(
     const id = `choice-chip-${useId()}`;
 
     return (
-      <chakra.label
-        htmlFor={id}
-        {...getRootProps()}
-        aria-label={String(children)}
-      >
+      <chakra.label htmlFor={id} {...getRootProps()}>
         <chakra.input
           {...getInputProps({}, ref)}
           id={id}
           disabled={isDisabled || state.isDisabled}
+          aria-label={String(children)}
         />
         <chakra.div
           {...getLabelProps()}


### PR DESCRIPTION
## Background

The voiceover on the checkbox is weird. When moving using voiceover buttons (on mac) you need to click three times to move out of a checkbox. 

## Solution

Move aria-label for check box from label to input. 

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Run spor locally and go to the playground. Add different check boxes and test out voiceover on them.
