### PR TITLE
Fix outline width for button in primary and tertiary

### DIFF
--- a/.changeset/brown-buckets-hug.md
+++ b/.changeset/brown-buckets-hug.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Button: fix outline width to align with design

--- a/packages/spor-react/src/theme/recipes/button.ts
+++ b/packages/spor-react/src/theme/recipes/button.ts
@@ -1,6 +1,6 @@
 import { defineRecipe } from "@chakra-ui/react";
-import { focusVisibleStyles } from "../utils/focus-utils";
 import tokens from "@vygruppen/spor-design-tokens";
+import { focusVisibleStyles } from "../utils/focus-utils";
 
 export const buttonRecipe = defineRecipe({
   className: "spor-button",
@@ -24,6 +24,9 @@ export const buttonRecipe = defineRecipe({
       boxShadow: "none",
       color: "text.disabled",
       background: "surface.disabled",
+    },
+    _focus: {
+      outlineOffset: tokens.size.stroke.md,
     },
   },
   variants: {
@@ -61,6 +64,13 @@ export const buttonRecipe = defineRecipe({
             outlineWidth: tokens.size.stroke.sm,
             outlineColor: "core.outline",
           },
+        },
+        _focus: {
+          outlineWidth: tokens.size.stroke.sm,
+          borderWidth: tokens.size.stroke.sm,
+          borderStyle: "solid",
+          borderColor: "core.outline.default",
+          outlineColor: "core.outline.focus",
         },
       },
       ghost: {


### PR DESCRIPTION
## Background

we missed outline stroke width for focus state

## Solution

add styling

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [x] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [x] Updated documentation in the component file
- [x] Update green-beans-check.md with any major changes
- [x] Add changeset
- [x] Double check design in Figma

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)


