### PR TITLE
Add a test page

### DIFF
--- a/apps/docs/app/routes/_index/ActionLinks.tsx
+++ b/apps/docs/app/routes/_index/ActionLinks.tsx
@@ -6,6 +6,7 @@ import {
   TokensOutline30Icon,
   TrainOutline30Icon,
   StarsOutline30Icon,
+  RobotOutline30Icon,
 } from "@vygruppen/spor-icon-react";
 import {
   Box,
@@ -72,6 +73,13 @@ const links: LinkItem[] = [
     description: "Try out Spor components live in our playground",
     icon: TrainOutline30Icon,
     iconColor: "silver",
+  },
+  {
+    to: "/testing",
+    title: "Testing",
+    description: "Use this side to test CLS",
+    icon: RobotOutline30Icon,
+    iconColor: "seaMist",
   },
 ];
 

--- a/apps/docs/app/routes/testing/route.tsx
+++ b/apps/docs/app/routes/testing/route.tsx
@@ -1,0 +1,36 @@
+import { Heading } from "@chakra-ui/react";
+import { logDevReady } from "@remix-run/node";
+import { Expandable, Input, Stack, Text } from "@vygruppen/spor-react";
+
+const defaultCode = `<Stack textAlign="center">
+  <Heading>Welcome to the playground</Heading>
+  <Text>Here, you can test out Spor in your browser</Text>
+  <Text>
+    All components are exposed as global variables, 
+    so you don't need to download anything.
+  </Text>
+</Stack>`;
+
+export default function TestingPage() {
+  return (
+    <>
+      <Stack textAlign="center" marginTop={"8"}>
+        <Heading fontSize={"lg"}>Hello testers</Heading>
+        <Text>
+          Here, you can test out the components to check if there are any
+          problems with CLS
+        </Text>
+
+        <Stack marginInline={"30rem"}>
+          <Expandable title="Read more about the summer disruption">
+            <Text>
+              The summer disruption is when BaneNOR closes significant portions
+              of the railway network during periods throughout the summer to
+              carry out necessary improvements.
+            </Text>
+          </Expandable>
+        </Stack>
+      </Stack>
+    </>
+  );
+}


### PR DESCRIPTION
## Background

Needed a page to test hydration on components

## Solution

Added a temporary page that can be used during testing
**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [ ] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [ ] Updated documentation in the component file
- [ ] Update green-beans-check.md with any major changes
- [ ] Add changeset
- [ ] Double check design in Figma

## UU checks

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Desribe how code reviewer may test your solution (what page, expected result).

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
