### PR TITLE
Chore: Upgrade Skeleton to Chakra v3

### DIFF
--- a/.changeset/selfish-buckets-fail.md
+++ b/.changeset/selfish-buckets-fail.md
@@ -1,5 +1,8 @@
 ---
-"@vygruppen/spor-react": patch
+"@vygruppen/spor-react": minor
 ---
 
-Skeleton: should work out of the box as before
+### Skeleton Component Updates
+
+- **Skeleton**: Introduced new props. The `isLoaded` prop has been replaced with `loading`.
+- **SkeletonCircle**: The `boxSize` prop has been replaced with `size`.

--- a/.changeset/selfish-buckets-fail.md
+++ b/.changeset/selfish-buckets-fail.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Skeleton: should work out of the box as before

--- a/.changeset/selfish-buckets-fail.md
+++ b/.changeset/selfish-buckets-fail.md
@@ -4,5 +4,5 @@
 
 ### Skeleton Component Updates
 
-- **Skeleton**: Introduced new props. The `isLoaded` prop has been replaced with `loading`.
+- **Skeleton**: Introduced new props. The `isLoaded` prop has been replaced with `loading`, which is its opposite.
 - **SkeletonCircle**: The `boxSize` prop has been replaced with `size`.

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -72,6 +72,6 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonTextProps>(
     const recipe = useRecipe({ recipe: skeletonRecipe });
     const [recipeProps, restProps] = recipe.splitVariantProps(props);
     const styles = recipe(recipeProps);
-    return <ChakraSkeleton {...restProps} height="6" ref={ref} css={styles} />;
+    return <ChakraSkeleton height="6" {...restProps} ref={ref} css={styles} />;
   },
 );

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -1,40 +1,66 @@
 "use client";
+import { skeletonRecipe } from "@/theme/recipes/skeleton";
 import type {
   SkeletonProps as ChakraSkeletonProps,
   CircleProps,
+  RecipeVariantProps,
 } from "@chakra-ui/react";
-import { Skeleton as ChakraSkeleton, Circle, Stack } from "@chakra-ui/react";
+import {
+  Skeleton as ChakraSkeleton,
+  Circle,
+  Stack,
+  useRecipe,
+} from "@chakra-ui/react";
 import * as React from "react";
 import { forwardRef } from "react";
 
-export interface SkeletonCircleProps extends ChakraSkeletonProps {
-  size?: CircleProps["size"];
-}
+type SkeletonVariantProps = RecipeVariantProps<typeof skeletonRecipe>;
+
+export type SkeletonCircleProps = ChakraSkeletonProps &
+  SkeletonVariantProps & {
+    size?: CircleProps["size"];
+  };
 
 export const SkeletonCircle = React.forwardRef<
   HTMLDivElement,
   SkeletonCircleProps
 >(function SkeletonCircle(props, ref) {
-  const { size, ...rest } = props;
+  const recipe = useRecipe({ recipe: skeletonRecipe });
+
+  const [recipeProps, restProps] = recipe.splitVariantProps(props);
+
+  const styles = recipe(recipeProps);
+
+  const { size, ...rest } = restProps;
+
   return (
     <Circle size={size} asChild ref={ref}>
-      <ChakraSkeleton {...rest} />
+      <ChakraSkeleton {...rest} loading={false} css={styles} />
     </Circle>
   );
 });
 
-export interface SkeletonTextProps extends ChakraSkeletonProps {
-  noOfLines?: number;
-}
+export type SkeletonTextProps = ChakraSkeletonProps &
+  SkeletonVariantProps & {
+    noOfLines?: number;
+  };
 
 export const SkeletonText = forwardRef<HTMLDivElement, SkeletonTextProps>(
   function SkeletonText(props, ref) {
-    const { noOfLines = 3, gap, ...rest } = props;
+    const recipe = useRecipe({ recipe: skeletonRecipe });
+
+    const [recipeProps, restProps] = recipe.splitVariantProps(props);
+
+    const styles = recipe(recipeProps);
+
+    const { noOfLines = 3, gap, ...rest } = restProps;
+
     return (
       <Stack gap={gap} width="full" ref={ref}>
         {Array.from({ length: noOfLines }).map((_, index) => (
           <ChakraSkeleton
-            height="4"
+            height="0.5rem"
+            css={styles}
             key={index}
             {...props}
             _last={{ maxW: "80%" }}
@@ -46,4 +72,19 @@ export const SkeletonText = forwardRef<HTMLDivElement, SkeletonTextProps>(
   },
 );
 
-export const Skeleton = ChakraSkeleton;
+export type SkeletonProps = ChakraSkeletonProps & SkeletonVariantProps;
+
+export const Skeleton = forwardRef<HTMLDivElement, SkeletonTextProps>(
+  function SkeletonText(props, ref) {
+    const recipe = useRecipe({ recipe: skeletonRecipe });
+
+    const [recipeProps, restProps] = recipe.splitVariantProps(props);
+    const styles = recipe(recipeProps);
+
+    return (
+      <>
+        <ChakraSkeleton {...restProps} height="6" ref={ref} css={styles} />
+      </>
+    );
+  },
+);

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -56,7 +56,6 @@ export const SkeletonText = forwardRef<HTMLDivElement, SkeletonTextProps>(
             height="0.5rem"
             css={styles}
             key={index}
-            {...props}
             _last={{ maxW: "80%" }}
             {...rest}
           />

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -47,13 +47,12 @@ export const SkeletonText = forwardRef<HTMLDivElement, SkeletonTextProps>(
     const recipe = useRecipe({ recipe: skeletonRecipe });
     const [recipeProps, restProps] = recipe.splitVariantProps(props);
     const styles = recipe(recipeProps);
-    const { noOfLines = 3, height = "0.5rem", gap, ...rest } = restProps;
+    const { noOfLines = 3, gap, ...rest } = restProps;
 
     return (
       <Stack gap={gap} width="full" ref={ref}>
         {Array.from({ length: noOfLines }).map((_, index) => (
           <ChakraSkeleton
-            height={height}
             css={styles}
             key={index}
             _last={{ maxW: "80%" }}

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -73,6 +73,6 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonTextProps>(
     const [recipeProps, restProps] = recipe.splitVariantProps(props);
     const styles = recipe(recipeProps);
 
-    return <ChakraSkeleton {...restProps} ref={ref} css={styles} />;
+    return <ChakraSkeleton {...restProps} loading ref={ref} css={styles} />;
   },
 );

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -26,11 +26,8 @@ export const SkeletonCircle = React.forwardRef<
   SkeletonCircleProps
 >(function SkeletonCircle(props, ref) {
   const recipe = useRecipe({ recipe: skeletonRecipe });
-
   const [recipeProps, restProps] = recipe.splitVariantProps(props);
-
   const styles = recipe(recipeProps);
-
   const { size, ...rest } = restProps;
 
   return (
@@ -48,11 +45,8 @@ export type SkeletonTextProps = ChakraSkeletonProps &
 export const SkeletonText = forwardRef<HTMLDivElement, SkeletonTextProps>(
   function SkeletonText(props, ref) {
     const recipe = useRecipe({ recipe: skeletonRecipe });
-
     const [recipeProps, restProps] = recipe.splitVariantProps(props);
-
     const styles = recipe(recipeProps);
-
     const { noOfLines = 3, gap, ...rest } = restProps;
 
     return (
@@ -77,14 +71,8 @@ export type SkeletonProps = ChakraSkeletonProps & SkeletonVariantProps;
 export const Skeleton = forwardRef<HTMLDivElement, SkeletonTextProps>(
   function SkeletonText(props, ref) {
     const recipe = useRecipe({ recipe: skeletonRecipe });
-
     const [recipeProps, restProps] = recipe.splitVariantProps(props);
     const styles = recipe(recipeProps);
-
-    return (
-      <>
-        <ChakraSkeleton {...restProps} height="6" ref={ref} css={styles} />
-      </>
-    );
+    return <ChakraSkeleton {...restProps} height="6" ref={ref} css={styles} />;
   },
 );

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -26,13 +26,19 @@ export const SkeletonCircle = React.forwardRef<
   SkeletonCircleProps
 >(function SkeletonCircle(props, ref) {
   const recipe = useRecipe({ recipe: skeletonRecipe });
-  const [recipeProps, restProps] = recipe.splitVariantProps(props);
+
+  const [recipeProps, restProps] = recipe.splitVariantProps({
+    loading: true,
+    variant: "pulse",
+    ...props,
+  });
+
   const styles = recipe(recipeProps);
   const { size, ...rest } = restProps;
 
   return (
     <Circle size={size} asChild ref={ref}>
-      <ChakraSkeleton {...rest} loading={false} css={styles} />
+      <ChakraSkeleton {...rest} css={styles} />
     </Circle>
   );
 });
@@ -45,7 +51,11 @@ export type SkeletonTextProps = ChakraSkeletonProps &
 export const SkeletonText = forwardRef<HTMLDivElement, SkeletonTextProps>(
   function SkeletonText(props, ref) {
     const recipe = useRecipe({ recipe: skeletonRecipe });
-    const [recipeProps, restProps] = recipe.splitVariantProps(props);
+    const [recipeProps, restProps] = recipe.splitVariantProps({
+      loading: true,
+      variant: "pulse",
+      ...props,
+    });
     const styles = recipe(recipeProps);
     const { noOfLines = 3, height = "0.5rem", gap, ...rest } = restProps;
 
@@ -70,9 +80,13 @@ export type SkeletonProps = ChakraSkeletonProps & SkeletonVariantProps;
 export const Skeleton = forwardRef<HTMLDivElement, SkeletonTextProps>(
   function SkeletonText(props, ref) {
     const recipe = useRecipe({ recipe: skeletonRecipe });
-    const [recipeProps, restProps] = recipe.splitVariantProps(props);
+    const [recipeProps, restProps] = recipe.splitVariantProps({
+      loading: true,
+      variant: "pulse",
+      ...props,
+    });
     const styles = recipe(recipeProps);
 
-    return <ChakraSkeleton {...restProps} loading ref={ref} css={styles} />;
+    return <ChakraSkeleton {...restProps} ref={ref} css={styles} />;
   },
 );

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -73,8 +73,6 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonTextProps>(
     const [recipeProps, restProps] = recipe.splitVariantProps(props);
     const styles = recipe(recipeProps);
 
-    const { height = "6", ...rest } = restProps;
-
-    return <ChakraSkeleton height={height} {...rest} ref={ref} css={styles} />;
+    return <ChakraSkeleton {...restProps} ref={ref} css={styles} />;
   },
 );

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -47,13 +47,13 @@ export const SkeletonText = forwardRef<HTMLDivElement, SkeletonTextProps>(
     const recipe = useRecipe({ recipe: skeletonRecipe });
     const [recipeProps, restProps] = recipe.splitVariantProps(props);
     const styles = recipe(recipeProps);
-    const { noOfLines = 3, gap, ...rest } = restProps;
+    const { noOfLines = 3, height = "0.5rem", gap, ...rest } = restProps;
 
     return (
       <Stack gap={gap} width="full" ref={ref}>
         {Array.from({ length: noOfLines }).map((_, index) => (
           <ChakraSkeleton
-            height="0.5rem"
+            height={height}
             css={styles}
             key={index}
             _last={{ maxW: "80%" }}
@@ -72,6 +72,9 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonTextProps>(
     const recipe = useRecipe({ recipe: skeletonRecipe });
     const [recipeProps, restProps] = recipe.splitVariantProps(props);
     const styles = recipe(recipeProps);
-    return <ChakraSkeleton height="6" {...restProps} ref={ref} css={styles} />;
+
+    const { height = "6", ...rest } = restProps;
+
+    return <ChakraSkeleton height={height} {...rest} ref={ref} css={styles} />;
   },
 );

--- a/packages/spor-react/src/loader/Skeleton.tsx
+++ b/packages/spor-react/src/loader/Skeleton.tsx
@@ -47,12 +47,13 @@ export const SkeletonText = forwardRef<HTMLDivElement, SkeletonTextProps>(
     const recipe = useRecipe({ recipe: skeletonRecipe });
     const [recipeProps, restProps] = recipe.splitVariantProps(props);
     const styles = recipe(recipeProps);
-    const { noOfLines = 3, gap, ...rest } = restProps;
+    const { noOfLines = 3, height = "0.5rem", gap, ...rest } = restProps;
 
     return (
       <Stack gap={gap} width="full" ref={ref}>
         {Array.from({ length: noOfLines }).map((_, index) => (
           <ChakraSkeleton
+            height={height}
             css={styles}
             key={index}
             _last={{ maxW: "80%" }}

--- a/packages/spor-react/src/theme/recipes/skeleton.ts
+++ b/packages/spor-react/src/theme/recipes/skeleton.ts
@@ -5,7 +5,7 @@ export const skeletonRecipe = defineRecipe({
   variants: {
     loading: {
       true: {
-        borderRadius: "xs", 
+        borderRadius: "xs",
         boxShadow: "none",
         backgroundClip: "padding-box",
         cursor: "default",
@@ -24,17 +24,27 @@ export const skeletonRecipe = defineRecipe({
     },
     variant: {
       pulse: {
-        background: "steel",
+        background: {
+          _light: "silver",
+          _dark: "darkGrey",
+        },
         animation: "pulse",
         animationDuration: "var(--duration, 1.2s)",
       },
       shine: {
         "--animate-from": "200%",
-        "--animate-to": "-200%", 
-        "--start-color": "colors.lightGrey",
-        "--end-color": "colors.steel",
+        "--animate-to": "-200%",
+        "--start-color": {
+          _light: "colors.lightGrey",
+          _dark: "colors.dimGrey",
+        },
+
+        "--end-color": {
+          _light: "colors.platinum",
+          _dark: "colors.darkGrey",
+        },
         backgroundImage:
-        "linear-gradient(270deg,var(--start-color),var(--end-color),var(--end-color),var(--start-color))",
+          "linear-gradient(270deg,var(--start-color),var(--end-color),var(--end-color),var(--start-color))",
         backgroundSize: "400% 100%",
         animation: "bg-position var(--duration, 5s) ease-in-out infinite",
       },
@@ -44,9 +54,4 @@ export const skeletonRecipe = defineRecipe({
       },
     },
   },
-
-  defaultVariants: {
-    variant: "pulse",
-    loading: true,
-  },
-})
+});

--- a/packages/spor-react/src/theme/recipes/skeleton.ts
+++ b/packages/spor-react/src/theme/recipes/skeleton.ts
@@ -1,0 +1,52 @@
+import { defineRecipe } from "@chakra-ui/react";
+
+export const skeletonRecipe = defineRecipe({
+  className: "chakra-skeleton",
+  variants: {
+    loading: {
+      true: {
+        borderRadius: "xs", 
+        boxShadow: "none",
+        backgroundClip: "padding-box",
+        cursor: "default",
+        color: "transparent",
+        pointerEvents: "none",
+        userSelect: "none",
+        flexShrink: "0",
+        "&::before, &::after, *": {
+          visibility: "hidden",
+        },
+      },
+      false: {
+        background: "unset",
+        animation: "fade-in var(--fade-duration, 0.1s) ease-out !important",
+      },
+    },
+    variant: {
+      pulse: {
+        background: "steel",
+        animation: "pulse",
+        animationDuration: "var(--duration, 1.2s)",
+      },
+      shine: {
+        "--animate-from": "200%",
+        "--animate-to": "-200%", 
+        "--start-color": "colors.lightGrey",
+        "--end-color": "colors.steel",
+        backgroundImage:
+        "linear-gradient(270deg,var(--start-color),var(--end-color),var(--end-color),var(--start-color))",
+        backgroundSize: "400% 100%",
+        animation: "bg-position var(--duration, 5s) ease-in-out infinite",
+      },
+      none: {
+        animation: "none",
+        background: "steel",
+      },
+    },
+  },
+
+  defaultVariants: {
+    variant: "pulse",
+    loading: true,
+  },
+})


### PR DESCRIPTION
## Background

Upgrading to chakra 3 breaks default styling applied, so created a recipe. 

## Solution

## Chakra update checklist

- [x] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [x] Updated documentation in the component file
- [x] Update green-beans-check.md with any major changes
- [x] Add changeset
- [x] Double check design in Figma (no design for Skeleton)

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)