### PR TITLE
Fix scroll size for mobile version

### DIFF
--- a/packages/spor-react/src/theme/slot-recipes/drawer.ts
+++ b/packages/spor-react/src/theme/slot-recipes/drawer.ts
@@ -43,6 +43,7 @@ export const drawerSlotRecipe = defineSlotRecipe({
       maxHeight: "100dvh",
       color: "inherit",
       boxShadow: "lg",
+      minHeight: ["50vh", null, null, "auto"],
       _open: {
         animationDuration: "slowest",
         animationTimingFunction: "ease-in-smooth",
@@ -65,6 +66,7 @@ export const drawerSlotRecipe = defineSlotRecipe({
       flex: "1",
       overflow: "auto",
       fontSize: ["xs", null, null, "sm"],
+      minHeight: ["12", null, null, "auto"],
     },
     footer: {
       display: "flex",


### PR DESCRIPTION
## Background

When the zoom is up to 400% or we are on mobile and the content are enough long to cause a scroll, the scroll was not visible due to the size of the drawer and the header

## Solution

Check size of screen and responsive adapt the minHeight of both drawer and content body

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [x] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [x] Updated documentation in the component file
- [x] Update green-beans-check.md with any major changes
- [x] Add changeset
- [x] Double check design in Figma

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

run application locally and check http://localhost:3000/components/drawer reduce viewport by zooming to 400%
