### PR TITLE
fix illustration page

### DIFF
--- a/apps/docs/app/routes/_base.resources.illustration-library/route.tsx
+++ b/apps/docs/app/routes/_base.resources.illustration-library/route.tsx
@@ -89,11 +89,11 @@ export const loader = async () => {
   const { illustrations, article } = (await client.fetch(
     query,
   )) as SanityResponse;
-  return data({ illustrations, article });
+  return { illustrations, article };
 };
 
 export default function IllustrationLibraryPage() {
-  const { illustrations, article } = useLoaderData<typeof loader>().data;
+  const { illustrations, article } = useLoaderData<typeof loader>();
   const [searchValue, setSearchValue] = useState("");
   const colorMode = useColorModePreference();
   const [size, setSize] = useState("all");

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -25,7 +25,7 @@
     "@vygruppen/spor-design-tokens": "^3.8.1",
     "@vygruppen/spor-icon": "^3.2.0",
     "@vygruppen/spor-icon-react": "^3.12.0",
-    "@vygruppen/spor-react": "^11.0.",
+    "@vygruppen/spor-react": "^11.1.1",
     "archiver": "^5.3.2",
     "deepmerge": "^4.3.1",
     "framer-motion": "^8.5.5",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.53",
+  "version": "0.0.54",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "@vygruppen/spor-design-tokens": "^3.8.1",
     "@vygruppen/spor-icon": "^3.2.0",
     "@vygruppen/spor-icon-react": "^3.12.0",
-    "@vygruppen/spor-react": "^11.1.1",
+    "@vygruppen/spor-react": "^11.0.",
     "archiver": "^5.3.2",
     "deepmerge": "^4.3.1",
     "framer-motion": "^8.5.5",


### PR DESCRIPTION

## Background

/guides/introduction does not work currently due to a mistake made when migrating over to singel fetch

## Solution

Resolved the error
- [x] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Run it locally, and access http://localhost:3000/guides/introduction
