### PR TITLE
Update fix drawer close

### DIFF
--- a/packages/spor-react/src/theme/slot-recipes/drawer.ts
+++ b/packages/spor-react/src/theme/slot-recipes/drawer.ts
@@ -53,6 +53,9 @@ export const drawerSlotRecipe = defineSlotRecipe({
       },
     },
     header: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
       paddingX: "5",
       paddingBottom: "1",
     },


### PR DESCRIPTION
## Background

close button of drawer was not styled with title

## Solution

add fixing in code to make the button work with title of header drawer

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [ ] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [ ] Updated documentation in the component file
- [ ] Update green-beans-check.md with any major changes
- [ ] Add changeset
- [ ] Double check design in Figma

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

run application locally and check http://localhost:3000/components/drawer


