### PR TITLE
Fix for bold in ghost and padding

### DIFF
--- a/.changeset/eight-dingos-sit.md
+++ b/.changeset/eight-dingos-sit.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": major
+---
+
+useDisclosure hooks has changed prop from isOpen to open

--- a/packages/spor-react/src/theme/slot-recipes/card-select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/card-select.ts
@@ -24,7 +24,7 @@ export const cardSelectSlotRecipe = defineSlotRecipe({
     card: {
       borderRadius: "sm",
       boxShadow: "md",
-      padding: 3,
+      padding: 2,
       color: "core.text",
       backgroundColor: "surface",
     },
@@ -48,6 +48,7 @@ export const cardSelectSlotRecipe = defineSlotRecipe({
         trigger: {
           backgroundColor: "transparent",
           outline: "none",
+          fontWeight: "bold",
           color: "ghost.text",
           _hover: {
             backgroundColor: "ghost.surface.hover",


### PR DESCRIPTION
## Background

Minor fix for a missing bold text in label of ghost variant and correct padding for the card

## Solution

Made the changes on the style recipe, the missing function onClose of button is changed on sanity documentation

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [x] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [ ] Updated documentation in the component file
- [ ] Update green-beans-check.md with any major changes
- [ ] Add changeset
- [x] Double check design in Figma

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Desribe how code reviewer may test your solution (what page, expected result).

run application locally and check http://localhost:3000/components/card-select
