### PR TITLE
Fix icon library and illustration library route

### DIFF
--- a/apps/docs/app/routes/_base.resources.icon-library/SearchBar.tsx
+++ b/apps/docs/app/routes/_base.resources.icon-library/SearchBar.tsx
@@ -1,3 +1,4 @@
+import { Flex, Input, NativeSelect } from "@vygruppen/spor-react";
 import { useSearchFilter } from "./SearchFilterContext";
 
 /**
@@ -7,41 +8,35 @@ export function SearchBar() {
   const { searchFilter, setSearchString, setSize, setVariant } =
     useSearchFilter();
 
-  return null; // Todo: fix this searchBar
+  return (
+    <Flex as="form" gap={2}>
+      <Input
+        label="Look up icon"
+        onChange={(e) => {
+          setSearchString((e.target as HTMLInputElement).value);
+        }}
+        value={searchFilter.searchString}
+      />
 
-  // return (
-  //   <Flex as="form" gap={2}>
-  //     <Input
-  //       label="Look up icon"
-  //       onChange={(e) => {
-  //         setSearchString(e.target.value);
-  //       }}
-  //       value={searchFilter.searchString}
-  //     />
+      <NativeSelect
+        label="Size"
+        onChange={(e) => setSize((e.target as HTMLSelectElement).value)}
+        value={searchFilter.size}
+      >
+        <option value="18">18 x 18px</option>
+        <option value="24">24 x 24px</option>
+        <option value="30">30 x 30px</option>
+      </NativeSelect>
 
-  //     <NativeSelect>
-  //       <NativeSelectField
-  //         placeholder="Size"
-  //         onChange={(e) => setSize(e.target.value)}
-  //         value={searchFilter.size}
-  //       >
-  //         <option value="18">18 x 18px</option>
-  //         <option value="24">24 x 24px</option>
-  //         <option value="30">30 x 30px</option>
-  //       </NativeSelectField>
-  //     </NativeSelect>
-
-  //     <NativeSelect>
-  //       <NativeSelectField
-  //         placeholder="Variant"
-  //         value={searchFilter.variant}
-  //         onChange={(e) => setVariant(e.target.value)}
-  //       >
-  //         <option value="">All</option>
-  //         <option value="outline">Outline</option>
-  //         <option value="fill">Fill</option>
-  //       </NativeSelectField>
-  //     </NativeSelect>
-  //   </Flex>
-  // );
+      <NativeSelect
+        label="Variant"
+        value={searchFilter.variant}
+        onChange={(e) => setVariant((e.target as HTMLSelectElement).value)}
+      >
+        <option value="">All</option>
+        <option value="outline">Outline</option>
+        <option value="fill">Fill</option>
+      </NativeSelect>
+    </Flex>
+  );
 }

--- a/apps/docs/app/routes/_base.resources.icon-library/SearchResults.tsx
+++ b/apps/docs/app/routes/_base.resources.icon-library/SearchResults.tsx
@@ -6,27 +6,27 @@ import {
 } from "@vygruppen/spor-icon-react";
 import {
   Box,
-  StaticCard,
   Flex,
   Heading,
   IconButton,
   SimpleGrid,
   Stack,
+  StaticCard,
   Text,
   useColorModeValue,
 } from "@vygruppen/spor-react";
-import { memo, ReactNode, useMemo } from "react";
+import { memo, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { LinkableHeading } from "~/features/portable-text/LinkableHeading";
 import { toTitleCase } from "~/utils/stringUtils";
 import { NotFoundIllustration } from "../../features/illustrations/NotFoundIllustration";
 import { SearchFilter, useSearchFilter } from "./SearchFilterContext";
 import {
+  getIconByImportName,
   IconMetadata,
   IconsByCategory,
-  getIconByImportName,
   iconsByCategory,
 } from "./iconsData";
-import { useNavigate } from "react-router-dom";
 
 /**
  * Shows the current search results
@@ -184,11 +184,8 @@ function IconBox({ icon }: IconBoxProps) {
       <Flex justifyContent="flex-end" width="100%">
         <IconButton
           as="a"
-          onClick={() =>
-            navigate(
-              `/resources/icon-library/${icon.category}/${icon.fileName}`,
-            )
-          }
+          download={icon.fileName}
+          href={`/resources/icon-library/${icon.category}/${icon.fileName}`}
           variant="ghost"
           icon={<DownloadOutline18Icon />}
           size="sm"

--- a/apps/docs/app/routes/_base.resources.icon-library/route.tsx
+++ b/apps/docs/app/routes/_base.resources.icon-library/route.tsx
@@ -1,18 +1,15 @@
 import { DownloadOutline24Icon } from "@vygruppen/spor-icon-react";
-import { Button, Heading, Separator, Stack, Text } from "@vygruppen/spor-react";
+import {
+  Box,
+  Button,
+  Heading,
+  Separator,
+  Stack,
+  Text,
+} from "@vygruppen/spor-react";
 import { SearchBar } from "./SearchBar";
 import { SearchFilterProvider } from "./SearchFilterContext";
 import { SearchResults } from "./SearchResults";
-
-const downloadAllIcons = async () => {
-  const response = await fetch("/resources/icon-library/all-icons.zip");
-  const blob = await response.blob();
-  const url = window.URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = "/resources/icon-library/all-icons.zip";
-  a.click();
-};
 
 export default function IconsPage() {
   return (
@@ -26,17 +23,19 @@ export default function IconsPage() {
         identify and differentiate between different content so that they create
         value for the user.
       </Text>
-      <Button
-        variant="primary"
-        size="md"
-        leftIcon={<DownloadOutline24Icon />}
-        onClick={() => downloadAllIcons()}
-      >
-        Download all icons
-      </Button>
-
+      <Box maxWidth={["100%", null, null, "50%"]} marginX="auto">
+        <Button
+          variant="primary"
+          as="a"
+          size="md"
+          leftIcon={<DownloadOutline24Icon />}
+          download="all-icons.zip"
+          href="/resources/icon-library/all-icons.zip"
+        >
+          Download all icons
+        </Button>
+      </Box>
       <Separator />
-
       <SearchFilterProvider>
         <SearchBar />
         <SearchResults />

--- a/apps/docs/app/routes/_base.resources.icon-library/route.tsx
+++ b/apps/docs/app/routes/_base.resources.icon-library/route.tsx
@@ -1,13 +1,5 @@
-import { Link } from "@remix-run/react";
 import { DownloadOutline24Icon } from "@vygruppen/spor-icon-react";
-import {
-  Button,
-  ButtonGroup,
-  Heading,
-  Separator,
-  Stack,
-  Text,
-} from "@vygruppen/spor-react";
+import { Button, Heading, Separator, Stack, Text } from "@vygruppen/spor-react";
 import { SearchBar } from "./SearchBar";
 import { SearchFilterProvider } from "./SearchFilterContext";
 import { SearchResults } from "./SearchResults";
@@ -24,17 +16,18 @@ export default function IconsPage() {
         identify and differentiate between different content so that they create
         value for the user.
       </Text>
-      <ButtonGroup>
+      <a href="/resources/icon-library/all-icons.zip" download>
         <Button
-          asChild
           variant="primary"
           size="md"
           leftIcon={<DownloadOutline24Icon />}
         >
-          <Link to="all-icons.zip">Download all icons</Link>
+          Download all icons
         </Button>
-      </ButtonGroup>
+      </a>
+
       <Separator />
+
       <SearchFilterProvider>
         <SearchBar />
         <SearchResults />

--- a/apps/docs/app/routes/_base.resources.icon-library/route.tsx
+++ b/apps/docs/app/routes/_base.resources.icon-library/route.tsx
@@ -4,6 +4,16 @@ import { SearchBar } from "./SearchBar";
 import { SearchFilterProvider } from "./SearchFilterContext";
 import { SearchResults } from "./SearchResults";
 
+const downloadAllIcons = async () => {
+  const response = await fetch("/resources/icon-library/all-icons.zip");
+  const blob = await response.blob();
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "/resources/icon-library/all-icons.zip";
+  a.click();
+};
+
 export default function IconsPage() {
   return (
     <Stack gap={4}>
@@ -16,15 +26,14 @@ export default function IconsPage() {
         identify and differentiate between different content so that they create
         value for the user.
       </Text>
-      <a href="/resources/icon-library/all-icons.zip" download>
-        <Button
-          variant="primary"
-          size="md"
-          leftIcon={<DownloadOutline24Icon />}
-        >
-          Download all icons
-        </Button>
-      </a>
+      <Button
+        variant="primary"
+        size="md"
+        leftIcon={<DownloadOutline24Icon />}
+        onClick={() => downloadAllIcons()}
+      >
+        Download all icons
+      </Button>
 
       <Separator />
 

--- a/apps/docs/app/routes/_base.resources.illustration-library/route.tsx
+++ b/apps/docs/app/routes/_base.resources.illustration-library/route.tsx
@@ -15,8 +15,11 @@ import {
   IconButton,
   Image,
   NativeSelect,
-  NudgeWizardStep,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   SearchInput,
+  Separator,
   SimpleGrid,
   slugify,
   StaticCard,
@@ -27,6 +30,7 @@ import { useMemo, useState } from "react";
 import { PortableText } from "~/features/portable-text/PortableText";
 import { useBrand } from "~/utils/brand";
 import { getClient } from "~/utils/sanity/client";
+import { urlBuilder } from "~/utils/sanity/utils";
 
 type SanityResponse = {
   illustrations: {
@@ -122,6 +126,11 @@ export default function IllustrationLibraryPage() {
           <PortableText value={article.introduction} />
         </Box>
       )}
+      {article.content && (
+        <Box marginBottom={4}>
+          <PortableText value={article.content} />
+        </Box>
+      )}
       <Button
         variant="primary"
         size="lg"
@@ -133,6 +142,7 @@ export default function IllustrationLibraryPage() {
       >
         Download all illustrations
       </Button>
+      <Separator marginY={4} />
       <Flex marginBottom={5} gap={2}>
         <Box flex={1}>
           <SearchInput
@@ -164,40 +174,38 @@ export default function IllustrationLibraryPage() {
             padding={2}
             border="1px solid"
             borderColor="silver"
+            position={"relative"}
           >
             <Flex flexDirection="column" height="100%">
-              <Flex gap={1} alignItems="center">
+              <Flex gap={1} alignItems="center" flexDirection={"column"}>
                 <Text variant="sm">{illustration.title}</Text>
-                <NudgeWizardStep content={illustration.description}>
-                  <InformationOutline18Icon aria-label="Informasjon" />
-                </NudgeWizardStep>
+                <Popover>
+                  <PopoverTrigger>
+                    <InformationOutline18Icon aria-label="Informasjon" />
+                  </PopoverTrigger>
+                  <PopoverContent>{illustration.description}</PopoverContent>
+                </Popover>
                 <Image
                   src={
                     colorMode === "light"
-                      ? illustration.imageLightBackground.url
-                      : illustration.imageDarkBackground.url
+                      ? urlBuilder
+                          .image(illustration.imageLightBackground)
+                          .url() || ""
+                      : urlBuilder
+                          .image(illustration.imageDarkBackground)
+                          .url() || ""
                   }
                   alt={illustration.description}
                   width="100%"
-                  objectFit="contain"
-                  objectPosition="center"
-                  flex={1}
-                />
-                <Image
-                  src={
-                    colorMode === "light"
-                      ? illustration.imageLightBackground
-                      : illustration.imageDarkBackground
-                  }
-                  alt={illustration.description}
-                  width="100%"
+                  minHeight={12}
+                  maxHeight={15}
                   objectFit="contain"
                   objectPosition="center"
                   flex={1}
                 />
               </Flex>
             </Flex>
-            <Flex justifyContent="flex-end">
+            <Box position={"absolute"} bottom="0" right="0">
               <IconButton
                 variant="ghost"
                 size="sm"
@@ -212,17 +220,10 @@ export default function IllustrationLibraryPage() {
                 aria-label="Download SVG"
                 title="Download SVG"
               />
-            </Flex>
+            </Box>
           </StaticCard>
         ))}
       </SimpleGrid>
-      {/* 
-      
-    
-              
-              
-              
-          */}
     </Box>
   );
 }

--- a/apps/docs/app/routes/_base.resources.illustration-library/route.tsx
+++ b/apps/docs/app/routes/_base.resources.illustration-library/route.tsx
@@ -1,4 +1,3 @@
-import { data } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { SanityAsset } from "@sanity/image-url/lib/types/types";
 import {
@@ -16,8 +15,10 @@ import {
   IconButton,
   Image,
   NativeSelect,
+  NudgeWizardStep,
   SearchInput,
   SimpleGrid,
+  slugify,
   StaticCard,
   Text,
   useColorMode,
@@ -26,8 +27,6 @@ import { useMemo, useState } from "react";
 import { PortableText } from "~/features/portable-text/PortableText";
 import { useBrand } from "~/utils/brand";
 import { getClient } from "~/utils/sanity/client";
-import { urlBuilder } from "~/utils/sanity/utils";
-import { slugify } from "~/utils/stringUtils";
 
 type SanityResponse = {
   illustrations: {
@@ -87,11 +86,11 @@ export const loader = async () => {
   const { illustrations, article } = (await client.fetch(
     query,
   )) as SanityResponse;
-  return data({ illustrations, article });
+  return { illustrations, article };
 };
 
 export default function IllustrationLibraryPage() {
-  const { illustrations, article } = useLoaderData<typeof loader>().data;
+  const { illustrations, article } = useLoaderData<typeof loader>();
   const [searchValue, setSearchValue] = useState("");
   const { colorMode } = useColorMode();
   const [size, setSize] = useState("all");
@@ -108,121 +107,122 @@ export default function IllustrationLibraryPage() {
       );
   }, [illustrations, searchValue, size]);
 
-  return null; // Todo: fix this page
-
-  // return (
-  //   <Box>
-  //     <Badge
-  //       colorScheme={brand === Brand.CargoNet ? "light-yellow" : "light-green"}
-  //     >
-  //       {article.category?.title}
-  //     </Badge>
-  //     <Heading as="h1" size="2xl" marginBottom={1}>
-  //       {article.title}
-  //     </Heading>
-  //     {article.introduction && (
-  //       <Box marginBottom={2}>
-  //         <PortableText value={article.introduction} />
-  //       </Box>
-  //     )}
-  //     <Box marginBottom={4}>
-  //       <PortableText value={article.content} />
-  //     </Box>
-  //     <Button
-  //       variant="primary"
-  //       size="lg"
-  //       width="fit-content"
-  //       as="a"
-  //       download="illustrations.zip"
-  //       href="/resources/illustration-library/all"
-  //       leftIcon={<DownloadOutline24Icon />}
-  //     >
-  //       Download all illustrations
-  //     </Button>
-  //     <Divider marginY={3} />
-  //     <Flex marginBottom={5} gap={2}>
-  //       <Box flex={1}>
-  //         <SearchInput
-  //           label="Find illustration"
-  //           value={searchValue}
-  //           onChange={(e: any) => setSearchValue(e.target.value)}
-  //           width="100%"
-  //         />
-  //       </Box>
-  //       <Box>
-  //         <NativeSelect
-  //           label="Size"
-  //           value={size}
-  //           onChange={(e: any) => setSize(e.target.value)}
-  //           width="fit-content"
-  //         >
-  //           <option value="all">All</option>
-  //           <option value="small">Small</option>
-  //           <option value="medium">Medium</option>
-  //           <option value="large">Large</option>
-  //         </NativeSelect>
-  //       </Box>
-  //     </Flex>
-  //     <SimpleGrid columns={[1, 2, 3]} gap={2}>
-  //       {matchingIllustrations.map((illustration) => (
-  //         <StaticCard
-  //           colorScheme="white"
-  //           key={illustration._id}
-  //           padding={2}
-  //           border="1px solid"
-  //           borderColor="silver"
-  //         >
-  //           <Flex flexDirection="column" height="100%">
-  //             <Flex gap={1} alignItems="center">
-  //               <Text variant="sm">{illustration.title}</Text>
-  //               <Tooltip
-  //                 placement="top"
-  //                 arrowPadding={2}
-  //                 content={illustration.description}
-  //               >
-  //                 <InformationOutline18Icon aria-label="Informasjon" />
-  //               </Tooltip>
-  //             </Flex>
-  //             <Image
-  //               src={
-  //                 urlBuilder
-  //                   .image(
-  //                     colorMode === "light"
-  //                       ? illustration.imageLightBackground
-  //                       : illustration.imageDarkBackground,
-  //                   )
-  //                   .url() || ""
-  //               }
-  //               alt={illustration.description}
-  //               width="100%"
-  //               maxHeight="10rem"
-  //               objectFit="contain"
-  //               objectPosition="center"
-  //               flex={1}
-  //             />
-  //             <Flex justifyContent="flex-end">
-  //               <IconButton
-  //                 variant="ghost"
-  //                 size="sm"
-  //                 icon={<DownloadOutline18Icon />}
-  //                 as="a"
-  //                 download={`${slugify(illustration.title)}.svg`}
-  //                 href={urlBuilder
-  //                   .image(
-  //                     colorMode === "light"
-  //                       ? illustration.imageLightBackground
-  //                       : illustration.imageDarkBackground,
-  //                   )
-  //                   .forceDownload(`${slugify(illustration.title)}.svg`)
-  //                   .url()}
-  //                 aria-label="Download SVG"
-  //                 title="Download SVG"
-  //               />
-  //             </Flex>
-  //           </Flex>
-  //         </StaticCard>
-  //       ))}
-  //     </SimpleGrid>
-  //   </Box>
-  // );
+  return (
+    <Box>
+      <Badge
+        colorScheme={brand === Brand.CargoNet ? "light-yellow" : "light-green"}
+      >
+        {article.category?.title}
+      </Badge>
+      <Heading as="h1" variant="2xl" marginBottom={1}>
+        {article.title}
+      </Heading>
+      {article.introduction && (
+        <Box marginBottom={2}>
+          <PortableText value={article.introduction} />
+        </Box>
+      )}
+      <Button
+        variant="primary"
+        size="lg"
+        width="fit-content"
+        as="a"
+        download="illustrations.zip"
+        href="/resources/illustration-library/all"
+        leftIcon={<DownloadOutline24Icon />}
+      >
+        Download all illustrations
+      </Button>
+      <Flex marginBottom={5} gap={2}>
+        <Box flex={1}>
+          <SearchInput
+            label="Find illustration"
+            value={searchValue}
+            onChange={(e: any) => setSearchValue(e.target.value)}
+            width="100%"
+          />
+        </Box>
+        <Box>
+          <NativeSelect
+            label="Size"
+            value={size}
+            onChange={(e: any) => setSize(e.target.value)}
+            width="fit-content"
+          >
+            <option value="all">All</option>
+            <option value="small">Small</option>
+            <option value="medium">Medium</option>
+            <option value="large">Large</option>
+          </NativeSelect>
+        </Box>
+      </Flex>
+      <SimpleGrid columns={[1, 2, 3]} gap={2}>
+        {matchingIllustrations.map((illustration) => (
+          <StaticCard
+            colorScheme="white"
+            key={illustration._id}
+            padding={2}
+            border="1px solid"
+            borderColor="silver"
+          >
+            <Flex flexDirection="column" height="100%">
+              <Flex gap={1} alignItems="center">
+                <Text variant="sm">{illustration.title}</Text>
+                <NudgeWizardStep content={illustration.description}>
+                  <InformationOutline18Icon aria-label="Informasjon" />
+                </NudgeWizardStep>
+                <Image
+                  src={
+                    colorMode === "light"
+                      ? illustration.imageLightBackground.url
+                      : illustration.imageDarkBackground.url
+                  }
+                  alt={illustration.description}
+                  width="100%"
+                  objectFit="contain"
+                  objectPosition="center"
+                  flex={1}
+                />
+                <Image
+                  src={
+                    colorMode === "light"
+                      ? illustration.imageLightBackground
+                      : illustration.imageDarkBackground
+                  }
+                  alt={illustration.description}
+                  width="100%"
+                  objectFit="contain"
+                  objectPosition="center"
+                  flex={1}
+                />
+              </Flex>
+            </Flex>
+            <Flex justifyContent="flex-end">
+              <IconButton
+                variant="ghost"
+                size="sm"
+                icon={<DownloadOutline18Icon />}
+                as="a"
+                download={`${slugify(illustration.title)}.svg`}
+                href={
+                  colorMode === "light"
+                    ? illustration.imageLightBackground
+                    : illustration.imageDarkBackground
+                }
+                aria-label="Download SVG"
+                title="Download SVG"
+              />
+            </Flex>
+          </StaticCard>
+        ))}
+      </SimpleGrid>
+      {/* 
+      
+    
+              
+              
+              
+          */}
+    </Box>
+  );
 }

--- a/apps/docs/app/routes/_base.resources.illustration-library/route.tsx
+++ b/apps/docs/app/routes/_base.resources.illustration-library/route.tsx
@@ -214,8 +214,14 @@ export default function IllustrationLibraryPage() {
                 download={`${slugify(illustration.title)}.svg`}
                 href={
                   colorMode === "light"
-                    ? illustration.imageLightBackground
-                    : illustration.imageDarkBackground
+                    ? urlBuilder
+                        .image(illustration.imageLightBackground)
+                        .forceDownload(`${slugify(illustration.title)}.svg`)
+                        .url()
+                    : urlBuilder
+                        .image(illustration.imageDarkBackground)
+                        .forceDownload(`${slugify(illustration.title)}.svg`)
+                        .url()
                 }
                 aria-label="Download SVG"
                 title="Download SVG"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -23,6 +23,7 @@
     "@sanity/image-url": "^1.0.2",
     "@vygruppen/spor-design-tokens": "workspace:*",
     "@vygruppen/spor-react": "workspace:*",
+    "@vygruppen/spor-icon": "workspace:*",
     "@vygruppen/spor-icon-react": "workspace:*",
     "archiver": "^5.3.2",
     "deepmerge": "^4.3.1",

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -1,9 +1,9 @@
 import {
   Box,
   Center,
-  type ButtonProps as ChakraButtonProps,
   Button as ChakraButton,
   Flex,
+  type ButtonProps as ChakraButtonProps,
   type RecipeVariantProps,
 } from "@chakra-ui/react";
 import React, { forwardRef, PropsWithChildren } from "react";
@@ -30,6 +30,10 @@ export type ButtonProps = Exclude<
     variant: "primary" | "secondary" | "tertiary" | "ghost" | "floating";
     /* "lg" | "md" | "sm" | "xs". Defaults to md. */
     size?: "lg" | "md" | "sm" | "xs";
+    /* Link to a downloadable resource. */
+    download?: string;
+    /* Use this to specify a path combined with as="a" */
+    href?: string;
   };
 /**
  * Buttons are used to trigger actions.

--- a/packages/spor-react/src/button/IconButton.tsx
+++ b/packages/spor-react/src/button/IconButton.tsx
@@ -17,6 +17,8 @@ export type IconButtonProps = Exclude<
     spinner?: React.JSX.Element;
     icon?: React.JSX.Element;
     loading?: boolean;
+    download?: string;
+    href?: string;
   };
 
 /**

--- a/packages/spor-react/src/input/NativeSelect.tsx
+++ b/packages/spor-react/src/input/NativeSelect.tsx
@@ -4,9 +4,9 @@ import {
   NativeSelect as Select,
   useSlotRecipe,
 } from "@chakra-ui/react";
+import { DropdownDownFill18Icon } from "@vygruppen/spor-icon-react";
 import * as React from "react";
 import { nativeSelectSlotRecipe } from "../theme/slot-recipes/native-select";
-import { DropdownDownFill18Icon } from "@vygruppen/spor-icon-react";
 import { Field } from "./Field";
 
 type NativeSelectVariantProps = RecipeVariantProps<
@@ -19,6 +19,8 @@ type NativeSelectRootProps = Exclude<
 > &
   React.PropsWithChildren<NativeSelectVariantProps> & {
     icon?: React.ReactNode;
+    label: string;
+    value?: string;
   };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@vygruppen/spor-design-tokens':
         specifier: workspace:*
         version: link:../../packages/spor-design-tokens
+      '@vygruppen/spor-icon':
+        specifier: workspace:*
+        version: link:../../packages/spor-icon
       '@vygruppen/spor-icon-react':
         specifier: workspace:*
         version: link:../../packages/spor-icon-react


### PR DESCRIPTION
## Background

The route for download the icon library does not work properly

## Solution

Fix necessary components and enable the download

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [x] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [ ] Updated documentation in the component file
- [ ] Update green-beans-check.md with any major changes
- [ ] Add changeset
- [ ] Double check design in Figma

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

run application locally and check http://localhost:3000/resources/icon-library


