### PR TITLE
Fixed backgroundColor on several components

### DIFF
--- a/packages/spor-react/src/theme/recipes/button.ts
+++ b/packages/spor-react/src/theme/recipes/button.ts
@@ -62,7 +62,7 @@ export const buttonRecipe = defineRecipe({
           ...coreBackground("hover"),
           _active: {
             ...coreBorder("default"),
-            ...coreBackground("active"),
+            backgroundColor: "core.surface.active",
           },
         },
       },

--- a/packages/spor-react/src/theme/recipes/input.ts
+++ b/packages/spor-react/src/theme/recipes/input.ts
@@ -83,7 +83,9 @@ export const inputRecipe = defineRecipe({
         _active: {
           outline: "1px solid",
           outlineColor: "floating.outline.active",
+          backgroundColor: "core.surface.active",
         },
+
         focus: {
           outline: "1px solid",
           outlineColor: "outline.focus",

--- a/packages/spor-react/src/theme/recipes/pressable-card.ts
+++ b/packages/spor-react/src/theme/recipes/pressable-card.ts
@@ -32,7 +32,7 @@ export const pressableCardRecipe = defineRecipe({
         _hover: {
           ...coreBorder("hover"),
           _active: {
-            ...coreBackground("active"),
+            backgroundColor: "core.surface.active",
             ...coreBorder("active"),
           },
         },

--- a/packages/spor-react/src/theme/slot-recipes/accordion.ts
+++ b/packages/spor-react/src/theme/slot-recipes/accordion.ts
@@ -98,7 +98,7 @@ export const accordionSlotRecipe = defineSlotRecipe({
             outlineOffset: 0,
           },
           "&:active": {
-            ...coreBackground("active"),
+            backgroundColor: "core.surface.active",
             ...coreBorder("default"),
           },
         },

--- a/packages/spor-react/src/theme/slot-recipes/breadcrumb.ts
+++ b/packages/spor-react/src/theme/slot-recipes/breadcrumb.ts
@@ -33,7 +33,7 @@ export const breadcrumbSlotRecipe = defineSlotRecipe({
           _hover: {
             ...coreBorder("default"),
             _active: {
-              ...coreBackground("active"),
+              backgroundColor: "core.surface.active",
               outline: "none",
             },
           },

--- a/packages/spor-react/src/theme/slot-recipes/pagination.ts
+++ b/packages/spor-react/src/theme/slot-recipes/pagination.ts
@@ -29,7 +29,7 @@ export const paginationSlotRecipe = defineSlotRecipe({
       _selected: {
         cursor: "default",
         fontWeight: "bold",
-        ...coreBackground("active"),
+        backgroundColor: "core.surface.active",
       },
     },
     list: {

--- a/packages/spor-react/src/theme/slot-recipes/radio-card.ts
+++ b/packages/spor-react/src/theme/slot-recipes/radio-card.ts
@@ -44,7 +44,7 @@ export const radioCardSlotRecipe = defineSlotRecipe({
             outline: "2px solid",
             outlineColor: "core.outline.hover",
             _active: {
-              ...coreBackground("active"),
+              backgroundColor: "core.surface.active",
               ...coreBorder("active"),
             },
           },
@@ -56,10 +56,10 @@ export const radioCardSlotRecipe = defineSlotRecipe({
             _hover: {
               outline: "2px solid",
               outlineColor: "core.outline.hover",
-              ...coreBackground("active"),
+              backgroundColor: "core.surface.active",
             },
             _active: {
-              ...coreBackground("active"),
+              backgroundColor: "core.surface.active",
               ...coreBorder("active"),
             },
             _focusVisible: {

--- a/packages/spor-react/src/theme/utils/input-utils.ts
+++ b/packages/spor-react/src/theme/utils/input-utils.ts
@@ -14,7 +14,7 @@ export function inputVariant(state: InputState) {
           ...coreBorder("hover"),
         },
         _active: {
-          ...coreBackground("active"),
+          backgroundColor: "core.surface.active",
           ...coreBorder("default"),
         },
         _selected: {
@@ -34,11 +34,11 @@ export function inputVariant(state: InputState) {
         },
         _active: {
           ...floatingBorder("active"),
-          ...floatingBackground("active"),
+          backgroundColor: "core.surface.active",
         },
         _selected: {
-          ...floatingBorder("selected"),
-          ...floatingBackground("selected"),
+          backgroundColor: "floating.surface.selected",
+          borderColor: "floating.border.selected",
         },
       };
     case "default":
@@ -50,7 +50,7 @@ export function inputVariant(state: InputState) {
           ...coreBorder("hover"),
         },
         _active: {
-          ...coreBackground("active"),
+          backgroundColor: "core.surface.active",
           ...coreBorder("default"),
         },
         _selected: {


### PR DESCRIPTION
## Background

...coreBackground("active") gave the wrong color and affected many components
## Solution

Changed to backgroundColor: "core.surface.active",

## Chakra update checklist

- [ ] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [ ] Updated documentation in the component file
- [ ] Update green-beans-check.md with any major changes
- [ ] Add changeset
- [ ] Double check design in Figma

## UU checks

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

