### PR TITLE
Fix linetag

### DIFF
--- a/.changeset/eight-ads-flash.md
+++ b/.changeset/eight-ads-flash.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": major
+---
+
+Line Icon: added label prop to enable aria-label for voice-over

--- a/packages/spor-react/src/linjetag/LineIcon.tsx
+++ b/packages/spor-react/src/linjetag/LineIcon.tsx
@@ -28,7 +28,7 @@ export type LineIconProps = Exclude<BoxProps, "variant"> &
     backgroundColor?: string;
     disabled?: boolean;
     target?: string;
-    label?: string;
+    label: string;
   };
 
 /**

--- a/packages/spor-react/src/linjetag/LineIcon.tsx
+++ b/packages/spor-react/src/linjetag/LineIcon.tsx
@@ -6,9 +6,9 @@ import {
   useSlotRecipe,
 } from "@chakra-ui/react";
 import React, { forwardRef, PropsWithChildren } from "react";
+import { lineIconSlotRecipe } from "../theme/slot-recipes/line-icon";
 import { getCorrectIcon } from "./icons";
 import { CustomVariantProps, TagProps } from "./types";
-import { lineIconSlotRecipe } from "../theme/slot-recipes/line-icon";
 
 type LineIconVariantProps = RecipeVariantProps<typeof lineIconSlotRecipe>;
 
@@ -28,6 +28,7 @@ export type LineIconProps = Exclude<BoxProps, "variant"> &
     backgroundColor?: string;
     disabled?: boolean;
     target?: string;
+    label?: string;
   };
 
 /**
@@ -69,6 +70,7 @@ export const LineIcon = forwardRef<HTMLDivElement, LineIconProps>(
     disabled,
     style,
     target = "lineIcon",
+    label,
     ...rest
   }) {
     const recipe = useSlotRecipe({ key: "lineIcon" });
@@ -107,6 +109,7 @@ export const LineIcon = forwardRef<HTMLDivElement, LineIconProps>(
         padding={targetPadding()}
         borderWidth={borderContainer()}
         borderColor={variant === "walk" ? "core.outline" : "transparent"}
+        aria-label={label}
       >
         <Icon css={styles.icon} />
       </Box>


### PR DESCRIPTION
## Background

LineIcon missed aria-label and since it communicate significant information it is important to give this information to VO

## Solution

Add a required label prop to compoennt

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [x] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [x] Updated documentation in the component file
- [x] Update green-beans-check.md with any major changes
- [x] Add changeset
- [x] Double check design in Figma

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

run application locally and check http://localhost:3000
