### PR TITLE
deprecate useMediaQuery

### DIFF
--- a/.changeset/loud-plants-protect.md
+++ b/.changeset/loud-plants-protect.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Added deprecated warning on useMediaQuery

--- a/packages/spor-react/src/util/externals.tsx
+++ b/packages/spor-react/src/util/externals.tsx
@@ -12,7 +12,6 @@ export {
   useColorModeValue,
   useControllableProp,
   useDisclosure,
-  useMediaQuery,
   useMergeRefs,
   useOutsideClick,
   usePrefersReducedMotion,
@@ -27,4 +26,11 @@ export type {
   UseDisclosureProps,
   UseOutsideClickProps,
 } from "@chakra-ui/react";
+import { useMediaQuery as useMediaQueryChakra } from "@chakra-ui/react";
+
+/**
+ * @deprecated useMediaQuery is deprecated. Use CSS only to determine the media query. - SSR is not supported and usage of useMediaQuery for rendering will cause hydration errors.
+ */
+export const useMediaQuery = useMediaQueryChakra;
+
 export { useSize } from "@chakra-ui/react-use-size";


### PR DESCRIPTION
## Background

To support SSR, we should avoid using `useMediaQuery`, as the server cannot detect the user's screen size. A better alternative is to rely solely on CSS.

## Solution

Add a deprecated doc comment.