### PR TITLE
Remove icon service alert if more than one message

### DIFF
--- a/.changeset/smooth-dolls-turn.md
+++ b/.changeset/smooth-dolls-turn.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Service Alert: component does not show any icon if there are more than one warning message

--- a/packages/spor-react/src/alert/ServiceAlert.tsx
+++ b/packages/spor-react/src/alert/ServiceAlert.tsx
@@ -11,9 +11,9 @@ import {
   useMultiStyleConfig,
 } from "@chakra-ui/react";
 import React from "react";
+import { createTexts, useTranslation } from "../i18n";
 import { AlertIcon } from "./AlertIcon";
 import { BaseAlert, BaseAlertProps } from "./BaseAlert";
-import { createTexts, useTranslation } from "../i18n";
 
 type ServiceAlertProps = BaseAlertProps & {
   /** The title string  */
@@ -91,7 +91,7 @@ export const ServiceAlert = ({
                 maxWidth={contentWidth}
               >
                 <Flex as={headingLevel} alignItems="center">
-                  <AlertIcon variant={variant} />
+                  {notification === 1 && <AlertIcon variant={variant} />}
 
                   <Box
                     as="span"


### PR DESCRIPTION
## Background

A minor variation of design in service message was asked to remove the icon if there were more than one message 

## Solution

Add a condition to remove the icon if notifications were more than 1

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

run documentation locally and check http://localhost:3000/components/alert at the bottom of the page there is the service alert try to pass notification prop to 1 or higher

## Screenshots

![Skjermbilde 2025-03-18 kl  12 44 01](https://github.com/user-attachments/assets/046c062b-02fb-4322-a954-e1cb009667fa)

