### PR TITLE
Change "base" to "core"

### DIFF
--- a/.changeset/afraid-readers-hug.md
+++ b/.changeset/afraid-readers-hug.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": major
----
-
-InfoTag, LineIcon, TravelTag: Update to Chakra 3

--- a/.changeset/clean-roses-switch.md
+++ b/.changeset/clean-roses-switch.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-design-tokens": major
----
-
-Updated tokens to new syntax

--- a/.changeset/eight-forks-give.md
+++ b/.changeset/eight-forks-give.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-design-tokens": major
+"@vygruppen/spor-react": major
+---
+
+Name update: "base" is not "core" on all platforms. Colors and variants.

--- a/.changeset/eight-forks-give.md
+++ b/.changeset/eight-forks-give.md
@@ -3,4 +3,4 @@
 "@vygruppen/spor-react": major
 ---
 
-Name update: "base" is not "core" on all platforms. Colors and variants.
+Name update: "base" is now "core" on all platforms. Colors and variants.

--- a/.changeset/fuzzy-kangaroos-enjoy.md
+++ b/.changeset/fuzzy-kangaroos-enjoy.md
@@ -1,6 +1,0 @@
----
-"@vygruppen/spor-design-tokens": patch
-"@vygruppen/spor-react": patch
----
-
-Breadcrumb: updated to chakra 3

--- a/.changeset/great-moons-report.md
+++ b/.changeset/great-moons-report.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": major
----
-
-StaticCard: colorScheme is now colorPalette

--- a/.changeset/green-beans-check.md
+++ b/.changeset/green-beans-check.md
@@ -27,7 +27,14 @@ Spor is getting a major update with Chakra 3.
 - `Toast` prop `isClosable` is now `closable`. `useToast` is now `createToaster`.
 - `FormControl`, `FormLabel` and `FormErrorMessage` are removed and replaced by `Field`. `Field` supports the necessary props to support this.
 - `Separator` replaces `Divider`.
-- `UnorderedList` and ?  is deprecated. Use "as" prop instead.
+- `UnorderedList` and `OrderedList` is deprecated. Use `List` and `as` prop instead.
+
+### Darkmode
+
+`DarkMode` and `LightMode` has been removed. Use `className="dark"` instead.
+
+The `useColorMode` hook exports the state (`colorMode`) and toggle (`toggleColorMode`).
+
 
 ### Externals from Chakra:
 

--- a/.changeset/green-beans-check.md
+++ b/.changeset/green-beans-check.md
@@ -8,7 +8,7 @@ Spor is getting a major update with Chakra 3.
 
 ## Updated variants
 
-- `base` is now `default`
+- `base` is now `core`
 
 ### Update props
 
@@ -27,6 +27,7 @@ Spor is getting a major update with Chakra 3.
 - `Toast` prop `isClosable` is now `closable`. `useToast` is now `createToaster`.
 - `FormControl`, `FormLabel` and `FormErrorMessage` are removed and replaced by `Field`. `Field` supports the necessary props to support this.
 - `Separator` replaces `Divider`.
+- `UnorderedList` and ?  is deprecated. Use "as" prop instead.
 
 ### Externals from Chakra:
 

--- a/.changeset/hungry-planets-work.md
+++ b/.changeset/hungry-planets-work.md
@@ -1,6 +1,0 @@
----
-"@vygruppen/spor-design-tokens": patch
-"@vygruppen/spor-react": patch
----
-
-ProgressBar: made chakra 3 changes

--- a/.changeset/itchy-falcons-beam.md
+++ b/.changeset/itchy-falcons-beam.md
@@ -1,6 +1,0 @@
----
-"@vygruppen/spor-design-tokens": patch
-"@vygruppen/spor-react": patch
----
-
-Switch: updated to chakra 3

--- a/.changeset/lovely-drinks-compete.md
+++ b/.changeset/lovely-drinks-compete.md
@@ -1,6 +1,0 @@
----
-"@vygruppen/spor-design-tokens": patch
-"@vygruppen/spor-react": patch
----
-
-Textarea: updated to chakra 3

--- a/.changeset/ninety-terms-stare.md
+++ b/.changeset/ninety-terms-stare.md
@@ -1,6 +1,0 @@
----
-"@vygruppen/spor-design-tokens": patch
-"@vygruppen/spor-react": patch
----
-
-Checkbox: updated to chakra 3

--- a/.changeset/purple-bears-stare.md
+++ b/.changeset/purple-bears-stare.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": major
----
-
-Lists: UnorderedList and OrderedList is deprecated. Use "as" prop instead.

--- a/.changeset/red-dots-tickle.md
+++ b/.changeset/red-dots-tickle.md
@@ -1,6 +1,0 @@
----
-"@vygruppen/spor-design-tokens": patch
-"@vygruppen/spor-react": patch
----
-
-PressableCard: updated to chakra 3

--- a/.changeset/tame-weeks-repeat.md
+++ b/.changeset/tame-weeks-repeat.md
@@ -1,5 +1,0 @@
----
-"@vygruppen/spor-react": minor
----
-
-Divider: Updated with new syntax

--- a/packages/spor-design-tokens/tokens/color/cargonet.json
+++ b/packages/spor-design-tokens/tokens/color/cargonet.json
@@ -195,7 +195,7 @@
           }
         }
       },
-      "base": {
+      "core": {
         "surface": {
           "active": {
             "light": {

--- a/packages/spor-design-tokens/tokens/color/cargonet.json
+++ b/packages/spor-design-tokens/tokens/color/cargonet.json
@@ -209,10 +209,10 @@
         "outline": {
           "default": {
             "light": {
-              "value": "{color.cargonet.outline.default.light.value}"
+              "value": "{color.cargonet.outline.core.light.value}"
             },
             "dark": {
-              "value": "{color.cargonet.outline.default.dark.value}"
+              "value": "{color.cargonet.outline.core.dark.value}"
             }
           },
           "hover": {
@@ -226,18 +226,18 @@
         },
         "text": {
           "light": {
-            "value": "{color.cargonet.text.default.light.value}"
+            "value": "{color.cargonet.text.core.light.value}"
           },
           "dark": {
-            "value": "{color.cargonet.text.default.dark.value}"
+            "value": "{color.cargonet.text.core.dark.value}"
           }
         },
         "icon": {
           "light": {
-            "value": "{color.cargonet.icon.default.light.value}"
+            "value": "{color.cargonet.icon.core.light.value}"
           },
           "dark": {
-            "value": "{color.cargonet.icon.default.dark.value}"
+            "value": "{color.cargonet.icon.core.dark.value}"
           }
         }
       },
@@ -314,7 +314,7 @@
         },
         "text": {
           "light": {
-            "value": "{color.cargonet.text.default.light.value}"
+            "value": "{color.cargonet.text.core.light.value}"
           },
           "dark": {
             "value": "{color.alias.champagne.value}"
@@ -322,7 +322,7 @@
         },
         "icon": {
           "light": {
-            "value": "{color.cargonet.icon.default.light.value}"
+            "value": "{color.cargonet.icon.core.light.value}"
           },
           "dark": {
             "value": "{color.alias.champagne.value}"
@@ -384,18 +384,18 @@
         },
         "text": {
           "light": {
-            "value": "{color.cargonet.text.default.light.value}"
+            "value": "{color.cargonet.text.core.light.value}"
           },
           "dark": {
-            "value": "{color.cargonet.text.default.dark.value}"
+            "value": "{color.cargonet.text.core.dark.value}"
           }
         },
         "icon": {
           "light": {
-            "value": "{color.cargonet.icon.default.light.value}"
+            "value": "{color.cargonet.icon.core.light.value}"
           },
           "dark": {
-            "value": "{color.cargonet.icon.default.dark.value}"
+            "value": "{color.cargonet.icon.core.dark.value}"
           }
         }
       },
@@ -420,18 +420,18 @@
         },
         "text": {
           "light": {
-            "value": "{color.cargonet.text.default.light.value}"
+            "value": "{color.cargonet.text.core.light.value}"
           },
           "dark": {
-            "value": "{color.cargonet.text.default.dark.value}"
+            "value": "{color.cargonet.text.core.dark.value}"
           }
         },
         "icon": {
           "light": {
-            "value": "{color.cargonet.icon.default.light.value}"
+            "value": "{color.cargonet.icon.core.light.value}"
           },
           "dark": {
-            "value": "{color.cargonet.icon.default.dark.value}"
+            "value": "{color.cargonet.icon.core.dark.value}"
           }
         }
       }

--- a/packages/spor-design-tokens/tokens/color/vy-digital.json
+++ b/packages/spor-design-tokens/tokens/color/vy-digital.json
@@ -209,10 +209,10 @@
         "outline": {
           "default": {
             "light": {
-              "value": "{color.vyDigital.outline.default.light.value}"
+              "value": "{color.vyDigital.outline.core.light.value}"
             },
             "dark": {
-              "value": "{color.vyDigital.outline.default.dark.value}"
+              "value": "{color.vyDigital.outline.core.dark.value}"
             }
           },
           "hover": {
@@ -226,18 +226,18 @@
         },
         "text": {
           "light": {
-            "value": "{color.vyDigital.text.default.light.value}"
+            "value": "{color.vyDigital.text.core.light.value}"
           },
           "dark": {
-            "value": "{color.vyDigital.text.default.dark.value}"
+            "value": "{color.vyDigital.text.core.dark.value}"
           }
         },
         "icon": {
           "light": {
-            "value": "{color.vyDigital.icon.default.light.value}"
+            "value": "{color.vyDigital.icon.core.light.value}"
           },
           "dark": {
-            "value": "{color.vyDigital.icon.default.dark.value}"
+            "value": "{color.vyDigital.icon.core.dark.value}"
           }
         }
       },
@@ -360,7 +360,7 @@
               "value": "{color.alias.mint.value}"
             },
             "dark": {
-              "value": "{color.vyDigital.bg.default.dark.value}"
+              "value": "{color.vyDigital.bg.core.dark.value}"
             }
           }
         },
@@ -392,18 +392,18 @@
         },
         "text": {
           "light": {
-            "value": "{color.vyDigital.text.default.light.value}"
+            "value": "{color.vyDigital.text.core.light.value}"
           },
           "dark": {
-            "value": "{color.vyDigital.text.default.dark.value}"
+            "value": "{color.vyDigital.text.core.dark.value}"
           }
         },
         "icon": {
           "light": {
-            "value": "{color.vyDigital.icon.default.light.value}"
+            "value": "{color.vyDigital.icon.core.light.value}"
           },
           "dark": {
-            "value": "{color.vyDigital.icon.default.dark.value}"
+            "value": "{color.vyDigital.icon.core.dark.value}"
           }
         }
       },
@@ -428,18 +428,18 @@
         },
         "text": {
           "light": {
-            "value": "{color.vyDigital.text.default.light.value}"
+            "value": "{color.vyDigital.text.core.light.value}"
           },
           "dark": {
-            "value": "{color.vyDigital.text.default.dark.value}"
+            "value": "{color.vyDigital.text.core.dark.value}"
           }
         },
         "icon": {
           "light": {
-            "value": "{color.vyDigital.icon.default.light.value}"
+            "value": "{color.vyDigital.icon.core.light.value}"
           },
           "dark": {
-            "value": "{color.vyDigital.icon.default.dark.value}"
+            "value": "{color.vyDigital.icon.core.dark.value}"
           }
         }
       }

--- a/packages/spor-design-tokens/tokens/color/vy-digital.json
+++ b/packages/spor-design-tokens/tokens/color/vy-digital.json
@@ -195,7 +195,7 @@
           }
         }
       },
-      "base": {
+      "core": {
         "surface": {
           "active": {
             "light": {

--- a/packages/spor-react/CHANGELOG.md
+++ b/packages/spor-react/CHANGELOG.md
@@ -386,7 +386,7 @@
 
 ### Patch Changes
 
-- 7838d12: Removed coreBackground from base variant on most of the components.
+- 7838d12: Removed baseBackground from base variant on most of the components.
 - 162650e: CardSelect: Improve JSDoc
 - Updated dependencies [df1ae12]
   - @vygruppen/spor-design-tokens@3.5.3

--- a/packages/spor-react/CHANGELOG.md
+++ b/packages/spor-react/CHANGELOG.md
@@ -386,7 +386,7 @@
 
 ### Patch Changes
 
-- 7838d12: Removed baseBackground from base variant on most of the components.
+- 7838d12: Removed coreBackground from base variant on most of the components.
 - 162650e: CardSelect: Improve JSDoc
 - Updated dependencies [df1ae12]
   - @vygruppen/spor-design-tokens@3.5.3

--- a/packages/spor-react/src/breadcrumb/Breadcrumb.tsx
+++ b/packages/spor-react/src/breadcrumb/Breadcrumb.tsx
@@ -17,8 +17,11 @@ type BreadcrumbVariants = RecipeVariantProps<typeof breadcrumbRecipe>;
 export type BreadcrumbProps = BoxProps &
   PropsWithChildren<BreadcrumbVariants> & {
     children: React.ReactNode;
-    variant?: "base" | "ghost";
+    /* "core" or "ghost". Defaults to "core". */
+    variant?: "core" | "ghost";
+    /* Seperator for the crumbs */
     separator?: React.ReactNode;
+    /* Spacing between the seperator */
     separatorGap?: string | number;
   };
 
@@ -41,7 +44,7 @@ export type BreadcrumbProps = BoxProps &
 export const Breadcrumb = forwardRef<HTMLDivElement, BreadcrumbProps>(
   (
     {
-      variant = "base",
+      variant = "core",
       separator,
       separatorGap = "0.5rem",
       children,

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -18,11 +18,17 @@ export type ButtonProps = Exclude<
   "size" | "variant" | "colorPalette"
 > &
   PropsWithChildren<ButtonVariantProps> & {
+    /* Boolean value for loading state */
     loading?: boolean;
+    /* You may display a different loading text */
     loadingText?: React.ReactNode;
+    /* Display icon to the left */
     leftIcon?: React.ReactNode;
+    /* Display icon to the right */
     rightIcon?: React.ReactNode;
+    /* "primary" | "secondary" | "tertiary" | "ghost" | "floating". Defaults to primary. */
     variant: "primary" | "secondary" | "tertiary" | "ghost" | "floating";
+    /* "lg" | "md" | "sm" | "xs". Defaults to md. */
     size?: "lg" | "md" | "sm" | "xs";
   };
 /**
@@ -59,7 +65,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       loading,
       disabled,
       loadingText,
-      variant,
+      variant = "primary",
       size = "md",
       leftIcon,
       rightIcon,

--- a/packages/spor-react/src/button/FloatingActionButton.tsx
+++ b/packages/spor-react/src/button/FloatingActionButton.tsx
@@ -10,7 +10,7 @@ type FloatingActionButtonVariantProps = RecipeVariantProps<
 
 type FloatingActionButtonProps = BoxProps &
   PropsWithChildren<FloatingActionButtonVariantProps> & {
-    variant?: "accent" | "base" | "brand";
+    variant?: "accent" | "core" | "brand";
     placement?: "bottom right" | "bottom left" | "top right" | "top left";
     icon: React.ReactNode;
     children: React.ReactNode;

--- a/packages/spor-react/src/datepicker/Calendar.tsx
+++ b/packages/spor-react/src/datepicker/Calendar.tsx
@@ -15,10 +15,10 @@ import { CalendarHeader } from "./CalendarHeader";
 import { useCurrentLocale } from "./utils";
 import { CalendarVariants } from "./types";
 
-type CalendarProps = ReactAriaCalendarProps<DateValue> & {
-  showYearNavigation?: boolean;
-  variant: CalendarVariants;
-};
+type CalendarProps = ReactAriaCalendarProps<DateValue> &
+  CalendarVariants & {
+    showYearNavigation?: boolean;
+  };
 export function Calendar({
   showYearNavigation,
   variant,

--- a/packages/spor-react/src/datepicker/Calendar.tsx
+++ b/packages/spor-react/src/datepicker/Calendar.tsx
@@ -13,10 +13,11 @@ import { createTexts, useTranslation } from "../i18n";
 import { CalendarGrid } from "./CalendarGrid";
 import { CalendarHeader } from "./CalendarHeader";
 import { useCurrentLocale } from "./utils";
+import { CalendarVariants } from "./types";
 
 type CalendarProps = ReactAriaCalendarProps<DateValue> & {
   showYearNavigation?: boolean;
-  variant: ConditionalValue<"base" | "floating" | "ghost">;
+  variant: CalendarVariants;
 };
 export function Calendar({
   showYearNavigation,

--- a/packages/spor-react/src/datepicker/CalendarCell.tsx
+++ b/packages/spor-react/src/datepicker/CalendarCell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, useSlotRecipe } from "@chakra-ui/react";
+import { Box, ConditionalValue, useSlotRecipe } from "@chakra-ui/react";
 import {
   CalendarDate,
   DateValue,
@@ -14,12 +14,12 @@ import { DatePickerVariantProps } from "./DatePicker";
 import { datePickerSlotRecipe } from "../theme/slot-recipes/datepicker";
 import { CalendarVariants } from "./types";
 
-type CalendarCellProps = PropsWithChildren<DatePickerVariantProps> & {
-  variant: CalendarVariants;
-  state: CalendarState | RangeCalendarState;
-  date: CalendarDate;
-  currentMonth: DateValue;
-};
+type CalendarCellProps = PropsWithChildren<DatePickerVariantProps> &
+  CalendarVariants & {
+    state: CalendarState | RangeCalendarState;
+    date: CalendarDate;
+    currentMonth: DateValue;
+  };
 export function CalendarCell({
   state,
   date,

--- a/packages/spor-react/src/datepicker/CalendarCell.tsx
+++ b/packages/spor-react/src/datepicker/CalendarCell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, ConditionalValue, useSlotRecipe } from "@chakra-ui/react";
+import { Box, useSlotRecipe } from "@chakra-ui/react";
 import {
   CalendarDate,
   DateValue,
@@ -12,9 +12,10 @@ import { useCalendarCell } from "react-aria";
 import { CalendarState, RangeCalendarState } from "react-stately";
 import { DatePickerVariantProps } from "./DatePicker";
 import { datePickerSlotRecipe } from "../theme/slot-recipes/datepicker";
+import { CalendarVariants } from "./types";
 
 type CalendarCellProps = PropsWithChildren<DatePickerVariantProps> & {
-  variant: ConditionalValue<"base" | "floating" | "ghost">;
+  variant: CalendarVariants;
   state: CalendarState | RangeCalendarState;
   date: CalendarDate;
   currentMonth: DateValue;

--- a/packages/spor-react/src/datepicker/CalendarGrid.tsx
+++ b/packages/spor-react/src/datepicker/CalendarGrid.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { endOfMonth, getWeeksInMonth } from "@internationalized/date";
 import React from "react";
 import { AriaCalendarGridProps, useCalendarGrid } from "react-aria";
@@ -7,8 +8,9 @@ import { Language, useTranslation } from "../i18n";
 import { Text } from "../typography";
 import { CalendarCell } from "./CalendarCell";
 import { useCurrentLocale } from "./utils";
-import { ConditionalValue, useSlotRecipe } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react";
 import { datePickerSlotRecipe } from "../theme/slot-recipes/datepicker";
+import { CalendarVariants } from "./types";
 
 const weekDays: Record<Language, string[]> = {
   nb: ["Ma", "Ti", "On", "To", "Fr", "Lø", "Sø"],
@@ -18,7 +20,7 @@ const weekDays: Record<Language, string[]> = {
 };
 
 type CalendarGridProps = AriaCalendarGridProps & {
-  variant: ConditionalValue<"base" | "floating" | "ghost">;
+  variant: CalendarVariants;
   state: CalendarState | RangeCalendarState;
   offset?: { months?: number };
 };

--- a/packages/spor-react/src/datepicker/CalendarGrid.tsx
+++ b/packages/spor-react/src/datepicker/CalendarGrid.tsx
@@ -8,7 +8,7 @@ import { Language, useTranslation } from "../i18n";
 import { Text } from "../typography";
 import { CalendarCell } from "./CalendarCell";
 import { useCurrentLocale } from "./utils";
-import { useSlotRecipe } from "@chakra-ui/react";
+import { ConditionalValue, useSlotRecipe } from "@chakra-ui/react";
 import { datePickerSlotRecipe } from "../theme/slot-recipes/datepicker";
 import { CalendarVariants } from "./types";
 
@@ -19,11 +19,11 @@ const weekDays: Record<Language, string[]> = {
   en: ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
 };
 
-type CalendarGridProps = AriaCalendarGridProps & {
-  variant: CalendarVariants;
-  state: CalendarState | RangeCalendarState;
-  offset?: { months?: number };
-};
+type CalendarGridProps = AriaCalendarGridProps &
+  CalendarVariants & {
+    state: CalendarState | RangeCalendarState;
+    offset?: { months?: number };
+  };
 export function CalendarGrid({
   state,
   variant,

--- a/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
+++ b/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { BoxProps, PopoverAnchor, useSlotRecipe } from "@chakra-ui/react";
+import {
+  BoxProps,
+  ConditionalValue,
+  PopoverAnchor,
+  useSlotRecipe,
+} from "@chakra-ui/react";
 import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
 import React, {
   forwardRef,
@@ -19,8 +24,8 @@ import { CalendarVariants } from "./types";
 
 type CalendarTriggerButtonProps = AriaButtonProps<"button"> &
   PropsWithChildren<DatePickerVariantProps> &
-  BoxProps & {
-    variant: CalendarVariants;
+  BoxProps &
+  CalendarVariants & {
     disabled?: boolean;
     ariaLabelledby?: string;
   };

--- a/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
+++ b/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  BoxProps,
-  ConditionalValue,
-  PopoverAnchor,
-  useSlotRecipe,
-} from "@chakra-ui/react";
+import { BoxProps, PopoverAnchor, useSlotRecipe } from "@chakra-ui/react";
 import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
 import React, {
   forwardRef,
@@ -20,11 +15,12 @@ import {
   useTranslation,
 } from "..";
 import { datePickerSlotRecipe } from "../theme/slot-recipes/datepicker";
+import { CalendarVariants } from "./types";
 
 type CalendarTriggerButtonProps = AriaButtonProps<"button"> &
   PropsWithChildren<DatePickerVariantProps> &
   BoxProps & {
-    variant: ConditionalValue<"base" | "floating" | "ghost">;
+    variant: CalendarVariants;
     disabled?: boolean;
     ariaLabelledby?: string;
   };

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -2,7 +2,6 @@
 import {
   Box,
   BoxProps,
-  ConditionalValue,
   PopoverAnchor,
   Portal,
   RecipeVariantProps,
@@ -37,6 +36,7 @@ import {
   PopoverTrigger,
 } from "../popover";
 import { Field } from "../input/Field";
+import { CalendarVariants } from "./types";
 
 export type DatePickerVariantProps = RecipeVariantProps<
   typeof datePickerSlotRecipe
@@ -45,7 +45,7 @@ export type DatePickerVariantProps = RecipeVariantProps<
 type DatePickerProps = Omit<AriaDatePickerProps<DateValue>, "onChange"> &
   Pick<BoxProps, "minHeight" | "width"> &
   PropsWithChildren<DatePickerVariantProps> & {
-    variant: ConditionalValue<"base" | "floating" | "ghost">;
+    variant: CalendarVariants;
     name?: string;
     showYearNavigation?: boolean;
     withPortal?: boolean;
@@ -56,10 +56,10 @@ type DatePickerProps = Omit<AriaDatePickerProps<DateValue>, "onChange"> &
 /**
  * A date picker component.
  *
- * There are three different variants – `base`, `floating` and `ghost`.
+ * There are three different variants – `core`, `floating` and `ghost`.
  *
  * ```tsx
- * <DatePicker label="Dato" variant="base" />
+ * <DatePicker label="Dato" variant="core" />
  * ```
  */
 

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -44,8 +44,8 @@ export type DatePickerVariantProps = RecipeVariantProps<
 
 type DatePickerProps = Omit<AriaDatePickerProps<DateValue>, "onChange"> &
   Pick<BoxProps, "minHeight" | "width"> &
-  PropsWithChildren<DatePickerVariantProps> & {
-    variant: CalendarVariants;
+  PropsWithChildren<DatePickerVariantProps> &
+  CalendarVariants & {
     name?: string;
     showYearNavigation?: boolean;
     withPortal?: boolean;

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -2,6 +2,7 @@
 import {
   Box,
   BoxProps,
+  ConditionalValue,
   PopoverAnchor,
   Portal,
   useFieldContext,
@@ -37,12 +38,12 @@ type DateRangePickerProps = Omit<
   "onChange"
 > &
   Pick<BoxProps, "minHeight"> &
-  PropsWithChildren<DatePickerVariantProps> & {
+  PropsWithChildren<DatePickerVariantProps> &
+  CalendarVariants & {
     startLabel?: string;
     startName?: string;
     endLabel?: string;
     endName?: string;
-    variant?: CalendarVariants;
     withPortal?: boolean;
     onChange?: (
       dates: {

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -109,7 +109,7 @@ export function DateRangePicker({
     <PopoverContent css={styles.calendarPopover} maxWidth="none">
       <PopoverArrow />
       <PopoverBody>
-        <RangeCalendar variant={"bcorease"} {...calendarProps} />
+        <RangeCalendar variant={"core"} {...calendarProps} />
       </PopoverBody>
     </PopoverContent>
   );

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -2,7 +2,6 @@
 import {
   Box,
   BoxProps,
-  ConditionalValue,
   PopoverAnchor,
   Portal,
   useFieldContext,
@@ -31,6 +30,7 @@ import {
 import { Field } from "../input/Field";
 import { DatePickerVariantProps } from "./DatePicker";
 import { datePickerSlotRecipe } from "../theme/slot-recipes/datepicker";
+import { CalendarVariants } from "./types";
 
 type DateRangePickerProps = Omit<
   AriaDateRangePickerProps<DateValue>,
@@ -42,7 +42,7 @@ type DateRangePickerProps = Omit<
     startName?: string;
     endLabel?: string;
     endName?: string;
-    variant: ConditionalValue<"base" | "floating" | "ghost">;
+    variant?: CalendarVariants;
     withPortal?: boolean;
     onChange?: (
       dates: {
@@ -54,10 +54,10 @@ type DateRangePickerProps = Omit<
 /**
  * A date range picker component.
  *
- * There are three variants to choose from – `base`, `floating` and `ghost`.
+ * There are three variants to choose from – `core`, `floating` and `ghost`.
  *
  * ```tsx
- * <DateRangePicker startLabel="From" startName="from" endLabel="To" endName="to" variant="base" />
+ * <DateRangePicker startLabel="From" startName="from" endLabel="To" endName="to" variant="core" />
  * ```
  */
 export function DateRangePicker({
@@ -94,7 +94,7 @@ export function DateRangePicker({
   const locale = useCurrentLocale();
 
   const handleEnterClick = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !state.isOpen && variant === "base") {
+    if (e.key === "Enter" && !state.isOpen && variant === "core") {
       // Don't submit the form
       e.stopPropagation();
       state.setOpen(true);
@@ -109,7 +109,7 @@ export function DateRangePicker({
     <PopoverContent css={styles.calendarPopover} maxWidth="none">
       <PopoverArrow />
       <PopoverBody>
-        <RangeCalendar variant={"base"} {...calendarProps} />
+        <RangeCalendar variant={"bcorease"} {...calendarProps} />
       </PopoverBody>
     </PopoverContent>
   );

--- a/packages/spor-react/src/datepicker/RangeCalendar.tsx
+++ b/packages/spor-react/src/datepicker/RangeCalendar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box, ConditionalValue } from "@chakra-ui/react";
+import { Box } from "@chakra-ui/react";
 import { DateValue, createCalendar } from "@internationalized/date";
 import React, { useRef } from "react";
 import {
@@ -10,9 +10,10 @@ import { useRangeCalendarState } from "react-stately";
 import { CalendarGrid } from "./CalendarGrid";
 import { CalendarHeader } from "./CalendarHeader";
 import { useCurrentLocale } from "./utils";
+import { CalendarVariants } from "./types";
 
 type RangeCalendarProps = ReactAriaRangeCalendarProps<DateValue> & {
-  variant: ConditionalValue<"base" | "floating" | "ghost">;
+  variant: CalendarVariants;
 };
 
 export function RangeCalendar(props: RangeCalendarProps) {

--- a/packages/spor-react/src/datepicker/RangeCalendar.tsx
+++ b/packages/spor-react/src/datepicker/RangeCalendar.tsx
@@ -12,9 +12,8 @@ import { CalendarHeader } from "./CalendarHeader";
 import { useCurrentLocale } from "./utils";
 import { CalendarVariants } from "./types";
 
-type RangeCalendarProps = ReactAriaRangeCalendarProps<DateValue> & {
-  variant: CalendarVariants;
-};
+type RangeCalendarProps = ReactAriaRangeCalendarProps<DateValue> &
+  CalendarVariants;
 
 export function RangeCalendar(props: RangeCalendarProps) {
   const locale = useCurrentLocale();

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -11,8 +11,8 @@ import { datePickerSlotRecipe } from "../theme/slot-recipes/datepicker";
 import { CalendarVariants } from "./types";
 
 type StyledFieldProps = BoxProps &
-  PropsWithChildren<DatePickerVariantProps> & {
-    variant: CalendarVariants;
+  PropsWithChildren<DatePickerVariantProps> &
+  CalendarVariants & {
     isDisabled?: boolean;
     ariaLabelledby?: string;
   };

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -2,17 +2,17 @@
 import {
   Box,
   BoxProps,
-  ConditionalValue,
   useFieldContext,
   useSlotRecipe,
 } from "@chakra-ui/react";
 import React, { forwardRef, PropsWithChildren } from "react";
 import { DatePickerVariantProps } from "./DatePicker";
 import { datePickerSlotRecipe } from "../theme/slot-recipes/datepicker";
+import { CalendarVariants } from "./types";
 
 type StyledFieldProps = BoxProps &
   PropsWithChildren<DatePickerVariantProps> & {
-    variant: ConditionalValue<"base" | "floating" | "ghost">;
+    variant: CalendarVariants;
     isDisabled?: boolean;
     ariaLabelledby?: string;
   };

--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -126,7 +126,7 @@ export const TimePicker = ({
   )}`;
   return (
     <StyledField
-      variant="base"
+      variant="core"
       width="fit-content"
       paddingX={2}
       alignItems="center"

--- a/packages/spor-react/src/datepicker/types.ts
+++ b/packages/spor-react/src/datepicker/types.ts
@@ -1,1 +1,5 @@
-export type CalendarVariants = "core" | "floating" | "ghost";
+import { ConditionalValue } from "@chakra-ui/react";
+
+export type CalendarVariants = {
+  variant?: ConditionalValue<"core" | "floating" | "ghost">;
+};

--- a/packages/spor-react/src/datepicker/types.ts
+++ b/packages/spor-react/src/datepicker/types.ts
@@ -1,0 +1,1 @@
+export type CalendarVariants = "core" | "floating" | "ghost";

--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -5,7 +5,6 @@ import {
   chakra,
   ConditionalValue,
   Flex,
-  Icon,
   RecipeVariantProps,
   useSlotRecipe,
 } from "@chakra-ui/react";
@@ -34,10 +33,10 @@ type CardSelectProps = BoxProps &
     /** The design of the trigger button.
      *
      * - `ghost` is a transparent button with text
-     * - `base` is a button with a border and text
+     * - `core` is a button with a border and text
      * - `floating` is a button with a drop shadow (like a card) and text
      */
-    variant: "base" | "ghost" | "floating";
+    variant: "core" | "ghost" | "floating";
     /** The size of the trigger button */
     size: "sm" | "md" | "lg";
     /** Whether the card select is open / active, if controlled */

--- a/packages/spor-react/src/input/ChoiceChip.tsx
+++ b/packages/spor-react/src/input/ChoiceChip.tsx
@@ -29,7 +29,7 @@ export type ChoiceChipProps = PropsWithChildren<ChoiceChipVariantProps> & {
   };
   size?: "xs" | "sm" | "md" | "lg";
   chipType?: "icon" | "choice" | "filter";
-  variant?: "base" | "accent" | "floating";
+  variant?: "core" | "accent" | "floating";
 };
 /**
  * Choice chips are checkboxes that look like selectable buttons.
@@ -52,11 +52,11 @@ export type ChoiceChipProps = PropsWithChildren<ChoiceChipVariantProps> & {
  *  <ChoiceChip chipType="filter" icon={<Bus24Icon />}>Bus</ChoiceChip>
  * </Stack>
  *
- * There are also three different variants - `base`, `accent` and `floating`.
+ * There are also three different variants - `core`, `accent` and `floating`.
  *
  * ```tsx
  * <Stack flexDirection="row">
- *   <ChoiceChip variant="base">Bus</ChoiceChip>
+ *   <ChoiceChip variant="core">Bus</ChoiceChip>
  *   <ChoiceChip variant="accent">Boat</ChoiceChip>
  *   <ChoiceChip variant="floating">Train</ChoiceChip>
  * </Stack>
@@ -71,7 +71,7 @@ export const ChoiceChip = forwardRef(
       checked,
       size = "sm",
       chipType = "choice",
-      variant = "base",
+      variant = "core",
       ...props
     }: ChoiceChipProps,
     ref,

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -7,7 +7,6 @@ import {
   RecipeVariantProps,
   useSlotRecipe,
   type BoxProps,
-  ConditionalValue,
 } from "@chakra-ui/react";
 import type { Node } from "@react-types/shared";
 import React, {

--- a/packages/spor-react/src/layout/PressableCard.tsx
+++ b/packages/spor-react/src/layout/PressableCard.tsx
@@ -8,7 +8,7 @@ type PressableCardVariants = RecipeVariantProps<typeof pressableCardRecipe>;
 type PressableCardProps = BoxProps &
   PropsWithChildren<PressableCardVariants> & {
     children: React.ReactNode;
-    variant?: "floating" | "accent" | "base";
+    variant?: "floating" | "accent" | "core";
   };
 
 /**
@@ -18,7 +18,7 @@ type PressableCardProps = BoxProps &
  * It can be rendered as a button, link, label, or any other HTML element by specifying the `as` prop.
  * If no `as` prop is provided, it defaults to a button.
  *
- * The `variant` prop can be used to control the style variant of the card. It defaults to "base".
+ * The `variant` prop can be used to control the style variant of the card. It defaults to "core".
  *
  * Example usage:
  *
@@ -42,7 +42,7 @@ type PressableCardProps = BoxProps &
  */
 
 export const PressableCard = forwardRef<HTMLDivElement, PressableCardProps>(
-  ({ variant = "base", children, ...props }, ref) => {
+  ({ variant = "core", children, ...props }, ref) => {
     const recipe = useRecipe({ recipe: pressableCardRecipe });
     const styles = recipe({ variant });
     return (

--- a/packages/spor-react/src/layout/RadioCard.tsx
+++ b/packages/spor-react/src/layout/RadioCard.tsx
@@ -37,7 +37,7 @@ type RadioCardItemProps = Exclude<
     description?: React.ReactNode;
     addon?: React.ReactNode;
     inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-    variant?: "base" | "floating";
+    variant?: "core" | "floating";
   };
 
 export const RadioCardItem = React.forwardRef<
@@ -74,7 +74,7 @@ export const RadioCardItem = React.forwardRef<
 type RadioCardRootProps = RadioCardVariantProps &
   Exclude<ChakraRadioCard.RootProps, "variant"> & {
     children: React.ReactNode;
-    variant?: "base" | "floating";
+    variant?: "core" | "floating";
   };
 
 export const RadioCardRoot = forwardRef<HTMLDivElement, RadioCardRootProps>(

--- a/packages/spor-react/src/nudge/Nudge.tsx
+++ b/packages/spor-react/src/nudge/Nudge.tsx
@@ -74,7 +74,7 @@ const EXPIRATION_DELAY = 1000 * 60 * 60 * 24 * 30; // 30 days
  *  name="my-nudge"
  *  content="Check out this enormous new feature!"
  * >
- *   <StaticCard variant="base" padding={2} width="fit-content">My new feature</StaticCard>
+ *   <StaticCard colorPalette="blue" padding={2} width="fit-content">My new feature</StaticCard>
  * </Nudge>
  * ```
  */

--- a/packages/spor-react/src/stepper/Stepper.tsx
+++ b/packages/spor-react/src/stepper/Stepper.tsx
@@ -30,9 +30,9 @@ type StepperProps = PropsWithChildren<StepperVariantProps> & {
   /** The labels of each step */
   steps: string[];
   /** The variant.
-   * "base" has a transparent background,
+   * "core" has a transparent background,
    * while "accent" has a slight accent color  */
-  variant: "base" | "accent";
+  variant: "core" | "accent";
   /** Disables all clicks */
   disabled?: boolean;
 };

--- a/packages/spor-react/src/stepper/StepperContext.tsx
+++ b/packages/spor-react/src/stepper/StepperContext.tsx
@@ -9,7 +9,7 @@ type StepperContextType = {
 };
 const StepperContext = React.createContext<StepperContextType | null>(null);
 
-type Variant = "base" | "accent";
+type Variant = "core" | "accent";
 
 type StepperProviderProps = {
   /** Stepper steps */

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -8,7 +8,7 @@ import { useSlotRecipe } from "@chakra-ui/react";
 type StepperStepProps = PropsWithChildren<StepperVariantProps> & {
   children: React.ReactNode;
   stepNumber: number;
-  variant: "base" | "accent";
+  variant: "core" | "accent";
   disabled?: boolean;
 };
 export const StepperStep = ({

--- a/packages/spor-react/src/tab/Tabs.tsx
+++ b/packages/spor-react/src/tab/Tabs.tsx
@@ -16,13 +16,13 @@ export type TabsProps = Exclude<
   "colorPalette" | "variant" | "orientation" | "size"
 > &
   PropsWithChildren<TabsVariantProps> & {
-    /** Defaults to `default` */
-    variant?: "default" | "accent";
+    /** Defaults to `core` */
+    variant?: "core" | "accent";
     /** Defaults to `sm` */
     size?: "xs" | "sm" | "md" | "lg";
   };
 export const Tabs = forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
-  const { variant = "default", size = "sm" } = props;
+  const { variant = "core", size = "sm" } = props;
   return <ChakraTabs.Root {...props} ref={ref} variant={variant} size={size} />;
 });
 

--- a/packages/spor-react/src/theme/recipes/breadcrumb.ts
+++ b/packages/spor-react/src/theme/recipes/breadcrumb.ts
@@ -22,7 +22,7 @@ export const breadcrumbRecipe = defineRecipe({
     },
   },
   variants: {
-    base: {
+    core: {
       "&:not([aria-current=page])": {
         _hover: {
           ...baseBorder("default"),

--- a/packages/spor-react/src/theme/recipes/breadcrumb.ts
+++ b/packages/spor-react/src/theme/recipes/breadcrumb.ts
@@ -1,4 +1,4 @@
-import { baseBackground, baseBorder } from "../utils/base-utils";
+import { coreBackground, coreBorder } from "../utils/core-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { ghostBackground } from "../utils/ghost-utils";
 import { defineRecipe } from "@chakra-ui/react";
@@ -25,10 +25,10 @@ export const breadcrumbRecipe = defineRecipe({
     core: {
       "&:not([aria-current=page])": {
         _hover: {
-          ...baseBorder("default"),
+          ...coreBorder("default"),
         },
         _active: {
-          ...baseBackground("active"),
+          ...coreBackground("active"),
         },
       },
     },

--- a/packages/spor-react/src/theme/recipes/button.ts
+++ b/packages/spor-react/src/theme/recipes/button.ts
@@ -1,7 +1,7 @@
 import { defineRecipe } from "@chakra-ui/react";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { surface } from "../utils/surface-utils";
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 import { ghostBackground } from "../utils/ghost-utils";
 import { accentBackground, accentText } from "../utils/accent-utils";
@@ -27,7 +27,7 @@ export const buttonRecipe = defineRecipe({
       pointerEvents: "none",
       boxShadow: "none",
       ...surface("disabled"),
-      ...baseText("disabled"),
+      ...coreText("disabled"),
     },
   },
   variants: {
@@ -53,26 +53,26 @@ export const buttonRecipe = defineRecipe({
         },
       },
       tertiary: {
-        ...baseBackground("default"),
-        ...baseText("default"),
-        ...baseBorder("default"),
+        ...coreBackground("default"),
+        ...coreText("default"),
+        ...coreBorder("default"),
 
         _hover: {
-          ...baseBorder("hover"),
-          ...baseBackground("hover"),
+          ...coreBorder("hover"),
+          ...coreBackground("hover"),
           _active: {
-            ...baseBorder("default"),
-            ...baseBackground("active"),
+            ...coreBorder("default"),
+            ...coreBackground("active"),
           },
         },
       },
       ghost: {
         ...ghostBackground("default"),
-        ...baseText("default"),
+        ...coreText("default"),
         _hover: {
           ...ghostBackground("hover"),
           _disabled: {
-            ...baseText("disabled"),
+            ...coreText("disabled"),
           },
           _active: {
             ...ghostBackground("active"),

--- a/packages/spor-react/src/theme/recipes/input.ts
+++ b/packages/spor-react/src/theme/recipes/input.ts
@@ -1,7 +1,7 @@
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { defineRecipe } from "@chakra-ui/react";
 import { surface } from "../utils/surface-utils";
-import { baseBackground, baseBorder } from "../utils/base-utils";
+import { coreBackground, coreBorder } from "../utils/core-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 
 export const inputRecipe = defineRecipe({
@@ -25,29 +25,29 @@ export const inputRecipe = defineRecipe({
 
     _disabled: {
       ...surface("disabled"),
-      ...baseBorder("disabled"),
+      ...coreBorder("disabled"),
       pointerEvents: "none",
     },
     _invalid: {
-      ...baseBorder("invalid"),
+      ...coreBorder("invalid"),
       _hover: {
-        ...baseBorder("hover"),
+        ...coreBorder("hover"),
       },
     },
   },
   variants: {
     variant: {
       core: {
-        ...baseBackground("default"),
-        ...baseBorder("default"),
+        ...coreBackground("default"),
+        ...coreBorder("default"),
         _hover: {
-          ...baseBorder("hover"),
+          ...coreBorder("hover"),
         },
         _active: {
-          ...baseBorder("active"),
+          ...coreBorder("active"),
         },
         _focus: {
-          ...baseBorder("focus"),
+          ...coreBorder("focus"),
         },
       },
       floating: {

--- a/packages/spor-react/src/theme/recipes/link.ts
+++ b/packages/spor-react/src/theme/recipes/link.ts
@@ -1,5 +1,5 @@
 import { defineRecipe } from "@chakra-ui/react";
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { brandBackground, brandText } from "../utils/brand-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 
@@ -47,7 +47,7 @@ export const linkRecipe = defineRecipe({
     {
       variant: "primary",
       css: {
-        ...baseText("default"),
+        ...coreText("default"),
       },
       _hover: {
         ...brandText("hover"),
@@ -58,19 +58,19 @@ export const linkRecipe = defineRecipe({
       variant: "secondary",
       css: {
         backgroundImage: `linear-gradient("blackAlpha.400", "blackAlpha.400")`,
-        ...baseText("default"),
+        ...coreText("default"),
         "&:focus, &:focus-visible, &:active, &:hover": {
           outline: "1px solid",
         },
       },
-      ...baseBackground("default"),
+      ...coreBackground("default"),
       _hover: {
-        ...baseBorder("hover"), // TODO: This is also weird
-        ...baseBackground("hover"),
+        ...coreBorder("hover"), // TODO: This is also weird
+        ...coreBackground("hover"),
         outlineWidth: 1,
       },
       _active: {
-        ...baseBackground("active"),
+        ...coreBackground("active"),
       },
     },
   ],

--- a/packages/spor-react/src/theme/recipes/pressable-card.ts
+++ b/packages/spor-react/src/theme/recipes/pressable-card.ts
@@ -1,4 +1,4 @@
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 import { accentBackground, accentText } from "../utils/accent-utils";
 import { defineRecipe } from "../../util";
@@ -16,9 +16,9 @@ export const pressableCardRecipe = defineRecipe({
     transitionDuration: "fast",
 
     _disabled: {
-      ...baseBackground("disabled"),
-      ...baseBorder("disabled"),
-      ...baseText("disabled"),
+      ...coreBackground("disabled"),
+      ...coreBorder("disabled"),
+      ...coreText("disabled"),
       outline: "none",
       pointerEvents: "none",
     },
@@ -28,13 +28,13 @@ export const pressableCardRecipe = defineRecipe({
     variant: {
       core: {
         cursor: "pointer",
-        ...baseBorder("default"),
+        ...coreBorder("default"),
         _hover: {
-          ...baseBorder("hover"),
+          ...coreBorder("hover"),
         },
         _active: {
-          ...baseBackground("active"),
-          ...baseBorder("active"),
+          ...coreBackground("active"),
+          ...coreBorder("active"),
         },
       },
       accent: {

--- a/packages/spor-react/src/theme/recipes/pressable-card.ts
+++ b/packages/spor-react/src/theme/recipes/pressable-card.ts
@@ -26,7 +26,7 @@ export const pressableCardRecipe = defineRecipe({
 
   variants: {
     variant: {
-      base: {
+      core: {
         cursor: "pointer",
         ...baseBorder("default"),
         _hover: {
@@ -68,6 +68,6 @@ export const pressableCardRecipe = defineRecipe({
     },
   },
   defaultVariants: {
-    variant: "base",
+    variant: "core",
   },
 });

--- a/packages/spor-react/src/theme/recipes/textarea.ts
+++ b/packages/spor-react/src/theme/recipes/textarea.ts
@@ -27,7 +27,7 @@ export const textareaRecipe = defineRecipe({
   },
   variants: {
     variant: {
-      base: {
+      core: {
         ...inputVariant("base"),
       },
       floating: {
@@ -53,7 +53,7 @@ export const textareaRecipe = defineRecipe({
     },
   },
   defaultVariants: {
-    variant: "base",
+    variant: "core",
     size: "md",
   },
 });

--- a/packages/spor-react/src/theme/semantic-tokens/cargonet.ts
+++ b/packages/spor-react/src/theme/semantic-tokens/cargonet.ts
@@ -147,7 +147,7 @@ export const cargonet = {
       },
     },
   },
-  default: {
+  core: {
     surface: {
       active: {
         value: {

--- a/packages/spor-react/src/theme/semantic-tokens/vyDigital.ts
+++ b/packages/spor-react/src/theme/semantic-tokens/vyDigital.ts
@@ -147,7 +147,7 @@ export const vyDigital = {
       },
     },
   },
-  default: {
+  core: {
     surface: {
       active: {
         value: {

--- a/packages/spor-react/src/theme/slot-recipes/accordion.ts
+++ b/packages/spor-react/src/theme/slot-recipes/accordion.ts
@@ -1,4 +1,4 @@
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { ghostBackground } from "../utils/ghost-utils";
@@ -25,7 +25,7 @@ export const accordionSlotRecipe = defineSlotRecipe({
       borderRadius: "sm",
       display: "flex",
       justifyContent: "space-between",
-      ...baseText("default"),
+      ...coreText("default"),
       textAlign: "left",
       width: "100%",
       alignItems: "center",
@@ -93,17 +93,17 @@ export const accordionSlotRecipe = defineSlotRecipe({
       },
       core: {
         itemTrigger: {
-          ...baseBorder("default"),
+          ...coreBorder("default"),
           _expanded: {
             borderBottomRadius: "none",
           },
           _hover: {
-            ...baseBorder("hover"),
+            ...coreBorder("hover"),
             outlineOffset: 0,
           },
           _active: {
-            ...baseBackground("active"),
-            ...baseBorder("default"),
+            ...coreBackground("active"),
+            ...coreBorder("default"),
           },
         },
       },

--- a/packages/spor-react/src/theme/slot-recipes/card-select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/card-select.ts
@@ -26,7 +26,7 @@ export const cardSelectSlotRecipe = defineSlotRecipe({
   },
   variants: {
     variant: {
-      base: {
+      core: {
         trigger: {
           ...baseBorder("default"),
           _hover: {
@@ -92,7 +92,7 @@ export const cardSelectSlotRecipe = defineSlotRecipe({
     },
   },
   defaultVariants: {
-    variant: "base",
+    variant: "core",
     size: "md",
   },
 });

--- a/packages/spor-react/src/theme/slot-recipes/card-select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/card-select.ts
@@ -1,4 +1,4 @@
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { defineSlotRecipe } from "@chakra-ui/react";
@@ -13,14 +13,14 @@ export const cardSelectSlotRecipe = defineSlotRecipe({
       alignItems: "center",
       transitionProperty: "outline",
       transitionDuration: "fast",
-      ...baseText("default"),
+      ...coreText("default"),
       ...focusVisibleStyles(),
     },
     card: {
       borderRadius: "sm",
       boxShadow: "md",
       padding: 3,
-      ...baseText("default"),
+      ...coreText("default"),
       backgroundColor: `color-mix(in srgb, white 10%, var(--spor-colors-bg-default-dark))`,
     },
   },
@@ -28,16 +28,16 @@ export const cardSelectSlotRecipe = defineSlotRecipe({
     variant: {
       core: {
         trigger: {
-          ...baseBorder("default"),
+          ...coreBorder("default"),
           _hover: {
-            ...baseBorder("hover"),
+            ...coreBorder("hover"),
           },
           _active: {
-            ...baseBackground("active"),
-            ...baseBorder("default"),
+            ...coreBackground("active"),
+            ...coreBorder("default"),
           },
           _expanded: {
-            ...baseBackground("active"),
+            ...coreBackground("active"),
           },
         },
       },

--- a/packages/spor-react/src/theme/slot-recipes/checkbox.ts
+++ b/packages/spor-react/src/theme/slot-recipes/checkbox.ts
@@ -1,4 +1,4 @@
-import { baseBackground, baseText } from "../utils/base-utils";
+import { coreBackground, coreText } from "../utils/core-utils";
 import { brandBackground, brandText } from "../utils/brand-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { defineSlotRecipe } from "@chakra-ui/react";
@@ -9,7 +9,7 @@ export const checkboxSlotRecipe = defineSlotRecipe({
   base: {
     root: {
       _hover: {
-        ...baseBackground("hover"),
+        ...coreBackground("hover"),
         borderColor: brandBackground("hover").backgroundColor,
       },
       _invalid: {
@@ -35,7 +35,7 @@ export const checkboxSlotRecipe = defineSlotRecipe({
       border: "2px solid",
       borderColor: "base.outline.default",
       borderRadius: "xs",
-      ...baseBackground("default"),
+      ...coreBackground("default"),
       ...focusVisibleStyles(),
 
       _checked: {
@@ -44,8 +44,8 @@ export const checkboxSlotRecipe = defineSlotRecipe({
         borderColor: brandBackground("default").backgroundColor,
 
         _disabled: {
-          ...baseBackground("disabled"),
-          ...baseText("disabled"),
+          ...coreBackground("disabled"),
+          ...coreText("disabled"),
           borderColor: "currentColor",
         },
 
@@ -56,11 +56,11 @@ export const checkboxSlotRecipe = defineSlotRecipe({
       },
 
       _disabled: {
-        ...baseBackground("disabled"),
-        borderColor: baseText("disabled").color,
+        ...coreBackground("disabled"),
+        borderColor: coreText("disabled").color,
       },
       _invalid: {
-        ...baseBackground("default"),
+        ...coreBackground("default"),
         borderColor: "brightRed",
       },
     },

--- a/packages/spor-react/src/theme/slot-recipes/choice-chip.ts
+++ b/packages/spor-react/src/theme/slot-recipes/choice-chip.ts
@@ -62,7 +62,7 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
   },
   variants: {
     variant: {
-      base: {
+      core: {
         root: {
           ...baseBorder("default"),
           ...baseText("default"),
@@ -154,7 +154,7 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
     },
   },
   defaultVariants: {
-    variant: "base",
+    variant: "core",
     size: "sm",
   },
 });

--- a/packages/spor-react/src/theme/slot-recipes/choice-chip.ts
+++ b/packages/spor-react/src/theme/slot-recipes/choice-chip.ts
@@ -1,6 +1,6 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
 import { accentBackground, accentText } from "../utils/accent-utils";
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { brandBackground } from "../utils/brand-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
@@ -23,33 +23,33 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
         ...accentBackground("selected"),
         _hover: {
           ...brandBackground("hover"),
-          ...baseText("selected"),
+          ...coreText("selected"),
           outlineColor: "transparent",
         },
         _active: {
-          ...baseText("selected"),
+          ...coreText("selected"),
           ...brandBackground("active"),
         },
       },
       _disabled: {
         pointerEvents: "none",
         boxShadow: "none",
-        ...baseText("disabled"),
-        ...baseBackground("disabled"),
+        ...coreText("disabled"),
+        ...coreBackground("disabled"),
         _hover: {
-          ...baseBackground("disabled"),
+          ...coreBackground("disabled"),
           boxShadow: "none",
-          ...baseText("disabled"),
+          ...coreText("disabled"),
         },
         _checked: {
           cursor: "not-allowed",
           boxShadow: "none",
-          ...baseText("disabled"),
-          ...baseBackground("disabled"),
+          ...coreText("disabled"),
+          ...coreBackground("disabled"),
           _hover: {
-            ...baseBackground("disabled"),
+            ...coreBackground("disabled"),
             boxShadow: "none",
-            ...baseText("disabled"),
+            ...coreText("disabled"),
           },
         },
       },
@@ -64,15 +64,15 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
     variant: {
       core: {
         root: {
-          ...baseBorder("default"),
-          ...baseText("default"),
+          ...coreBorder("default"),
+          ...coreText("default"),
           _hover: {
-            ...baseText("default"),
-            ...baseBorder("hover"),
+            ...coreText("default"),
+            ...coreBorder("hover"),
           },
           _active: {
-            ...baseBackground("active"),
-            ...baseBorder("default"),
+            ...coreBackground("active"),
+            ...coreBorder("default"),
           },
         },
       },
@@ -97,19 +97,19 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
       floating: {
         root: {
           ...floatingBackground("default"),
-          ...baseText("default"),
+          ...coreText("default"),
           ...floatingBorder("default"),
           boxShadow: "sm",
           _hover: {
             ...floatingBackground("hover"),
             ...floatingBorder("hover"),
-            ...baseText("default"),
+            ...coreText("default"),
             boxShadow: "md",
           },
           _active: {
             ...floatingBackground("active"),
             ...floatingBorder("active"),
-            ...baseText("default"),
+            ...coreText("default"),
           },
         },
       },

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -1,6 +1,6 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
 import { accentText } from "../utils/accent-utils";
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { brandBackground, brandText } from "../utils/brand-utils";
 import { floatingBorder, floatingBackground } from "../utils/floating-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
@@ -36,9 +36,9 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       },
       _disabled: {
         pointerEvents: "none",
-        ...baseBackground("disabled"),
-        ...baseBorder("disabled"),
-        ...baseText("disabled"),
+        ...coreBackground("disabled"),
+        ...coreBorder("disabled"),
+        ...coreText("disabled"),
       },
       _focusWithin: {
         ...focusVisibleStyles()._focusVisible,
@@ -72,7 +72,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
         ...ghostBackground("active"),
       },
       _invalid: {
-        ...baseBorder("invalid"),
+        ...coreBorder("invalid"),
       },
     },
     arrow: {
@@ -80,12 +80,12 @@ export const datePickerSlotRecipe = defineSlotRecipe({
     },
     calendarPopover: {
       ...floatingBackground("default"),
-      ...baseText("default"),
+      ...coreText("default"),
       ...floatingBorder("default"),
       boxShadow: "md",
     },
     weekdays: {
-      ...baseText("default"),
+      ...coreText("default"),
     },
     weekend: {
       ...accentText("default"),
@@ -108,7 +108,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
     },
     dateCell: {
       ...ghostBackground("default"),
-      ...baseText("default"),
+      ...coreText("default"),
       borderRadius: "50%",
       position: "relative",
       transition: ".1s ease-in-out",
@@ -125,8 +125,8 @@ export const datePickerSlotRecipe = defineSlotRecipe({
         ...ghostBackground("active"),
       },
       _disabled: {
-        ...baseBackground("disabled"),
-        ...baseText("disabled"),
+        ...coreBackground("disabled"),
+        ...coreText("disabled"),
         pointerEvents: "none",
       },
       _selected: {
@@ -138,12 +138,12 @@ export const datePickerSlotRecipe = defineSlotRecipe({
         },
       },
       "&[data-today]": {
-        ...baseBorder("default"),
+        ...coreBorder("default"),
       },
       "&[data-unavailable]": {
         pointerEvents: "none",
-        ...baseBackground("disabled"),
-        ...baseText("disabled"),
+        ...coreBackground("disabled"),
+        ...coreText("disabled"),
       },
     },
   },
@@ -151,14 +151,14 @@ export const datePickerSlotRecipe = defineSlotRecipe({
     variant: {
       core: {
         wrapper: {
-          ...baseBorder("default"),
-          ...baseBackground("default"),
+          ...coreBorder("default"),
+          ...coreBackground("default"),
 
           _hover: {
-            ...baseBorder("hover"),
+            ...coreBorder("hover"),
           },
           _invalid: {
-            ...baseBorder("invalid"),
+            ...coreBorder("invalid"),
           },
         },
       },
@@ -172,17 +172,17 @@ export const datePickerSlotRecipe = defineSlotRecipe({
             ...floatingBorder("hover"),
           },
           _invalid: {
-            ...baseBorder("invalid"),
+            ...coreBorder("invalid"),
           },
         },
       },
       ghost: {
         wrapper: {
           _hover: {
-            ...baseBorder("hover"),
+            ...coreBorder("hover"),
           },
           _invalid: {
-            ...baseBorder("invalid"),
+            ...coreBorder("invalid"),
           },
         },
       },

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -149,7 +149,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
   },
   variants: {
     variant: {
-      base: {
+      core: {
         wrapper: {
           ...baseBorder("default"),
           ...baseBackground("default"),
@@ -189,6 +189,6 @@ export const datePickerSlotRecipe = defineSlotRecipe({
     },
   },
   defaultVariants: {
-    variant: "base",
+    variant: "core",
   },
 });

--- a/packages/spor-react/src/theme/slot-recipes/dialog.ts
+++ b/packages/spor-react/src/theme/slot-recipes/dialog.ts
@@ -1,6 +1,6 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
 import { bg } from "../utils/bg-utils";
-import { baseText } from "../utils/base-utils";
+import { coreText } from "../utils/core-utils";
 
 export const dialogSlotRecipe = defineSlotRecipe({
   slots: [
@@ -28,7 +28,7 @@ export const dialogSlotRecipe = defineSlotRecipe({
     dialog: {
       borderRadius: "md",
       ...bg("default"),
-      ...baseText("default"),
+      ...coreText("default"),
       marginY: "3.75rem",
       zIndex: "modal",
       boxShadow: "md",

--- a/packages/spor-react/src/theme/slot-recipes/drawer.ts
+++ b/packages/spor-react/src/theme/slot-recipes/drawer.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { baseText } from "../utils/base-utils";
+import { coreText } from "../utils/core-utils";
 import { bg } from "../utils/bg-utils";
 
 export const drawerSlotRecipe = defineSlotRecipe({
@@ -28,7 +28,7 @@ export const drawerSlotRecipe = defineSlotRecipe({
     },
     dialog: {
       ...bg("default"),
-      ...baseText("default"),
+      ...coreText("default"),
       zIndex: "modal",
       maxHeight: "calc(100% - 7.5rem)",
       boxShadow: "md",

--- a/packages/spor-react/src/theme/slot-recipes/floating-action-button.ts
+++ b/packages/spor-react/src/theme/slot-recipes/floating-action-button.ts
@@ -55,7 +55,7 @@ export const floatingActionButtonSlotRecipe = defineSlotRecipe({
           },
         },
       },
-      base: {
+      core: {
         root: {
           ...baseBackground("default"),
           ...baseBorder("default"),

--- a/packages/spor-react/src/theme/slot-recipes/floating-action-button.ts
+++ b/packages/spor-react/src/theme/slot-recipes/floating-action-button.ts
@@ -1,6 +1,6 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
 import { accentBackground, accentText } from "../utils/accent-utils";
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { brandBackground, brandText } from "../utils/brand-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { surface } from "../utils/surface-utils";
@@ -27,7 +27,7 @@ export const floatingActionButtonSlotRecipe = defineSlotRecipe({
       ...focusVisibleStyles(),
       _disabled: {
         ...surface("disabled"),
-        ...baseText("disabled"),
+        ...coreText("disabled"),
         pointerEvents: "none",
       },
     },
@@ -57,16 +57,16 @@ export const floatingActionButtonSlotRecipe = defineSlotRecipe({
       },
       core: {
         root: {
-          ...baseBackground("default"),
-          ...baseBorder("default"),
-          ...baseText("default"),
+          ...coreBackground("default"),
+          ...coreBorder("default"),
+          ...coreText("default"),
           _hover: {
-            ...baseBackground("hover"),
-            ...baseBorder("hover"),
+            ...coreBackground("hover"),
+            ...coreBorder("hover"),
           },
           _active: {
-            ...baseBorder("default"),
-            ...baseBackground("active"),
+            ...coreBorder("default"),
+            ...coreBackground("active"),
           },
         },
       },

--- a/packages/spor-react/src/theme/slot-recipes/listbox.ts
+++ b/packages/spor-react/src/theme/slot-recipes/listbox.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { baseBorder } from "../utils/base-utils";
+import { coreBorder } from "../utils/core-utils";
 import { ghostBackground, ghostText } from "../utils/ghost-utils";
 import { surface } from "../utils/surface-utils";
 import { outlineBorder } from "../utils/outline-utils";
@@ -53,7 +53,7 @@ export const listBoxSlotRecipe = defineSlotRecipe({
     variant: {
       core: {
         root: {
-          ...baseBorder("default"),
+          ...coreBorder("default"),
         },
       },
       floating: {

--- a/packages/spor-react/src/theme/slot-recipes/listbox.ts
+++ b/packages/spor-react/src/theme/slot-recipes/listbox.ts
@@ -51,7 +51,7 @@ export const listBoxSlotRecipe = defineSlotRecipe({
   },
   variants: {
     variant: {
-      base: {
+      core: {
         root: {
           ...baseBorder("default"),
         },
@@ -64,6 +64,6 @@ export const listBoxSlotRecipe = defineSlotRecipe({
     },
   },
   defaultVariants: {
-    variant: "base",
+    variant: "core",
   },
 });

--- a/packages/spor-react/src/theme/slot-recipes/media-controller-button.ts
+++ b/packages/spor-react/src/theme/slot-recipes/media-controller-button.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { baseText } from "../utils/base-utils";
+import { coreText } from "../utils/core-utils";
 import { brandBackground, brandText } from "../utils/brand-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { ghostBackground } from "../utils/ghost-utils";
@@ -66,7 +66,7 @@ export const mediaControllerSlotRecipe = defineSlotRecipe({
           _disabled: {
             pointerEvents: "none",
             ...surface("disabled"),
-            ...baseText("disabled"),
+            ...coreText("disabled"),
           },
         },
         icon: {

--- a/packages/spor-react/src/theme/slot-recipes/native-select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/native-select.ts
@@ -1,4 +1,4 @@
-import { baseText } from "../utils/base-utils";
+import { coreText } from "../utils/core-utils";
 import { inputBaseStyle, inputVariant } from "../utils/input-utils";
 import { defineSlotRecipe } from "@chakra-ui/react";
 
@@ -38,7 +38,7 @@ export const nativeSelectSlotRecipe = defineSlotRecipe({
       strokeLinecap: "round",
       fontSize: "sm",
       _disabled: {
-        ...baseText("disabled"),
+        ...coreText("disabled"),
       },
     },
   },

--- a/packages/spor-react/src/theme/slot-recipes/native-select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/native-select.ts
@@ -44,7 +44,7 @@ export const nativeSelectSlotRecipe = defineSlotRecipe({
   },
   variants: {
     variant: {
-      base: {
+      core: {
         field: {
           ...inputVariant("base"),
         },
@@ -57,6 +57,6 @@ export const nativeSelectSlotRecipe = defineSlotRecipe({
     },
   },
   defaultVariants: {
-    variant: "base",
+    variant: "core",
   },
 });

--- a/packages/spor-react/src/theme/slot-recipes/numeric-stepper.ts
+++ b/packages/spor-react/src/theme/slot-recipes/numeric-stepper.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 
 export const numericStepperRecipe = defineSlotRecipe({
@@ -19,8 +19,8 @@ export const numericStepperRecipe = defineSlotRecipe({
       textAlign: "center",
       transitionProperty: "common",
       transitionDuration: "fast",
-      ...baseText("default"),
-      ...baseBackground("default"),
+      ...coreText("default"),
+      ...coreBackground("default"),
 
       _disabled: {
         pointerEvents: "none",
@@ -28,11 +28,11 @@ export const numericStepperRecipe = defineSlotRecipe({
       },
 
       _hover: {
-        ...baseBorder("default"),
+        ...coreBorder("default"),
       },
 
       _active: {
-        ...baseBackground("active"),
+        ...coreBackground("active"),
       },
 
       ...focusVisibleStyles,
@@ -44,7 +44,7 @@ export const numericStepperRecipe = defineSlotRecipe({
       paddingX: 1,
       textAlign: "center",
       width: "4ch",
-      ...baseText("default"),
+      ...coreText("default"),
     },
     button: {
       minWidth: "24px",

--- a/packages/spor-react/src/theme/slot-recipes/radio-card.ts
+++ b/packages/spor-react/src/theme/slot-recipes/radio-card.ts
@@ -38,7 +38,7 @@ export const radioCardSlotRecipe = defineSlotRecipe({
   },
   variants: {
     variant: {
-      base: {
+      core: {
         root: {
           ...baseText("default"),
           ...baseBackground("default"),

--- a/packages/spor-react/src/theme/slot-recipes/radio-card.ts
+++ b/packages/spor-react/src/theme/slot-recipes/radio-card.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 import { outlineBorder } from "../utils/outline-utils";
 
@@ -25,9 +25,9 @@ export const radioCardSlotRecipe = defineSlotRecipe({
 
       _disabled: {
         pointerEvents: "none",
-        ...baseBackground("disabled"),
-        ...baseBorder("disabled"),
-        ...baseText("disabled"),
+        ...coreBackground("disabled"),
+        ...coreBorder("disabled"),
+        ...coreText("disabled"),
       },
       _checked: {
         outline: "2px solid",
@@ -40,25 +40,25 @@ export const radioCardSlotRecipe = defineSlotRecipe({
     variant: {
       core: {
         root: {
-          ...baseText("default"),
-          ...baseBackground("default"),
-          ...baseBorder("default"),
+          ...coreText("default"),
+          ...coreBackground("default"),
+          ...coreBorder("default"),
           _hover: {
-            ...baseBackground("hover"),
-            ...baseBorder("hover"),
+            ...coreBackground("hover"),
+            ...coreBorder("hover"),
           },
           _active: {
-            ...baseBackground("active"),
-            ...baseBorder("active"),
+            ...coreBackground("active"),
+            ...coreBorder("active"),
           },
         },
         _checked: {
           _hover: {
-            ...baseBorder("hover"),
+            ...coreBorder("hover"),
           },
           _active: {
-            ...baseBackground("active"),
-            ...baseBorder("active"),
+            ...coreBackground("active"),
+            ...coreBorder("active"),
           },
         },
         _focusedChecked: {
@@ -73,7 +73,7 @@ export const radioCardSlotRecipe = defineSlotRecipe({
           outlineOffset: "1px",
           boxShadow: `inset 0 0 0 1px rgba(0, 0, 0, 0.40)`,
           _hover: {
-            ...baseBorder("hover"),
+            ...coreBorder("hover"),
             boxShadow: "none",
             outlineOffset: "0px",
           },

--- a/packages/spor-react/src/theme/slot-recipes/radio.ts
+++ b/packages/spor-react/src/theme/slot-recipes/radio.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { brandBackground } from "../utils/brand-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 
@@ -23,13 +23,13 @@ export const radioSlotRecipe = defineSlotRecipe({
       height: "1rem",
       backgroundColor: "inherit",
       border: "2px solid",
-      borderColor: baseBorder("default").outlineColor,
+      borderColor: coreBorder("default").outlineColor,
       borderRadius: "50%",
       ...focusVisibleStyles(),
       _disabled: {
-        ...baseBackground("disabled"),
-        ...baseBorder("disabled"),
-        ...baseText("disabled"),
+        ...coreBackground("disabled"),
+        ...coreBorder("disabled"),
+        ...coreText("disabled"),
       },
       _checked: {
         color: "brand.surface.default",
@@ -45,9 +45,9 @@ export const radioSlotRecipe = defineSlotRecipe({
         },
         _disabled: {
           pointerEvents: "none",
-          ...baseBackground("disabled"),
-          ...baseBorder("disabled"),
-          ...baseText("disabled"),
+          ...coreBackground("disabled"),
+          ...coreBorder("disabled"),
+          ...coreText("disabled"),
         },
       },
     },

--- a/packages/spor-react/src/theme/slot-recipes/select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/select.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 import { surface } from "../utils/surface-utils";
@@ -186,20 +186,20 @@ export const selectSlotRecipe = defineSlotRecipe({
     variant: {
       core: {
         control: {
-          ...baseBorder("default"),
+          ...coreBorder("default"),
           _hover: {
-            ...baseBorder("hover"),
+            ...coreBorder("hover"),
           },
           _active: {
-            ...baseBackground("active"),
+            ...coreBackground("active"),
           },
           _invalid: {
-            ...baseBorder("invalid"),
+            ...coreBorder("invalid"),
           },
           _disabled: {
             pointerEvents: "none",
-            ...baseText("disabled"),
-            ...baseBackground("disabled"),
+            ...coreText("disabled"),
+            ...coreBackground("disabled"),
           },
         },
       },

--- a/packages/spor-react/src/theme/slot-recipes/stepper.ts
+++ b/packages/spor-react/src/theme/slot-recipes/stepper.ts
@@ -58,7 +58,7 @@ export const stepperSlotRecipe = defineSlotRecipe({
   },
   variants: {
     variant: {
-      base: {
+      core: {
         root: {
           backgroundColor: "transparent",
         },
@@ -87,8 +87,5 @@ export const stepperSlotRecipe = defineSlotRecipe({
         },
       },
     },
-  },
-  defaultVariants: {
-    variant: "base",
   },
 });

--- a/packages/spor-react/src/theme/slot-recipes/stepper.ts
+++ b/packages/spor-react/src/theme/slot-recipes/stepper.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { baseText } from "../utils/base-utils";
+import { coreText } from "../utils/core-utils";
 import { brandBackground } from "../utils/brand-utils";
 import { accentText, accentBackground } from "../utils/accent-utils";
 
@@ -69,9 +69,9 @@ export const stepperSlotRecipe = defineSlotRecipe({
           ...accentText("default"),
         },
         stepButton: {
-          color: baseText("default").color,
+          color: coreText("default").color,
           _disabled: {
-            color: baseText("disabled").color,
+            color: coreText("disabled").color,
           },
           _hover: {
             backgroundColor: accentBackground("hover").backgroundColor,

--- a/packages/spor-react/src/theme/slot-recipes/switch.ts
+++ b/packages/spor-react/src/theme/slot-recipes/switch.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { baseBackground, baseBorder } from "../utils/base-utils";
+import { coreBackground, coreBorder } from "../utils/core-utils";
 import { brandBackground } from "../utils/brand-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 
@@ -22,29 +22,29 @@ export const switchSlotRecipe = defineSlotRecipe({
     track: {
       transitionProperty: "common",
       transitionDuration: "fast",
-      ...baseBorder("default"),
+      ...coreBorder("default"),
       ...focusVisibleStyles(),
-      ...baseBackground("default"),
+      ...coreBackground("default"),
 
       _hover: {
-        ...baseBorder("hover"),
+        ...coreBorder("hover"),
       },
       _checked: {
         ...brandBackground("default"),
         outlineColor: "transparent",
 
         _hover: {
-          ...baseBackground("default"),
+          ...coreBackground("default"),
           ...brandBackground("hover"),
         },
       },
       _disabled: {
         pointerEvents: "none",
-        ...baseBackground("default"),
-        ...baseBorder("disabled"),
+        ...coreBackground("default"),
+        ...coreBorder("disabled"),
         _checked: {
-          ...baseBackground("disabled"),
-          ...baseBorder("disabled"),
+          ...coreBackground("disabled"),
+          ...coreBorder("disabled"),
         },
       },
     },

--- a/packages/spor-react/src/theme/slot-recipes/table.ts
+++ b/packages/spor-react/src/theme/slot-recipes/table.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { baseText } from "../utils/base-utils";
+import { coreText } from "../utils/core-utils";
 
 const numericStyles = {
   "&[data-is-numeric=true]": {
@@ -24,10 +24,10 @@ export const tableSlotRecipe = defineSlotRecipe({
       tableLayout: "fixed",
       borderCollapse: "collapse",
       width: "100%",
-      ...baseText("default"),
+      ...coreText("default"),
     },
     body: {
-      ...baseText("default"),
+      ...coreText("default"),
     },
     columnHeader: {
       fontWeight: "bold",

--- a/packages/spor-react/src/theme/slot-recipes/tabs.ts
+++ b/packages/spor-react/src/theme/slot-recipes/tabs.ts
@@ -32,7 +32,7 @@ export const tabsSlotRecipe = defineSlotRecipe({
   },
   variants: {
     variant: {
-      default: {
+      core: {
         list: {
           ...baseBackground("default"),
           ...baseText("default"),

--- a/packages/spor-react/src/theme/slot-recipes/tabs.ts
+++ b/packages/spor-react/src/theme/slot-recipes/tabs.ts
@@ -1,6 +1,6 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
 import { accentBackground, accentText } from "../utils/accent-utils";
-import { baseBackground, baseBorder, baseText } from "../utils/base-utils";
+import { coreBackground, coreBorder, coreText } from "../utils/core-utils";
 import { brandBackground, brandText } from "../utils/brand-utils";
 import { focusVisibleStyles } from "../utils/focus-utils";
 
@@ -34,18 +34,18 @@ export const tabsSlotRecipe = defineSlotRecipe({
     variant: {
       core: {
         list: {
-          ...baseBackground("default"),
-          ...baseText("default"),
-          ...baseBorder("default"),
+          ...coreBackground("default"),
+          ...coreText("default"),
+          ...coreBorder("default"),
         },
         trigger: {
-          ...baseText("default"),
+          ...coreText("default"),
           _hover: {
-            ...baseBorder("hover"),
+            ...coreBorder("hover"),
             outlineOffset: "-2px",
           },
           _active: {
-            ...baseBackground("active"),
+            ...coreBackground("active"),
           },
         },
       },

--- a/packages/spor-react/src/theme/utils/core-utils.ts
+++ b/packages/spor-react/src/theme/utils/core-utils.ts
@@ -3,15 +3,15 @@ import { focusVisibleStyles } from "./focus-utils";
 import { surface } from "./surface-utils";
 import { State, Subset } from "./types";
 
-type BaseBackgroundState = Subset<
+type coreBackgroundState = Subset<
   State,
   "default" | "active" | "selected" | "hover" | "disabled"
 >;
-export function baseBackground(state: BaseBackgroundState) {
+export function coreBackground(state: coreBackgroundState) {
   switch (state) {
     case "active":
       return {
-        backgroundColor: "default.surface.active",
+        backgroundColor: "core.surface.active",
       };
     case "selected":
       return brandBackground("default");
@@ -29,12 +29,12 @@ type BorderState = Subset<
   "hover" | "focus" | "active" | "disabled" | "selected" | "invalid" | "default"
 >;
 
-export function baseBorder(state: BorderState) {
+export function coreBorder(state: BorderState) {
   switch (state) {
     case "hover":
       return {
         outline: "2px solid",
-        outlineColor: "default.outline.hover",
+        outlineColor: "core.outline.hover",
       };
     case "focus": {
       return focusVisibleStyles()._focusVisible;
@@ -48,7 +48,7 @@ export function baseBorder(state: BorderState) {
     case "active": {
       return {
         outline: "1px solid",
-        outlineColor: "default.outline",
+        outlineColor: "core.outline",
       };
     }
     case "invalid": {
@@ -61,13 +61,13 @@ export function baseBorder(state: BorderState) {
     default:
       return {
         outline: "1px solid",
-        outlineColor: "default.outline",
+        outlineColor: "core.outline",
       };
   }
 }
 
-type BaseTextState = Subset<State, "default" | "selected" | "disabled">;
-export function baseText(state: BaseTextState) {
+type coreTextState = Subset<State, "default" | "selected" | "disabled">;
+export function coreText(state: coreTextState) {
   switch (state) {
     case "selected":
       return {
@@ -79,7 +79,7 @@ export function baseText(state: BaseTextState) {
       };
     default:
       return {
-        color: "default.text",
+        color: "core.text",
       };
   }
 }

--- a/packages/spor-react/src/theme/utils/input-utils.ts
+++ b/packages/spor-react/src/theme/utils/input-utils.ts
@@ -1,4 +1,4 @@
-import { baseBackground, baseBorder, baseText } from "./base-utils";
+import { coreBackground, coreBorder, coreText } from "./core-utils";
 import { floatingBackground, floatingBorder } from "./floating-utils";
 import { InputState } from "./types";
 import { focusVisibleStyles } from "./focus-utils";
@@ -8,18 +8,18 @@ export function inputVariant(state: InputState) {
   switch (state) {
     case "base":
       return {
-        ...baseBackground("default"),
-        ...baseBorder("default"),
+        ...coreBackground("default"),
+        ...coreBorder("default"),
         _hover: {
-          ...baseBorder("hover"),
+          ...coreBorder("hover"),
         },
         _active: {
-          ...baseBackground("active"),
-          ...baseBorder("default"),
+          ...coreBackground("active"),
+          ...coreBorder("default"),
         },
         _selected: {
-          ...baseBackground("selected"),
-          ...baseBorder("selected"),
+          ...coreBackground("selected"),
+          ...coreBorder("selected"),
         },
       };
     case "floating":
@@ -44,18 +44,18 @@ export function inputVariant(state: InputState) {
     case "default":
     default:
       return {
-        ...baseBackground("default"),
-        ...baseBorder("default"),
+        ...coreBackground("default"),
+        ...coreBorder("default"),
         _hover: {
-          ...baseBorder("hover"),
+          ...coreBorder("hover"),
         },
         _active: {
-          ...baseBackground("active"),
-          ...baseBorder("default"),
+          ...coreBackground("active"),
+          ...coreBorder("default"),
         },
         _selected: {
-          ...baseBackground("selected"),
-          ...baseBorder("selected"),
+          ...coreBackground("selected"),
+          ...coreBorder("selected"),
         },
       };
   }
@@ -80,13 +80,13 @@ export const inputBaseStyle = () => ({
     },
     _disabled: {
       ...surface("disabled"),
-      ...baseBorder("disabled"),
+      ...coreBorder("disabled"),
       pointerEvents: "none",
     },
     _invalid: {
-      ...baseBorder("invalid"),
+      ...coreBorder("invalid"),
       _hover: {
-        ...baseBorder("hover"),
+        ...coreBorder("hover"),
       },
     },
     " + label, + div[data-lastpass-icon-root] + label": {
@@ -112,7 +112,7 @@ export const inputBaseStyle = () => ({
   },
   group: {
     ":has(:disabled)": {
-      ...baseText("disabled"),
+      ...coreText("disabled"),
     },
   },
 });


### PR DESCRIPTION
## Background

As discussed internally, Chakra has default values with the name "base" that creates typing errors when typegen to the project. Therefore it was decided to change the name "base" to "core" on all platforms. 

Also in this PR: Had to update how the variants are created for datepicker. 
