### PR TITLE
Fix: Switching themes with Chakra 3

### DIFF
--- a/.changeset/popular-berries-suffer.md
+++ b/.changeset/popular-berries-suffer.md
@@ -1,0 +1,8 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+### Changed
+
+- Changed the way the theme is switched to work with Chakra 3.
+- Removed the `theme` prop and its value from `SporProvider`. Specifying brand should be sufficient.

--- a/apps/docs/app/features/brand-switcher/BrandSwitcher.tsx
+++ b/apps/docs/app/features/brand-switcher/BrandSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useFetcher } from "@remix-run/react";
-import { Brand, Select } from "@vygruppen/spor-react";
+import { Brand } from "@vygruppen/spor-react";
 import { useMatchesData } from "~/utils/useMatchesData";
 
 export const BrandSwitcher = () => {
@@ -7,11 +7,11 @@ export const BrandSwitcher = () => {
   const data = useMatchesData("root");
   const brand = data?.brand ?? Brand.VyDigital;
   return (
+    // Use native select until spor select is available
     <fetcher.Form method="post" action="/api/brand">
-      <Select
+      <select
         name="brand"
-        defaultValue={brand as any}
-        collection={brand}
+        defaultValue={brand as string}
         onChange={(e: any) => {
           const formData = new FormData();
           formData.set("brand", e.target.value);
@@ -24,7 +24,7 @@ export const BrandSwitcher = () => {
         <option value="VyDigital">Vy Digital</option>
         <option value="VyUtvikling">Vy Utvikling</option>
         <option value="CargoNet">CargoNet</option>
-      </Select>
+      </select>
     </fetcher.Form>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24697,7 +24697,6 @@
         "@vygruppen/spor-icon-react": "^3.12.0",
         "@vygruppen/spor-loader": "^0.4.0",
         "awesome-phonenumber": "^5.11.0",
-        "deepmerge": "^4.3.1",
         "framer-motion": "^11.11.17",
         "next-themes": "^0.4.4",
         "react-aria": "^3.33.1",

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -25,7 +25,6 @@
     "@vygruppen/spor-icon-react": "^3.12.0",
     "@vygruppen/spor-loader": "^0.4.0",
     "awesome-phonenumber": "^5.11.0",
-    "deepmerge": "^4.3.1",
     "framer-motion": "^11.11.17",
     "next-themes": "^0.4.4",
     "react-aria": "^3.33.1",

--- a/packages/spor-react/src/provider/SporProvider.tsx
+++ b/packages/spor-react/src/provider/SporProvider.tsx
@@ -1,23 +1,14 @@
 "use client";
 import { Global } from "@emotion/react";
-import deepmerge from "deepmerge";
 import React from "react";
-import { Language, LanguageProvider } from "..";
-import { Brand, brandTheme, fontFaces } from "../theme/brand";
-import { system as sporSystem } from "../theme";
-import {
-  ChakraProvider,
-  ChakraProviderProps,
-  defaultSystem,
-} from "@chakra-ui/react";
+import { Language, LanguageProvider, themes } from "..";
+import { Brand, fontFaces } from "../theme/brand";
+import { ChakraProvider, ChakraProviderProps } from "@chakra-ui/react";
 import { ColorModeProvider } from "../color-mode";
-import { vyDigitalColors } from "@/theme/semantic-tokens/colors";
 
 type SporProviderProps = Exclude<ChakraProviderProps, "value"> & {
   language?: Language;
   brand?: Brand;
-  theme?: typeof sporSystem;
-  value?: typeof sporSystem;
 };
 
 /**
@@ -58,19 +49,13 @@ import { theme } from '../../../../apps/docs/app/features/portable-text/code-blo
  * ```
  */
 export const SporProvider = ({
-  theme = sporSystem,
   language = Language.NorwegianBokmal,
   brand = Brand.VyDigital,
   children,
-  ...props
 }: SporProviderProps) => {
-  const brandCustomizations = brandTheme[brand] ?? {};
-
-  const extendedTheme = deepmerge(theme, brandCustomizations);
-
   return (
     <LanguageProvider language={language}>
-      <ChakraProvider {...props} value={extendedTheme}>
+      <ChakraProvider value={themes[brand]}>
         <ColorModeProvider>
           <Global styles={fontFaces} />
           {children}

--- a/packages/spor-react/src/theme/brand.ts
+++ b/packages/spor-react/src/theme/brand.ts
@@ -1,16 +1,7 @@
-import tokens from "@vygruppen/spor-design-tokens";
-import { cargonetColors, vyDigitalColors } from "./semantic-tokens/colors";
-
 export enum Brand {
   VyDigital = "VyDigital",
   VyUtvikling = "VyUtvikling",
   CargoNet = "CargoNet",
 }
-
-export const brandTheme = {
-  [Brand.VyDigital]: {},
-  [Brand.VyUtvikling]: vyDigitalColors,
-  [Brand.CargoNet]: cargonetColors,
-};
 
 export { fontFaces } from "./font-faces";

--- a/packages/spor-react/src/theme/index.ts
+++ b/packages/spor-react/src/theme/index.ts
@@ -12,13 +12,12 @@ import { semanticTokens } from "./semantic-tokens";
 import { slotRecipes } from "./slot-recipes";
 import { textStyles } from "./tokens/text-styles";
 import { tokens } from "./tokens";
-import { Brand, brandTheme } from "./brand";
+import { Brand } from "./brand";
 import { config } from "./tokens/config";
 
 const generateTheme = (brand: Brand) =>
   defineConfig({
     ...config,
-    ...brandTheme,
     globalCss,
     theme: {
       breakpoints,
@@ -46,3 +45,5 @@ export const themes = {
     generateTheme(Brand.VyUtvikling),
   ),
 };
+
+export const system = themes[Brand.VyDigital];

--- a/packages/spor-react/src/theme/index.ts
+++ b/packages/spor-react/src/theme/index.ts
@@ -12,23 +12,37 @@ import { semanticTokens } from "./semantic-tokens";
 import { slotRecipes } from "./slot-recipes";
 import { textStyles } from "./tokens/text-styles";
 import { tokens } from "./tokens";
-import { brandTheme } from "./brand";
+import { Brand, brandTheme } from "./brand";
 import { config } from "./tokens/config";
 
-const themeConfig = defineConfig({
-  ...config,
-  ...brandTheme,
-  globalCss,
-  theme: {
-    breakpoints,
-    keyframes,
-    tokens,
-    semanticTokens,
-    recipes,
-    slotRecipes,
-    textStyles,
-    animationStyles,
-  },
-});
+const generateTheme = (brand: Brand) =>
+  defineConfig({
+    ...config,
+    ...brandTheme,
+    globalCss,
+    theme: {
+      breakpoints,
+      keyframes,
+      tokens,
+      semanticTokens: semanticTokens[brand],
+      recipes,
+      slotRecipes,
+      textStyles,
+      animationStyles,
+    },
+  });
 
-export const system = createSystem(defaultBaseConfig, themeConfig);
+export const themes = {
+  [Brand.VyDigital]: createSystem(
+    defaultBaseConfig,
+    generateTheme(Brand.VyDigital),
+  ),
+  [Brand.CargoNet]: createSystem(
+    defaultBaseConfig,
+    generateTheme(Brand.CargoNet),
+  ),
+  [Brand.VyUtvikling]: createSystem(
+    defaultBaseConfig,
+    generateTheme(Brand.VyUtvikling),
+  ),
+};

--- a/packages/spor-react/src/theme/semantic-tokens/index.ts
+++ b/packages/spor-react/src/theme/semantic-tokens/index.ts
@@ -1,9 +1,24 @@
-import { colors } from "./colors";
+import { cargonetColors, colors, vyDigitalColors } from "./colors";
 import { shadows } from "./shadows";
 import { radii } from "./radii";
+import { Brand } from "../brand";
 
-export const semanticTokens = {
-  colors,
+const baseSemanticTokens = {
   shadows,
   radii,
+};
+
+export const semanticTokens = {
+  [Brand.VyUtvikling]: {
+    ...baseSemanticTokens,
+    colors,
+  },
+  [Brand.CargoNet]: {
+    ...baseSemanticTokens,
+    colors: cargonetColors,
+  },
+  [Brand.VyDigital]: {
+    ...baseSemanticTokens,
+    colors: vyDigitalColors,
+  },
 };

--- a/packages/spor-react/src/theme/slot-recipes/anatomy.ts
+++ b/packages/spor-react/src/theme/slot-recipes/anatomy.ts
@@ -79,17 +79,6 @@ export const travelTagAnatomy = createAnatomy("travel-tag").parts(
   "deviationIcon",
 );
 
-export const dialogAnatomy = createAnatomy("dialog").parts(
-  "header",
-  "body",
-  "footer",
-  "backdrop",
-  "positioner",
-  "content",
-  "title",
-  "description",
-);
-
 export const drawerAnatomy = createAnatomy("drawer").parts(
   "header",
   "body",


### PR DESCRIPTION
## Background

Previous implementation of switching between themes breaks with chakra 3. 
Use of deepmerge with theme does not work anymore.

## Solution

Create multiple systems to toggle between. 

## Chakra update checklist

- [x] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [x] Updated documentation in the component file
- [x] Update green-beans-check.md with any major changes
- [x] Add changeset
- [x] Double check design in Figma