### PR TITLE
remove suspense from phonenumber input, due to issues in SSR enviorment

### DIFF
--- a/.changeset/poor-dingos-shop.md
+++ b/.changeset/poor-dingos-shop.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Removed lazy from phone number input

--- a/packages/spor-react/src/input/CountryCodeSelect.tsx
+++ b/packages/spor-react/src/input/CountryCodeSelect.tsx
@@ -35,7 +35,7 @@ export const CountryCodeSelect = (props: CountryCodeSelectProps) => {
     <InfoSelect
       label={t(texts.countryCode)}
       isLabelSrOnly={true}
-      items={callingCodes as typeof callingCodes}
+      items={callingCodes}
       variant={props.variant}
       {...props}
     >

--- a/packages/spor-react/src/input/CountryCodeSelect.tsx
+++ b/packages/spor-react/src/input/CountryCodeSelect.tsx
@@ -35,7 +35,7 @@ export const CountryCodeSelect = (props: CountryCodeSelectProps) => {
     <InfoSelect
       label={t(texts.countryCode)}
       isLabelSrOnly={true}
-      items={callingCodes as any}
+      items={callingCodes as typeof callingCodes}
       variant={props.variant}
       {...props}
     >

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -128,5 +128,3 @@ const texts = createTexts({
     sv: "Landskod",
   },
 });
-
-// const LazyCountryCodeSelect = React.lazy(() => import("./CountryCodeSelect"));

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -4,9 +4,10 @@ import {
   forwardRef,
   useControllableState,
 } from "@chakra-ui/react";
-import React, { Suspense } from "react";
-import { InfoSelect, Input, Item, createTexts, useTranslation } from "..";
+import React from "react";
+import { Input, createTexts, useTranslation } from "..";
 import { AttachedInputs } from "./AttachedInputs";
+import { CountryCodeSelect } from "./CountryCodeSelect";
 
 type CountryCodeAndPhoneNumber = {
   countryCode: string;
@@ -71,34 +72,19 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
     });
     return (
       <AttachedInputs {...boxProps}>
-        <Suspense
-          fallback={
-            <InfoSelect
-              isLabelSrOnly
-              label={t(texts.countryCodeLabel)}
-              width="6.25rem"
-              height="100%"
-              value="+47"
-              variant={variant}
-            >
-              <Item key="+47">+47</Item>
-            </InfoSelect>
+        <CountryCodeSelect
+          value={value.countryCode}
+          onChange={(countryCode) =>
+            onChange({
+              countryCode: countryCode as string,
+              nationalNumber: value.nationalNumber,
+            })
           }
-        >
-          <LazyCountryCodeSelect
-            value={value.countryCode}
-            onChange={(countryCode) =>
-              onChange({
-                countryCode: countryCode as string,
-                nationalNumber: value.nationalNumber,
-              })
-            }
-            name={name ? `${name}-country-code` : "country-code"}
-            height="100%"
-            width="6.25rem"
-            variant={variant}
-          />
-        </Suspense>
+          name={name ? `${name}-country-code` : "country-code"}
+          height="100%"
+          width="6.25rem"
+          variant={variant}
+        />
         <Input
           ref={ref}
           type="tel"
@@ -143,4 +129,4 @@ const texts = createTexts({
   },
 });
 
-const LazyCountryCodeSelect = React.lazy(() => import("./CountryCodeSelect"));
+// const LazyCountryCodeSelect = React.lazy(() => import("./CountryCodeSelect"));


### PR DESCRIPTION
## Background
We notice that we have some issues with `optimize deps` in our main-frontend repository, and it seems to be linked to this component:

```
The file does not exist at "/root/project/node_modules/.vite/deps/chunk-3GG4VEIX.js?v=6513bab6" which is in the optimize deps directory. The dependency might be incompatible with the dep optimizer. Try adding it to `optimizeDeps.exclude`.
```
In a server-rendered environment, this is not needed since we're code-splitting indirectly, as we're already splitting up the bundle and sending the JavaScript that is needed, and nothing more.

## Solution
Removed the use of React.lazy

## UU Checks
- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari, and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if necessary)

If no packages, only docs have been changed:
- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to Test
Open docs and test the phone-number-input