### PR TITLE
Update RadioCard to include input value

### DIFF
--- a/.changeset/nervous-pots-wave.md
+++ b/.changeset/nervous-pots-wave.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Update RadioCard to specify input value

--- a/packages/spor-react/src/layout/RadioCard.tsx
+++ b/packages/spor-react/src/layout/RadioCard.tsx
@@ -98,6 +98,7 @@ export const RadioCard = forwardRef(
           type="radio"
           id={inputId}
           name={name}
+          value={value}
           ref={ref}
           checked={isChecked}
           onChange={() => onChange(value)}


### PR DESCRIPTION
## Background

The value attribute isn't specified for the hidden `<input type="radio">` in `<RadioCard>` which results in the inputs defaulting to "on" for the value. This is problematic when trying to send the selected `<RadioCard>` value in a form (especially when using Conform).

## Solution

Updated RadioCard input to include value attribute.

Example of submitted formData when "Buss" is selected (see console log):
| Before | After |
| --- | --- |
| ![Screenshot 2025-04-22 at 12 36 40](https://github.com/user-attachments/assets/9a8196a2-fb37-4c50-bed2-23e157a25beb) | ![Screenshot 2025-04-22 at 12 36 54](https://github.com/user-attachments/assets/1e2babb6-c06e-4104-a4c3-b448ff6d24d7) |

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] ~Sanity documentation has been / will be updated (if neccessary)~
