### PR TITLE
Chakra 3: Update Textarea

### DIFF
--- a/.changeset/dull-pears-sort.md
+++ b/.changeset/dull-pears-sort.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Textarea: New props `label`, `invalid`, `errorText` and `helperText`

--- a/apps/docs/app/root/layout/SiteHeader.tsx
+++ b/apps/docs/app/root/layout/SiteHeader.tsx
@@ -19,6 +19,10 @@ import {
   VyLogo,
   useDisclosure,
   Input,
+  Switch,
+  useColorMode,
+  Button,
+  ColorModeButton,
 } from "@vygruppen/spor-react";
 import { useEffect, useState } from "react";
 import { SearchableContentMenu } from "../../routes/_base/content-menu/SearchableContentMenu";
@@ -69,7 +73,7 @@ export const SiteHeader = () => {
           />
         </Link>
       </Box>
-
+      <ColorModeButton /> {/* temp solution */}
       <DesktopNavigation
         onSearchClick={() => setSearchDialogOpen(!searchDialogOpen)}
       />

--- a/apps/docs/app/root/layout/SiteSettings.tsx
+++ b/apps/docs/app/root/layout/SiteSettings.tsx
@@ -46,7 +46,7 @@ export const SiteSettings = ({ showLabel }: SiteSettingsProps) => {
             id="site-settings-dark-mode"
             size="sm"
             onChange={() => toggleColorMode()}
-            defaultChecked={colorMode === "dark"}
+            defaultChecked={colorMode === "light"}
           />
         </Stack>
       </Flex>

--- a/packages/spor-react/src/color-mode/color-mode.tsx
+++ b/packages/spor-react/src/color-mode/color-mode.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import type { IconButtonProps } from "@chakra-ui/react";
+import { ClientOnly, IconButton, Skeleton } from "@chakra-ui/react";
 import { ThemeProvider, useTheme } from "next-themes";
 import type { ThemeProviderProps } from "next-themes";
 import * as React from "react";
+import { LuMoon, LuSun } from "react-icons/lu";
 
 export interface ColorModeProviderProps extends ThemeProviderProps {}
 
@@ -12,13 +15,21 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
   );
 }
 
-export function useColorMode() {
+export type ColorMode = "light" | "dark";
+
+export interface UseColorModeReturn {
+  colorMode: ColorMode;
+  setColorMode: (colorMode: ColorMode) => void;
+  toggleColorMode: () => void;
+}
+
+export function useColorMode(): UseColorModeReturn {
   const { resolvedTheme, setTheme } = useTheme();
-  const toggleColorMode: () => void = () => {
+  const toggleColorMode = () => {
     setTheme(resolvedTheme === "light" ? "dark" : "light");
   };
   return {
-    colorMode: resolvedTheme,
+    colorMode: resolvedTheme as ColorMode,
     setColorMode: setTheme,
     toggleColorMode,
   };
@@ -26,5 +37,39 @@ export function useColorMode() {
 
 export function useColorModeValue<T>(light: T, dark: T) {
   const { colorMode } = useColorMode();
-  return colorMode === "light" ? light : dark;
+  return colorMode === "dark" ? dark : light;
 }
+
+export function ColorModeIcon() {
+  const { colorMode } = useColorMode();
+  return colorMode === "dark" ? <LuMoon /> : <LuSun />;
+}
+
+interface ColorModeButtonProps extends Omit<IconButtonProps, "aria-label"> {}
+
+export const ColorModeButton = React.forwardRef<
+  HTMLButtonElement,
+  ColorModeButtonProps
+>(function ColorModeButton(props, ref) {
+  const { toggleColorMode } = useColorMode();
+  return (
+    <ClientOnly fallback={<Skeleton boxSize="8" />}>
+      <IconButton
+        onClick={toggleColorMode}
+        variant="ghost"
+        aria-label="Toggle color mode"
+        size="sm"
+        ref={ref}
+        {...props}
+        css={{
+          _icon: {
+            width: "5",
+            height: "5",
+          },
+        }}
+      >
+        <ColorModeIcon />
+      </IconButton>
+    </ClientOnly>
+  );
+});

--- a/packages/spor-react/src/input/Textarea.tsx
+++ b/packages/spor-react/src/input/Textarea.tsx
@@ -1,45 +1,56 @@
 "use client";
+
 import {
   RecipeVariantProps,
   useRecipe,
   Textarea as ChakraTextarea,
   TextareaProps as ChakraTextareaProps,
+  FieldLabel,
 } from "@chakra-ui/react";
-import React, { forwardRef } from "react";
+import React, { forwardRef, PropsWithChildren, ReactNode } from "react";
 import { textareaRecipe } from "../theme/recipes/textarea";
+import { Field, FieldProps } from "./Field";
 
 type TextareaVariants = RecipeVariantProps<typeof textareaRecipe>;
 export type TextareaProps = Exclude<
   ChakraTextareaProps,
-  "size" | "variant" | "colorPalette"
+  "size" | "colorPalette"
 > &
-  TextareaVariants & {
-    placeholder?: string;
+  FieldProps &
+  PropsWithChildren<TextareaVariants> & {
+    /* A label for the textarea */
+    label: ReactNode;
   };
+
 /**
- * Text area that works with the `Field` component.
  *
- * To use Textarea with a label, wrap it in a `Field` component:
+ * A simple Textarea component:
  *
  * ```tsx
- * <Field label="Description">
- *   <Textarea />
- * </Field>
+ *   <Textarea label="Description" />
  * ```
+ *
+ * Textarea has two variants core, and floating.
+ *
  */
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ placeholder, ...props }, ref) => {
-    const recipe = useRecipe({ recipe: textareaRecipe });
-    const styles = recipe({});
+  (props, ref) => {
+    const { label, variant = "core", ...fieldProps } = props;
+    const recipe = useRecipe({ key: "textarea" });
+    const styles = recipe({ variant });
 
     return (
-      <ChakraTextarea
-        {...props}
-        css={styles}
-        ref={ref}
-        placeholder={placeholder}
-      />
+      <Field {...fieldProps}>
+        <ChakraTextarea
+          {...props}
+          css={styles}
+          className="peer"
+          ref={ref}
+          placeholder=" "
+        />
+        <FieldLabel>{label}</FieldLabel>
+      </Field>
     );
   },
 );

--- a/packages/spor-react/src/theme/recipes/input.ts
+++ b/packages/spor-react/src/theme/recipes/input.ts
@@ -4,6 +4,8 @@ import { surface } from "../utils/surface-utils";
 import { baseBackground, baseBorder } from "../utils/base-utils";
 import { floatingBackground, floatingBorder } from "../utils/floating-utils";
 
+/* FYI: The styling in this file is also used in Textarea */
+
 export const inputRecipe = defineRecipe({
   base: {
     appearance: "none",
@@ -30,6 +32,12 @@ export const inputRecipe = defineRecipe({
     },
     _invalid: {
       ...baseBorder("invalid"),
+      _active: {
+        ...baseBorder("invalid"),
+      },
+      _focus: {
+        ...baseBorder("invalid"),
+      },
       _hover: {
         ...baseBorder("hover"),
       },

--- a/packages/spor-react/src/theme/recipes/textarea.ts
+++ b/packages/spor-react/src/theme/recipes/textarea.ts
@@ -1,59 +1,21 @@
 import { defineRecipe } from "@chakra-ui/react";
-import { inputBaseStyle, inputVariant } from "../utils/input-utils";
+import { inputRecipe } from "./input";
 
 export const textareaRecipe = defineRecipe({
   className: "spor-textarea",
   base: {
+    ...inputRecipe.base,
     minHeight: "5rem",
-    verticalAlign: "top",
-    appearance: "none",
-    paddingTop: 2,
-    transitionProperty: "common",
-    transitionDuration: "normal",
-    "&:not(:placeholder-shown)": {
-      "&:has(+ label)": {
-        paddingTop: 4,
-      },
-      "& + label": {
-        transform: "scale(0.825) translateY(-10px)",
-      },
-    },
-    _disabled: {
-      cursor: "not-allowed",
-      pointerEvents: "none",
-      boxShadow: "none",
-      ...inputBaseStyle().field,
-    },
+    paddingTop: 4,
   },
   variants: {
     variant: {
-      base: {
-        ...inputVariant("base"),
+      core: {
+        ...inputRecipe.variants?.variant.core,
       },
       floating: {
-        ...inputVariant("floating"),
+        ...inputRecipe.variants?.variant.floating,
       },
     },
-    size: {
-      sm: {
-        fontSize: "sm",
-        padding: 2,
-        borderRadius: "md",
-      },
-      md: {
-        fontSize: "md",
-        padding: 3,
-        borderRadius: "md",
-      },
-      lg: {
-        fontSize: "lg",
-        padding: 4,
-        borderRadius: "lg",
-      },
-    },
-  },
-  defaultVariants: {
-    variant: "base",
-    size: "md",
   },
 });

--- a/packages/spor-react/src/theme/slot-recipes/anatomy.ts
+++ b/packages/spor-react/src/theme/slot-recipes/anatomy.ts
@@ -1,0 +1,9 @@
+import { createAnatomy } from "@ark-ui/react/anatomy";
+
+export const fieldAnatomy = createAnatomy("field").parts(
+  "root",
+  "label",
+  "requiredIndicator",
+  "helperText",
+  "errorText",
+);

--- a/packages/spor-react/src/theme/slot-recipes/field.ts
+++ b/packages/spor-react/src/theme/slot-recipes/field.ts
@@ -59,7 +59,7 @@ export const fieldSlotRecipe = defineSlotRecipe({
       textStyle: "xs",
       width: "fit-content",
       position: "absolute",
-      top: 8,
+      bottom: -4,
       left: 3,
       zIndex: "dropdown",
       maxWidth: "50ch",

--- a/packages/spor-react/src/theme/slot-recipes/field.ts
+++ b/packages/spor-react/src/theme/slot-recipes/field.ts
@@ -15,7 +15,7 @@ export const fieldSlotRecipe = defineSlotRecipe({
       /* For when input is filled */
       pos: "absolute",
       paddingX: 3,
-      top: 1,
+      top: "0.3rem",
       fontWeight: "normal",
       fontSize: ["mobile.xs", "desktop.xs"],
       color: "text",
@@ -35,7 +35,7 @@ export const fieldSlotRecipe = defineSlotRecipe({
         /* For when input is in focus */
         fontSize: ["mobile.xs", "desktop.xs"],
         color: "text",
-        top: 1,
+        top: "0.3rem",
       },
       _disabled: {
         opacity: 0.4,

--- a/packages/spor-react/src/theme/slot-recipes/field.ts
+++ b/packages/spor-react/src/theme/slot-recipes/field.ts
@@ -1,8 +1,9 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
+import { fieldAnatomy } from "./anatomy";
 
 export const fieldSlotRecipe = defineSlotRecipe({
-  slots: ["root", "label", "requiredIndicator", "helperText", "errorText"],
   className: "spor-field",
+  slots: fieldAnatomy.keys(),
   base: {
     root: {
       display: "flex",
@@ -14,7 +15,7 @@ export const fieldSlotRecipe = defineSlotRecipe({
       /* For when input is filled */
       pos: "absolute",
       paddingX: 3,
-      top: "0.5",
+      top: 1,
       fontWeight: "normal",
       fontSize: ["mobile.xs", "desktop.xs"],
       color: "text",
@@ -34,7 +35,7 @@ export const fieldSlotRecipe = defineSlotRecipe({
         /* For when input is in focus */
         fontSize: ["mobile.xs", "desktop.xs"],
         color: "text",
-        top: "0.5",
+        top: 1,
       },
       _disabled: {
         opacity: 0.4,


### PR DESCRIPTION
## Background

Textarea updated with same styles as input. 

## Solution

Textarea recieves the same style as Input. Also added the same syntax with Field, which makes it possible to add errorText, helperText and label with the component.

(Also added a temporary solution for dark/light mode in the header)

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Desribe how code reviewer may test your solution (what page, expected result).

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="564" alt="image" src="https://github.com/user-attachments/assets/4acbd188-f4a7-4a60-8add-830210947da5" /> | <img width="509" alt="image" src="https://github.com/user-attachments/assets/5fd1c16e-e0e8-4c22-9dea-a21a79780db8" /> |
