### PR TITLE
ExternalId is always ignored

### DIFF
--- a/.changeset/pretty-kings-drive.md
+++ b/.changeset/pretty-kings-drive.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fixed bug where externalId on Heading was ignored

--- a/packages/spor-react/src/typography/Heading.tsx
+++ b/packages/spor-react/src/typography/Heading.tsx
@@ -46,9 +46,10 @@ export const Heading = ({
   ...props
 }: HeadingProps) => {
   const id =
-    (externalId ?? (autoId && typeof props.children === "string"))
-      ? slugify(props.children as string)
-      : undefined;
+    externalId ??
+    (autoId && typeof props.children === "string"
+      ? slugify(props.children)
+      : undefined);
   const color = useColorModeValue("text.primary.light", "text.primary.dark");
   return <Text as={as} textStyle={variant} id={id} color={color} {...props} />;
 };


### PR DESCRIPTION
## Background

setting manual id on Heading didn't work, even with autoId=false. This turned out to be because the logic for setting the id was wrong.

## Solution

Fixed the logic

## How to test

See that you can set the id and it is used, instead of the auto-generated one.
