### PR TITLE
Fix: Update disabled color value in vy-digital.json

### DIFF
--- a/.changeset/empty-rabbits-shout.md
+++ b/.changeset/empty-rabbits-shout.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-design-tokens": patch
+---
+
+Updated disabled text color

--- a/.changeset/empty-rabbits-shout.md
+++ b/.changeset/empty-rabbits-shout.md
@@ -2,4 +2,4 @@
 "@vygruppen/spor-design-tokens": patch
 ---
 
-Updated disabled text color
+**Color tokens**: Updated disabled text color

--- a/packages/spor-design-tokens/tokens/color/vy-digital.json
+++ b/packages/spor-design-tokens/tokens/color/vy-digital.json
@@ -70,7 +70,7 @@
         },
         "disabled": {
           "light": {
-            "value": "{color.palette.blackAlpha.400.value}"
+            "value": "{color.palette.blackAlpha.300.value}"
           },
           "dark": {
             "value": "{color.palette.whiteAlpha.400.value}"


### PR DESCRIPTION
## Background

Color for disabled text is different on [spor.vy.no](http://spor.vy.no/) (40% black) than on figma (30% black). Figma is correct. 

## Solution

te disabled color value in vy-digital.json to 30% black

## UU checks

- [x ] It is possible to use the keyboard to reach your changes
- [ x] It is possible to enlarge the text 400% without losing functionality
- [ x] It works on both mobile and desktop
- [ x] It works in both Chrome, Safari and Firefox
- [ x] It works with VoiceOver
- [ x] There are no errors in aXe / SiteImprove-plugins / Wave
- [ x] Sanity documentation has been / will be updated (if neccessary)

## How to test

Desribe how code reviewer may test your solution (what page, expected result).

## Screenshots

| Before | After |
| ------ | ----- |

![image](https://github.com/user-attachments/assets/12d042e6-6b3b-4b02-ade2-578f009bd0d9)

![image](https://github.com/user-attachments/assets/6d6bf650-72e3-4c96-857c-bb7e4e145fdf)
 
