### PR TITLE
Fixed hydration error that caused the label to 'dance' around

### DIFF
--- a/.changeset/yellow-rabbits-care.md
+++ b/.changeset/yellow-rabbits-care.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Set correct position of label for input elements that caused the dance during hydration step

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -66,12 +66,11 @@ export const Input = forwardRef<InputProps, "input">(
             },
           }}
         />
-<<<<<<< Updated upstream
-        <FormLabel htmlFor={inputId} id={labelId} pointerEvents="none">
-=======
+
         <FormLabel
           htmlFor={inputId}
           id={labelId}
+          pointerEvents="none"
           sx={{
             position: "absolute",
             left: "2.6rem",
@@ -88,7 +87,6 @@ export const Input = forwardRef<InputProps, "input">(
             },
           }}
         >
->>>>>>> Stashed changes
           {label}
         </FormLabel>
         {rightIcon && (

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -60,8 +60,35 @@ export const Input = forwardRef<InputProps, "input">(
           ref={ref}
           overflow="hidden"
           placeholder=" " // This is needed to make the label work as expected
+          css={{
+            "&::-webkit-search-cancel-button": {
+              WebkitAppearance: "none",
+            },
+          }}
         />
+<<<<<<< Updated upstream
         <FormLabel htmlFor={inputId} id={labelId} pointerEvents="none">
+=======
+        <FormLabel
+          htmlFor={inputId}
+          id={labelId}
+          sx={{
+            position: "absolute",
+            left: "2.6rem",
+            top: "26.9%",
+            fontSize: "1.13rem",
+            pointerEvents: "none",
+            margin: 0,
+            zIndex: 2,
+            "input:focus + &, input[data-has-value] + &": {
+              color: "var(--chakra-colors-gray-600)",
+            },
+            "input[data-has-value] + &": {
+              transform: "translateY(-40%) scale(0.9)",
+            },
+          }}
+        >
+>>>>>>> Stashed changes
           {label}
         </FormLabel>
         {rightIcon && (


### PR DESCRIPTION
## Background

The form label was dancing around before the page got javascript

## Solution

Added css to set it to the correct position

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [x] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [x] Updated documentation in the component file
- [x] Update green-beans-check.md with any major changes
- [x] Add changeset
- [x] Double check design in Figma

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Desribe how code reviewer may test your solution (what page, expected result).

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
