### PR TITLE
Fix floating button stroke

### DIFF
--- a/.changeset/tender-balloons-sin.md
+++ b/.changeset/tender-balloons-sin.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Floating Action Button: fix problems with outline stroke

--- a/packages/spor-react/src/theme/slot-recipes/floating-action-button.ts
+++ b/packages/spor-react/src/theme/slot-recipes/floating-action-button.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import { focusVisibleStyles } from "../utils/focus-utils";
+import tokens from "@vygruppen/spor-design-tokens";
 import { floatingActionButtonAnatomy } from "./anatomy";
 
 export const floatingActionButtonSlotRecipe = defineSlotRecipe({
@@ -21,7 +21,10 @@ export const floatingActionButtonSlotRecipe = defineSlotRecipe({
       transitionProperty: "common",
       position: "fixed",
       zIndex: "dropdown",
-      ...focusVisibleStyles(),
+      _focus: {
+        outlineOffset: tokens.size.stroke.lg,
+        outlineColor: "outline.focus",
+      },
       _disabled: {
         backgroundColor: "surface.disabled",
         color: "text.disabled",


### PR DESCRIPTION
## Background

Stoke outilne problem with the FloatinActionButton

## Solution

Add necessary style

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [x] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [x] Updated documentation in the component file
- [x] Update green-beans-check.md with any major changes
- [x] Add changeset
- [x] Double check design in Figma

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)
