### PR TITLE
Change color of ServiceAlert global-deviation variant

### DIFF
--- a/.changeset/kind-impalas-hammer.md
+++ b/.changeset/kind-impalas-hammer.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Changed color of the ServiceAlert varient global-deviation to be the same as a regular service alert

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@vygruppen/spor-design-tokens": "^3.8.1",
         "@vygruppen/spor-icon": "^3.2.0",
         "@vygruppen/spor-icon-react": "^3.12.0",
-        "@vygruppen/spor-react": "^10.9.2",
+        "@vygruppen/spor-react": "^11.0.4",
         "archiver": "^5.3.2",
         "deepmerge": "^4.3.1",
         "framer-motion": "^8.5.5",
@@ -32967,7 +32967,7 @@
     },
     "packages/spor-react": {
       "name": "@vygruppen/spor-react",
-      "version": "10.9.2",
+      "version": "11.0.4",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/spor-react/src/theme/components/alert-service.ts
+++ b/packages/spor-react/src/theme/components/alert-service.ts
@@ -43,23 +43,27 @@ const config = helpers.defineMultiStyleConfig({
     "global-deviation": {
       container: {
         _hover: {
-          outlineColor: "primrose",
+          backgroundColor: "teal.600",
+          outlineColor: "teal.600",
+        },
+        _focus: {
+          outlineColor: "green.500",
         },
         _active: {
-          backgroundColor: "blonde",
-          outlineColor: "primrose",
+          backgroundColor: "teal.400",
+          outlineColor: "pine",
         },
-        color: "darkGrey",
+        color: "white",
       },
       outerBox: {
-        outlineColor: "primrose",
-        backgroundColor: "blonde",
+        outlineColor: "blueGreen",
+        backgroundColor: "darkTeal",
       },
       notificationText: {
-        color: "darkGrey",
+        color: "white",
       },
       serviceMessageContent: {
-        color: "darkGrey",
+        color: "white",
       },
     },
     service: {


### PR DESCRIPTION
## Background

There was a need to make the two variants of the ServiceAlert component have identical colors, so that the color does not suddenly change when changing view for cases where the views have different ServiceAlert variants

## Solution

Change the colors of the "global-deviation" to be equal the "service" variant

If no packages, only docs has been changed:

- [x] Documentation version has been bumped (package.json in docs)

## How to test

Start the application manually, then check the last variant of the component showcased under: http://localhost:3000/components/alert 

## Screenshots

| Before | After |
| ------ | ----- |
|<img width="1028" alt="image" src="https://github.com/user-attachments/assets/5f71c46f-97b4-4769-9881-449f1d0ef0d7" />|<img width="1028" alt="image" src="https://github.com/user-attachments/assets/0491aabb-70bc-4641-99bb-69e48fd64681" />|
