### PR TITLE
Fix choice button

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.0.54",
+  "version": "0.0.55",
   "name": "@vygruppen/docs",
   "description": "The Spor documentation",
   "license": "MIT",

--- a/packages/spor-react/src/input/ChoiceChip.tsx
+++ b/packages/spor-react/src/input/ChoiceChip.tsx
@@ -86,8 +86,8 @@ export const ChoiceChip = forwardRef(
 
     return (
       <chakra.label
-        htmlFor={id}
         {...getRootProps()}
+        htmlFor={id}
         aria-label={String(children)}
       >
         <chakra.input


### PR DESCRIPTION
## Background
When using <ChoiceChip> and providing an id to said ChoiceChip, the implementation breaks because label will pass the id to the `for` attribute on itself while the id on the input will be the generated id from `useId()`. By changing the order of `RootProps` and `htmlFor` we make sure the `for`-attribute is set correctly.

Example of usage with id which broke the previous implementation:
```tsx
<MyChoiceChip
                  id={id}
                  key={id + choiceChip}
                  onChange={() =>
                    dispatch({ type: "set-tags", payload: choiceChip })
                  }
                  icon={{
                    default: getChoiceChipIcons(choiceChip).default,
                    checked: getChoiceChipIcons(choiceChip).checked,
                  }}
                  variant="base"
                  width="auto"
                  aria-describedby={
                    state.invalidFormSubmitted
                      ? "Kan ikke lagre tom logg."
                      : "Valgknapp"
                  }
     >
```


## Solution
Changing the order of `getRootProps` and `htmlFor` ensures the right id is used.

Describe what has been done.
## UU checks

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

## How to test
I was not able to make the npm pack work with local development, but I copied the component over to my web-app and tested there. When using the component with the correct order, you should find the following is set correctly in the component tree:
![image](https://github.com/user-attachments/assets/33c63267-3f43-42b5-99f6-41422f418a1b)

Note how the `for="..."` matches the `id` of the `<input>`.

| Before | After |
| ------ | ----- |
|        |       |
