### PR TITLE
Add missing spor-icon package

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,6 +24,7 @@
     "@sanity/image-url": "^1.0.2",
     "@vygruppen/spor-design-tokens": "workspace:*",
     "@vygruppen/spor-react": "workspace:*",
+    "@vygruppen/spor-icon": "workspace:*",
     "@vygruppen/spor-icon-react": "workspace:*",
     "archiver": "^5.3.2",
     "deepmerge": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@vygruppen/spor-design-tokens':
         specifier: workspace:*
         version: link:../../packages/spor-design-tokens
+      '@vygruppen/spor-icon':
+        specifier: workspace:*
+        version: link:../../packages/spor-icon
       '@vygruppen/spor-icon-react':
         specifier: workspace:*
         version: link:../../packages/spor-icon-react


### PR DESCRIPTION
## Background

We missed spor-icon package for the docs remix app, this lead to a fail when user tried to download icons or all icons zip

## Solution

add missin library


