### PR TITLE
Update PhoneNumberInput name prop

### DIFF
--- a/.changeset/spicy-ears-explode.md
+++ b/.changeset/spicy-ears-explode.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Update PhoneNumberInput name prop

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -14,9 +14,14 @@ type PhoneNumberInputProps = Omit<BoxProps, "onChange"> & {
   label?: string;
   /** The root name.
    *
-   * Please note that when specifying the name, the rendered names will be `${name}-country-code` and `${name}-phone-number`, respectively
+   * Please note that when specifying the name, the rendered names will be `${name}-country-code` and `${name}-phone-number` unless a name is provided for both countryCode and nationalNumber.
    */
-  name?: string;
+  name?:
+    | string
+    | {
+        countryCode: string;
+        nationalNumber: string;
+      };
   /** Callback for when the country code or phone number changes */
   onChange?: (change: CountryCodeAndPhoneNumber) => void;
   /** The optional value of the country code and phone number */
@@ -31,7 +36,7 @@ type PhoneNumberInputProps = Omit<BoxProps, "onChange"> & {
  * <PhoneNumberInput name="phone" />
  * ```
  *
- * > Please note that when specifying the name, the rendered names will be `${name}-country-code` and `${name}-phone-number`, respectively
+ * > Please note that when specifying the name, the rendered names will be `${name}-country-code` and `${name}-phone-number` unless a name is provided for both countryCode and nationalNumber.
  *
  * The field can be controlled as well:
  * ```tsx
@@ -76,7 +81,13 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
               nationalNumber: value.nationalNumber,
             })
           }
-          name={name ? `${name}-country-code` : "country-code"}
+          name={
+            name
+              ? typeof name !== "string" && name.countryCode
+                ? name.countryCode
+                : `${name}-country-code`
+              : "country-code"
+          }
           height="100%"
           width="6.25rem"
           variant={variant}
@@ -86,7 +97,13 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, As>(
           type="tel"
           label={label}
           value={value.nationalNumber}
-          name={name ? `${name}-phone-number` : "phone-number"}
+          name={
+            name
+              ? typeof name !== "string" && name.nationalNumber
+                ? name.nationalNumber
+                : `${name}-phone-number`
+              : "phone-number"
+          }
           onChange={(e) => {
             // Removes everything but numbers, spaces and dashes
             const strippedValue = e.target.value.replace(/[^\d\s-]/g, "");

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -5,11 +5,11 @@ import { AttachedInputs } from "./AttachedInputs";
 import { CountryCodeSelect } from "./CountryCodeSelect";
 import { As } from "@chakra-ui/system";
 
-type CountryCodeAndPhoneNumber = {
+export type CountryCodeAndPhoneNumber = {
   countryCode: string;
   nationalNumber: string;
 };
-type PhoneNumberInputProps = Omit<BoxProps, "onChange"> & {
+export type PhoneNumberInputProps = Omit<BoxProps, "onChange"> & {
   /** The label. Defaults to a localized version of "Phone number" */
   label?: string;
   /** The root name.


### PR DESCRIPTION
## Background

Not being able to set specific `name`-attributes for the country-code and national-number inputs is a bit problematic when using [Conform](https://conform.guide/).

Conform expects a certain naming convention (e.g. `phoneNumber.countryCode`) which is currently not possible to achieve as the PhoneNumberInput adds a suffix to the name, i.e. `${name}-country-code` and `${name}-phone-number`.
This results in relying on hidden inputs and other hacky solutions when using PhoneNumberInput with Conform.

## Solution

Updated the name prop to

```
name?:
  | string
  | { countryCode: string; nationalNumber: string; };
```

If given a string it works the same way as previously, if given an object no `-country-code`/`-phone-number` suffix is added.

## UU checks

- [ ] Sanity documentation has been / will be updated (if neccessary)

## How to test

Check that the PhoneNumberInput works as expected when given a string or an object for the name. 
