### PR TITLE
Feature: New release Slackbot with webhooks and github actions

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -22,7 +22,7 @@ jobs:
 
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')
-          CHANGES=$(echo "${BODY}" | grep -oP '(?<=-   ).*')
+          CHANGES=$(echo "${BODY}" | grep -oP '(?<=-   ).*' | sed 's/^[a-f0-9]*: //')
           curl -X POST -H 'Content-type: application/json' --data "{
             \"text\": \"*Ny versjon av spor er ute!* 📦✨ \n
           ⚡️ *Versjon*: v${VERSION} \n

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -18,24 +18,8 @@ jobs:
           REPO: ${{ github.repository }}
           TAG_NAME: "@vygruppen/spor-react@11.3.0"
           HTML_URL: "https://github.com/nsbno/spor/releases/tag/%40vygruppen/spor-react%4011.3.0"
-          BODY: |
-            ### Minor Changes
+          BODY: "### Patch Changes-   6ac14ad: Fixed bug where externalId on Heading was ignored"
 
-            -   000e30a: - Replace npm with pnpm as package manager.
-                -   Update CI pipelines and Docker to use pnpm.
-                -   Update Docker to install from frozen lockfile to ensure exact dependency versions.
-                -   Fix dependency cycle between spor-react-icons and spor-package.
-                -   Update docs to use pnpm.
-                -   Install correct npm packages in apps/packages in monorepo.
-                -   Replace npm-feed installs with direct "workspace:\*" installs for better local development.
-                -   Replace inline commands for tsup with tsup.config.ts files.
-
-            ### Patch Changes
-
-            -   Updated dependencies [000e30a]
-                -   @vygruppen/spor-design-tokens@3.10.0
-                -   @vygruppen/spor-icon-react@3.13.0
-                -   @vygruppen/spor-loader@0.5.0
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')
           CHANGES=$(echo "${BODY}" | grep -oP '(?<=-   ).*')

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
   push:
     branches:
-      - test-branch
+      - slack_notify
 
 jobs:
   notify-slack:

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -37,4 +37,11 @@ jobs:
                 -   @vygruppen/spor-icon-react@3.13.0
                 -   @vygruppen/spor-loader@0.5.0
         run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"text":"Hello, *World!*"}' $SLACK_WEBHOOK_URL
+          curl -X POST -H 'Content-type: application/json' --data '{
+            "text": 
+            "*Ny versjon av spor er ute!* 📦✨ \n\n
+             ⚡️ Versjon: ${TAG_NAME} \n\n
+             🔧 Endringer: ${BODY} :book: \n\n
+             📖 Changelog: <${HTML_URL}|${TAG_NAME}> 
+             📦 Installer: `npm i @vygruppen/spor-react@latest` "
+          }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -20,5 +20,5 @@ jobs:
           BODY: ${{ github.event.release.body }}
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{
-            "text": "🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n🔗 ${RELEASE_URL} ${github.event.release.body} "
+            "text": "🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n🔗 2${RELEASE_URL} ${github.event.release.body} "
           }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -23,5 +23,5 @@ jobs:
           API_URL: ${{github.api_url}}
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{
-            "text": ":rocket: New *release* *${RELEASE_VERSION}* in *${REPO}*!\n\n:link: <${RELEASE_URL}|Release URL>\n\n${BODY}\n\n${TEST}\n\n<${API_URL}|Go to API>"
+            "text": ":rocket: test now New *release* *${RELEASE_VERSION}* in *${REPO}*!\n\n:link: <${RELEASE_URL}|Release URL>\n\n${BODY}\n\n${TEST}\n\n<${API_URL}|Go to API>"
           }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -37,11 +37,4 @@ jobs:
                 -   @vygruppen/spor-icon-react@3.13.0
                 -   @vygruppen/spor-loader@0.5.0
         run: |
-          curl -X POST -H 'Content-type: application/json' --data "{
-            \"text\": 
-            \"*Ny versjon av spor er ute!* 📦✨ \n\n
-             ⚡️ Versjon: ${TAG_NAME} \n\n
-             🔧 Endringer: ${BODY} :book: \n\n
-             📖 Changelog: <${HTML_URL}|${TAG_NAME}> 
-             📦 Installer: `npm i @vygruppen/spor-react@latest` \"
-          }" $SLACK_WEBHOOK_URL
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Hello, *World!*"}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -39,11 +39,12 @@ jobs:
 
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')
-          CHANGES=$(echo "${BODY}" | grep -oP '(?<=-   ).*' | sed 's/^[a-f0-9]*: //' | head -n 1)
+          CHANGES=$(echo "${BODY}" | grep -oP '(?<=-   ).*' | sed 's/^[a-f0-9]*: //')
           curl -X POST -H 'Content-type: application/json' --data "{
             \"text\": \"*Ny versjon av spor er ute!* 📦✨ \n
           ⚡️ *Versjon*: v${VERSION} \n
           🔧 *Endringer*: ${CHANGES} \n
+          🔧 *BODY*: ${BODY} \n
           📖 *Changelog*: <${HTML_URL}|${TAG_NAME}> \n
           📦 *Installer*: \`npm i @vygruppen/spor-react@latest\` \n \"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -37,10 +37,11 @@ jobs:
                 -   @vygruppen/spor-icon-react@3.13.0
                 -   @vygruppen/spor-loader@0.5.0
         run: |
+          VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')
           curl -X POST -H 'Content-type: application/json' --data "{
             \"text\": \"*Ny versjon av spor er ute!* 📦✨ \n
-          ⚡️:️ Versjon: ${TAG_NAME} \n
-          🔧: Endringer:  \n
-          📖: Changelog: <${HTML_URL}|${TAG_NAME}> \n
-          📦: Installer: \`npm i @vygruppen/spor-react@latest\` \n \"
+          ⚡️ *Versjon*: ${VERSION} \n
+          🔧 *Endringer*:  \n
+          📖 *Changelog*: <${HTML_URL}|${TAG_NAME}> \n
+          📦 *Installer*: \`npm i @vygruppen/spor-react@latest\` \n \"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -18,7 +18,7 @@ jobs:
           REPO: ${{ github.repository }}
           TAG_NAME: "@vygruppen/spor-react@11.3.0"
           HTML_URL: "https://github.com/nsbno/spor/releases/tag/%40vygruppen/spor-react%4011.3.0"
-          BODY: "### Patch Changes-   6ac14ad: Fixed bug where externalId on Heading was ignored"
+          BODY: "### Minor Changes -   000e30a: - Replace npm with pnpm as package manager. -   Update CI pipelines and Docker to use pnpm. -   Update Docker to install from frozen lockfile to ensure exact dependency versions. -   Fix dependency cycle between spor-react-icons and spor-package. -   Update docs to use pnpm. -   Install correct npm packages in apps/packages in monorepo. -   Replace npm-feed installs with direct workspace:* installs for better local development. -   Replace inline commands for tsup with tsup.config.ts files.  Patch Changes -   Updated dependencies [000e30a] -   @vygruppen/spor-design-tokens@3.10.0 -   @vygruppen/spor-icon-react@3.13.0 -   @vygruppen/spor-loader@0.5.0"
 
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')
@@ -26,7 +26,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data "{
             \"text\": \"*Ny versjon av spor er ute!* 📦✨ \n
           ⚡️ *Versjon*: v${VERSION} \n
-          🔧 *Endringer*: \n${CHANGES} \n
+          🔧 *Endringer*: ${CHANGES} \n
           📖 *Changelog*: <${HTML_URL}|${TAG_NAME}> \n
           📦 *Installer*: \`npm i @vygruppen/spor-react@latest\` \n \"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -39,9 +39,9 @@ jobs:
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{
             "text": 
-            "*Ny versjon av spor er ute!* 📦✨ \n\n
-             ⚡️ Versjon: ${TAG_NAME} \n\n
-             🔧 Endringer: ${BODY} :book: \n\n
-             📖 Changelog: <${HTML_URL}|${TAG_NAME}> 
-             📦 Installer: `npm i @vygruppen/spor-react@latest` "
+            "*Ny versjon av spor er ute!* 📦✨ \n
+          ⚡️ Versjon: ${TAG_NAME} \n
+          🔧 Endringer: ${BODY} :book: \n
+          📖 Changelog: <${HTML_URL}|${TAG_NAME}> \n
+          📦 Installer: `npm i @vygruppen/spor-react@latest` \n"
           }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -44,7 +44,6 @@ jobs:
             \"text\": \"*Ny versjon av spor er ute!* 📦✨ \n
           ⚡️ *Versjon*: v${VERSION} \n
           🔧 *Endringer*: ${CHANGES} \n
-          🔧 *BODY*: ${BODY} \n
           📖 *Changelog*: <${HTML_URL}|${TAG_NAME}> \n
           📦 *Installer*: \`npm i @vygruppen/spor-react@latest\` \n \"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,7 +1,11 @@
 name: Notify Slack on New Release
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
+  push:
+    branches:
+      - test-branch
 
 jobs:
   notify-slack:
@@ -13,7 +17,8 @@ jobs:
           REPO: ${{ github.repository }}
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
           RELEASE_URL: ${{ github.event.release.html_url }}
+          BODY: ${{ github.event.release.body }}
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{
-            "text": "🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n🔗 ${RELEASE_URL}"
+            "text": "🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n🔗 ${RELEASE_URL} ${github.event.release.body} "
           }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -38,9 +38,9 @@ jobs:
                 -   @vygruppen/spor-loader@0.5.0
         run: |
           curl -X POST -H 'Content-type: application/json' --data "{
-            \"text\": \"*Ny versjon av spor er ute!* :package::sparkles: \n
-          :zap:️ Versjon: ${TAG_NAME} \n
-          :wrench: Endringer: :book: \n
-          :book: Changelog: <${HTML_URL}|${TAG_NAME}> \n
-          :package: Installer: `npm i @vygruppen/spor-react@latest` \n \"
+            \"text\": \"*Ny versjon av spor er ute!* 📦✨ \n
+          ⚡️:️ Versjon: ${TAG_NAME} \n
+          🔧: Endringer:  \n
+          📖: Changelog: <${HTML_URL}|${TAG_NAME}> \n
+          📦: Installer: \`npm i @vygruppen/spor-react@latest\` \n \"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -18,24 +18,7 @@ jobs:
           REPO: ${{ github.repository }}
           TAG_NAME: "@vygruppen/spor-react@11.3.0"
           HTML_URL: "https://github.com/nsbno/spor/releases/tag/%40vygruppen/spor-react%4011.3.0"
-          BODY: |
-            ### Minor Changes
-
-            - 000e30a: - Replace npm with pnpm as package manager.
-              - Update CI pipelines and Docker to use pnpm.
-              - Update Docker to install from frozen lockfile to ensure exact dependency versions.
-              - Fix dependency cycle between spor-react-icons and spor-package.
-              - Update docs to use pnpm.
-              - Install correct npm packages in apps/packages in monorepo.
-              - Replace npm-feed installs with direct workspace:* installs for better local development.
-              - Replace inline commands for tsup with tsup.config.ts files.
-
-            ### Patch Changes
-
-            - Updated dependencies [000e30a]
-              - @vygruppen/spor-design-tokens@3.10.0
-              - @vygruppen/spor-icon-react@3.13.0
-              - @vygruppen/spor-loader@0.5.0
+          BODY: "### Minor Changes -   000e30a: - Replace npm with pnpm as package manager. -   Update CI pipelines and Docker to use pnpm. -   Update Docker to install from frozen lockfile to ensure exact dependency versions. -   Fix dependency cycle between spor-react-icons and spor-package. -   Update docs to use pnpm. -   Install correct npm packages in apps/packages in monorepo. -   Replace npm-feed installs with direct workspace:* installs for better local development. -   Replace inline commands for tsup with tsup.config.ts files.  Patch Changes -   Updated dependencies [000e30a] -   @vygruppen/spor-design-tokens@3.10.0 -   @vygruppen/spor-icon-react@3.13.0 -   @vygruppen/spor-loader@0.5.0"
 
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -18,7 +18,9 @@ jobs:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
           RELEASE_URL: ${{ github.event.release.html_url }}
           BODY: ${{ github.event.release.body }}
+          TEST: "test"
+          OTHER: ${{github.api_url}}
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{
-            "text": "🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n🔗 2${RELEASE_URL} ${github.event.release.body} "
+            "text": "🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n🔗 2${RELEASE_URL} ${BODY} ${TEST} ${OTHER}"
           }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -3,10 +3,6 @@ name: Notify Slack on New Release
 on:
   release:
     types: [published]
-  push:
-    branches:
-      - slack_notify
-  workflow_dispatch:
 
 jobs:
   notify-slack:

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -22,6 +22,6 @@ jobs:
           TEST: "test"
           API_URL: ${{ github.api_url }}
         run: |
-          curl -X POST -H 'Content-type: application/json' --data '{
-            "text": "A new release has been published: ${REPO} - ${RELEASE_VERSION}\n\nRelease Notes: ${BODY}\n${RELEASE_URL} \n\n${API_URL} ${TEST}"
-          }' $SLACK_WEBHOOK_URL
+          curl -X POST -H 'Content-type: application/json' --data "{
+            \"text\": \"A *new* release has been published: ${REPO} - ${RELEASE_VERSION}\n\nRelease Notes: ${BODY}\n${RELEASE_URL} \n\n${API_URL} ${TEST}\"
+          }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -16,12 +16,32 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           REPO: ${{ github.repository }}
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
-          BODY: ${{ github.event.release.body }}
-          TEST: "test"
-          API_URL: ${{ github.api_url }}
+          TAG_NAME: "@vygruppen/spor-react@11.3.0"
+          HTML_URL: "https://github.com/nsbno/spor/releases/tag/%40vygruppen/spor-react%4011.3.0"
+          BODY: |
+            ### Minor Changes
+
+            -   000e30a: - Replace npm with pnpm as package manager.
+                -   Update CI pipelines and Docker to use pnpm.
+                -   Update Docker to install from frozen lockfile to ensure exact dependency versions.
+                -   Fix dependency cycle between spor-react-icons and spor-package.
+                -   Update docs to use pnpm.
+                -   Install correct npm packages in apps/packages in monorepo.
+                -   Replace npm-feed installs with direct "workspace:\*" installs for better local development.
+                -   Replace inline commands for tsup with tsup.config.ts files.
+
+            ### Patch Changes
+
+            -   Updated dependencies [000e30a]
+                -   @vygruppen/spor-design-tokens@3.10.0
+                -   @vygruppen/spor-icon-react@3.13.0
+                -   @vygruppen/spor-loader@0.5.0
         run: |
           curl -X POST -H 'Content-type: application/json' --data "{
-            \"text\": \"A *new* release has been published: ${REPO} - ${RELEASE_VERSION}\n\nRelease Notes: ${BODY}\n${RELEASE_URL} \n\n${API_URL} ${TEST}\"
+            \"text\": 
+            \"Ny minor-versjon av spor er ute! 📦✨ \n\n
+             ⚡️ Versjon: ${TAG_NAME} \n\n
+             🔧 Endringer: ${BODY} :book: \n\n
+             📖 Changelog: <${HTML_URL}|${TAG_NAME}> 
+             📦 Installer: `npm i @vygruppen/spor-react@latest` \"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -18,11 +18,28 @@ jobs:
           REPO: ${{ github.repository }}
           TAG_NAME: "@vygruppen/spor-react@11.3.0"
           HTML_URL: "https://github.com/nsbno/spor/releases/tag/%40vygruppen/spor-react%4011.3.0"
-          BODY: "### Minor Changes -   000e30a: - Replace npm with pnpm as package manager. -   Update CI pipelines and Docker to use pnpm. -   Update Docker to install from frozen lockfile to ensure exact dependency versions. -   Fix dependency cycle between spor-react-icons and spor-package. -   Update docs to use pnpm. -   Install correct npm packages in apps/packages in monorepo. -   Replace npm-feed installs with direct workspace:* installs for better local development. -   Replace inline commands for tsup with tsup.config.ts files.  Patch Changes -   Updated dependencies [000e30a] -   @vygruppen/spor-design-tokens@3.10.0 -   @vygruppen/spor-icon-react@3.13.0 -   @vygruppen/spor-loader@0.5.0"
+          BODY: |
+            ### Minor Changes
+
+            - 000e30a: - Replace npm with pnpm as package manager.
+              - Update CI pipelines and Docker to use pnpm.
+              - Update Docker to install from frozen lockfile to ensure exact dependency versions.
+              - Fix dependency cycle between spor-react-icons and spor-package.
+              - Update docs to use pnpm.
+              - Install correct npm packages in apps/packages in monorepo.
+              - Replace npm-feed installs with direct workspace:* installs for better local development.
+              - Replace inline commands for tsup with tsup.config.ts files.
+
+            ### Patch Changes
+
+            - Updated dependencies [000e30a]
+              - @vygruppen/spor-design-tokens@3.10.0
+              - @vygruppen/spor-icon-react@3.13.0
+              - @vygruppen/spor-loader@0.5.0
 
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')
-          CHANGES=$(echo "${BODY}" | grep -oP '-   [a-f0-9]+: (.+)' | sed 's/-   [a-f0-9]*: //')
+          CHANGES=$(echo "${BODY}" | grep -oP '(?<=-   ).*' | sed 's/^[a-f0-9]*: //')
           curl -X POST -H 'Content-type: application/json' --data "{
             \"text\": \"*Ny versjon av spor er ute!* 📦✨ \n
           ⚡️ *Versjon*: v${VERSION} \n

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -37,11 +37,11 @@ jobs:
                 -   @vygruppen/spor-icon-react@3.13.0
                 -   @vygruppen/spor-loader@0.5.0
         run: |
-          curl -X POST -H 'Content-type: application/json' --data '{
-            /"text/": 
-            /"*Ny versjon av spor er ute!* 📦✨ \n
+          curl -X POST -H 'Content-type: application/json' --data "{
+            \"text\": 
+            \"*Ny versjon av spor er ute!* 📦✨ \n
           ⚡️ Versjon: ${TAG_NAME} \n
           🔧 Endringer: ${BODY} :book: \n
           📖 Changelog: <${HTML_URL}|${TAG_NAME}> \n
-          📦 Installer: `npm i @vygruppen/spor-react@latest` \n /"
-          }' $SLACK_WEBHOOK_URL
+          📦 Installer: \`npm i @vygruppen/spor-react@latest\` \n\"
+          }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -38,5 +38,5 @@ jobs:
                 -   @vygruppen/spor-loader@0.5.0
         run: |
           curl -X POST -H 'Content-type: application/json' --data "{
-            \"text\": \"Ny minor-versjon av spor er ute! :package: :sparkles: :zap: Versjon: ${TAG_NAME} :wrench: Endringer: ${BODY} :book: Changelog: ${HTML_URL} :package: Installer: npm i @vygruppen/spor-react@latest\"
+            \"text\": \"Ny minor-versjon av spor er ute! :package: :sparkles: :zap: Versjon: ${TAG_NAME} :wrench: Endringer: :book: Changelog: ${HTML_URL} :package: Installer: npm i @vygruppen/spor-react@latest\"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -22,6 +22,6 @@ jobs:
           TEST: "test"
           API_URL: ${{github.api_url}}
         run: |
-          curl -X POST -H 'Content-type: application/json' --data "{
-            \"text\": \":rocket: New *release* *${RELEASE_VERSION}* in *${REPO}*!\n\n:link: <${RELEASE_URL}|Release URL>\n\n${BODY}\n\n${TEST}\n\n<${API_URL}|Go to API>\"
-          }" $SLACK_WEBHOOK_URL
+          curl -X POST -H 'Content-type: application/json' --data '{
+            "text": ":rocket: New *release* *${RELEASE_VERSION}* in *${REPO}*!\n\n:link: <${RELEASE_URL}|Release URL>\n\n${BODY}\n\n${TEST}\n\n<${API_URL}|Go to API>"
+          }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           curl -X POST -H 'Content-type: application/json' --data "{
             \"text\": 
-            \"Ny minor-versjon av spor er ute! 📦✨ \n\n
+            \"*Ny versjon av spor er ute!* 📦✨ \n\n
              ⚡️ Versjon: ${TAG_NAME} \n\n
              🔧 Endringer: ${BODY} :book: \n\n
              📖 Changelog: <${HTML_URL}|${TAG_NAME}> 

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -38,10 +38,11 @@ jobs:
                 -   @vygruppen/spor-loader@0.5.0
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')
+          CHANGES=$(echo "${BODY}" | grep -oP '(?<=-   ).*')
           curl -X POST -H 'Content-type: application/json' --data "{
             \"text\": \"*Ny versjon av spor er ute!* 📦✨ \n
-          ⚡️ *Versjon*: ${VERSION} \n
-          🔧 *Endringer*:  \n
+          ⚡️ *Versjon*: v${VERSION} \n
+          🔧 *Endringer*: \n${CHANGES} \n
           📖 *Changelog*: <${HTML_URL}|${TAG_NAME}> \n
           📦 *Installer*: \`npm i @vygruppen/spor-react@latest\` \n \"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -22,7 +22,7 @@ jobs:
 
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')
-          CHANGES=$(echo "${BODY}" | grep -oP '(?<=-   ).*' | sed 's/^[a-f0-9]*: //')
+          CHANGES=$(echo "${BODY}" | grep -oP '-   [a-f0-9]+: (.+)' | sed 's/-   [a-f0-9]*: //')
           curl -X POST -H 'Content-type: application/json' --data "{
             \"text\": \"*Ny versjon av spor er ute!* 📦✨ \n
           ⚡️ *Versjon*: v${VERSION} \n

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -38,10 +38,10 @@ jobs:
                 -   @vygruppen/spor-loader@0.5.0
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{
-            "text": 
-            "*Ny versjon av spor er ute!* 📦✨ \n
+            /"text/": 
+            /"*Ny versjon av spor er ute!* 📦✨ \n
           ⚡️ Versjon: ${TAG_NAME} \n
           🔧 Endringer: ${BODY} :book: \n
           📖 Changelog: <${HTML_URL}|${TAG_NAME}> \n
-          📦 Installer: `npm i @vygruppen/spor-react@latest` \n"
+          📦 Installer: `npm i @vygruppen/spor-react@latest` \n /"
           }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -38,5 +38,9 @@ jobs:
                 -   @vygruppen/spor-loader@0.5.0
         run: |
           curl -X POST -H 'Content-type: application/json' --data "{
-            \"text\": \"Ny minor-versjon av spor er ute! :package: :sparkles: :zap: Versjon: ${TAG_NAME} :wrench: Endringer: :book: Changelog: ${HTML_URL} :package: Installer: npm i @vygruppen/spor-react@latest\"
+            \"text\": \"*Ny versjon av spor er ute!* :package::sparkles: \n
+          :zap:️ Versjon: ${TAG_NAME} \n
+          :wrench: Endringer: :book: \n
+          :book: Changelog: <${HTML_URL}|${TAG_NAME}> \n
+          :package: Installer: `npm i @vygruppen/spor-react@latest` \n \"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -38,10 +38,5 @@ jobs:
                 -   @vygruppen/spor-loader@0.5.0
         run: |
           curl -X POST -H 'Content-type: application/json' --data "{
-            'text': 
-            '*Ny versjon av spor er ute!* 📦✨ \n
-          ⚡️ Versjon: ${TAG_NAME} \n
-          🔧 Endringer: ${BODY} :book: \n
-          📖 Changelog: <${HTML_URL}|${TAG_NAME}> \n
-          📦 Installer: `npm i @vygruppen/spor-react@latest` \n'
+            \"text\": \"Ny minor-versjon av spor er ute! :package: :sparkles: :zap: Versjon: ${TAG_NAME} :wrench: Endringer: ${BODY} :book: Changelog: ${HTML_URL} :package: Installer: npm i @vygruppen/spor-react@latest\"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -18,11 +18,28 @@ jobs:
           REPO: ${{ github.repository }}
           TAG_NAME: "@vygruppen/spor-react@11.3.0"
           HTML_URL: "https://github.com/nsbno/spor/releases/tag/%40vygruppen/spor-react%4011.3.0"
-          BODY: "### Minor Changes -   000e30a: - Replace npm with pnpm as package manager. -   Update CI pipelines and Docker to use pnpm. -   Update Docker to install from frozen lockfile to ensure exact dependency versions. -   Fix dependency cycle between spor-react-icons and spor-package. -   Update docs to use pnpm. -   Install correct npm packages in apps/packages in monorepo. -   Replace npm-feed installs with direct workspace:* installs for better local development. -   Replace inline commands for tsup with tsup.config.ts files.  Patch Changes -   Updated dependencies [000e30a] -   @vygruppen/spor-design-tokens@3.10.0 -   @vygruppen/spor-icon-react@3.13.0 -   @vygruppen/spor-loader@0.5.0"
+          BODY: |
+            ### Minor Changes
+
+            - 000e30a: - Replace npm with pnpm as package manager.
+              - Update CI pipelines and Docker to use pnpm.
+              - Update Docker to install from frozen lockfile to ensure exact dependency versions.
+              - Fix dependency cycle between spor-react-icons and spor-package.
+              - Update docs to use pnpm.
+              - Install correct npm packages in apps/packages in monorepo.
+              - Replace npm-feed installs with direct "workspace:*" installs for better local development.
+              - Replace inline commands for tsup with tsup.config.ts files.
+
+            ### Patch Changes
+
+            - Updated dependencies [000e30a]
+              - @vygruppen/spor-design-tokens@3.10.0
+              - @vygruppen/spor-icon-react@3.13.0
+              - @vygruppen/spor-loader@0.5.0
 
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')
-          CHANGES=$(echo "${BODY}" | grep -oP '(?<=-   ).*' | sed 's/^[a-f0-9]*: //')
+          CHANGES=$(echo "${BODY}" | grep -oP '(?<=-   ).*' | sed 's/^[a-f0-9]*: //' | head -n 1)
           curl -X POST -H 'Content-type: application/json' --data "{
             \"text\": \"*Ny versjon av spor er ute!* 📦✨ \n
           ⚡️ *Versjon*: v${VERSION} \n

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -16,9 +16,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           REPO: ${{ github.repository }}
-          TAG_NAME: "@vygruppen/spor-react@11.3.0"
-          HTML_URL: "https://github.com/nsbno/spor/releases/tag/%40vygruppen/spor-react%4011.3.0"
-          BODY: "### Minor Changes -   000e30a: - Replace npm with pnpm as package manager. -   Update CI pipelines and Docker to use pnpm. -   Update Docker to install from frozen lockfile to ensure exact dependency versions. -   Fix dependency cycle between spor-react-icons and spor-package. -   Update docs to use pnpm. -   Install correct npm packages in apps/packages in monorepo. -   Replace npm-feed installs with direct workspace:* installs for better local development. -   Replace inline commands for tsup with tsup.config.ts files.  Patch Changes -   Updated dependencies [000e30a] -   @vygruppen/spor-design-tokens@3.10.0 -   @vygruppen/spor-icon-react@3.13.0 -   @vygruppen/spor-loader@0.5.0"
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          HTML_URL: ${{ github.event.release.html_url }}
+          BODY: ${{ github.event.release.body }}
 
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -18,24 +18,7 @@ jobs:
           REPO: ${{ github.repository }}
           TAG_NAME: "@vygruppen/spor-react@11.3.0"
           HTML_URL: "https://github.com/nsbno/spor/releases/tag/%40vygruppen/spor-react%4011.3.0"
-          BODY: |
-            ### Minor Changes
-
-            - 000e30a: - Replace npm with pnpm as package manager.
-              - Update CI pipelines and Docker to use pnpm.
-              - Update Docker to install from frozen lockfile to ensure exact dependency versions.
-              - Fix dependency cycle between spor-react-icons and spor-package.
-              - Update docs to use pnpm.
-              - Install correct npm packages in apps/packages in monorepo.
-              - Replace npm-feed installs with direct "workspace:*" installs for better local development.
-              - Replace inline commands for tsup with tsup.config.ts files.
-
-            ### Patch Changes
-
-            - Updated dependencies [000e30a]
-              - @vygruppen/spor-design-tokens@3.10.0
-              - @vygruppen/spor-icon-react@3.13.0
-              - @vygruppen/spor-loader@0.5.0
+          BODY: "### Minor Changes -   000e30a: - Replace npm with pnpm as package manager. -   Update CI pipelines and Docker to use pnpm. -   Update Docker to install from frozen lockfile to ensure exact dependency versions. -   Fix dependency cycle between spor-react-icons and spor-package. -   Update docs to use pnpm. -   Install correct npm packages in apps/packages in monorepo. -   Replace npm-feed installs with direct workspace:* installs for better local development. -   Replace inline commands for tsup with tsup.config.ts files.  Patch Changes -   Updated dependencies [000e30a] -   @vygruppen/spor-design-tokens@3.10.0 -   @vygruppen/spor-icon-react@3.13.0 -   @vygruppen/spor-loader@0.5.0"
 
         run: |
           VERSION=$(echo "${TAG_NAME}" | sed 's/.*@//')

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -23,5 +23,5 @@ jobs:
           API_URL: ${{github.api_url}}
         run: |
           curl -X POST -H 'Content-type: application/json' --data "{
-            \"text\": \"🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n\n🔗 ${RELEASE_URL}\n\n${BODY}\n\n${TEST}\n\n<${API_URL}|go to api>\"
+            \"text\": \":rocket: New *release* *${RELEASE_VERSION}* in *${REPO}*!\n\n:link: <${RELEASE_URL}|Release URL>\n\n${BODY}\n\n${TEST}\n\n<${API_URL}|Go to API>\"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -20,8 +20,8 @@ jobs:
           RELEASE_URL: ${{ github.event.release.html_url }}
           BODY: ${{ github.event.release.body }}
           TEST: "test"
-          OTHER: ${{github.api_url}}
+          API_URL: ${{github.api_url}}
         run: |
           curl -X POST -H 'Content-type: application/json' --data "{
-            \"text\": \"🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n🔗 ${RELEASE_URL} ${BODY} ${TEST} ${OTHER}\"
+            \"text\": \"🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n\n🔗 ${RELEASE_URL}\n\n${BODY}\n\n${TEST}\n\n<${API_URL}|go to api>\"
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -20,8 +20,8 @@ jobs:
           RELEASE_URL: ${{ github.event.release.html_url }}
           BODY: ${{ github.event.release.body }}
           TEST: "test"
-          API_URL: ${{github.api_url}}
+          API_URL: ${{ github.api_url }}
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{
-            "text": ":rocket: test now New *release* *${RELEASE_VERSION}* in *${REPO}*!\n\n:link: <${RELEASE_URL}|Release URL>\n\n${BODY}\n\n${TEST}\n\n<${API_URL}|Go to API>"
+            "text": "A new release has been published: ${REPO} - ${RELEASE_VERSION}\n\nRelease Notes: ${BODY}\n${RELEASE_URL} \n\n${API_URL} ${TEST}"
           }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -38,10 +38,10 @@ jobs:
                 -   @vygruppen/spor-loader@0.5.0
         run: |
           curl -X POST -H 'Content-type: application/json' --data "{
-            \"text\": 
-            \"*Ny versjon av spor er ute!* 📦✨ \n
+            'text': 
+            '*Ny versjon av spor er ute!* 📦✨ \n
           ⚡️ Versjon: ${TAG_NAME} \n
           🔧 Endringer: ${BODY} :book: \n
           📖 Changelog: <${HTML_URL}|${TAG_NAME}> \n
-          📦 Installer: \`npm i @vygruppen/spor-react@latest\` \n\"
+          📦 Installer: `npm i @vygruppen/spor-react@latest` \n'
           }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - slack_notify
+  workflow_dispatch:
 
 jobs:
   notify-slack:
@@ -21,6 +22,6 @@ jobs:
           TEST: "test"
           OTHER: ${{github.api_url}}
         run: |
-          curl -X POST -H 'Content-type: application/json' --data '{
-            "text": "🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n🔗 2${RELEASE_URL} ${BODY} ${TEST} ${OTHER}"
-          }' $SLACK_WEBHOOK_URL
+          curl -X POST -H 'Content-type: application/json' --data "{
+            \"text\": \"🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n🔗 ${RELEASE_URL} ${BODY} ${TEST} ${OTHER}\"
+          }" $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,21 @@
+name: Notify Slack on New Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack Notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{
+            "text": "🚀 New release *${RELEASE_VERSION}* in *${REPO}*!\n🔗 ${RELEASE_URL}"
+          }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,8 +1,6 @@
 name: Notify Slack on New Release
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Background

The old one was using a free trial of zapper and would stop working soon. 

## Solution

Use slack webhooks and github actions to create a new one. 