### PR TITLE
timePicker - fix colors

### DIFF
--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -35,8 +35,8 @@ export const datePickerSlotRecipe = defineSlotRecipe({
     },
     dateTimeSegment: {
       _focus: {
-        backgroundColor: "brand.surface.hover",
-        color: "white",
+        backgroundColor: "ghost.surface.active",
+        color: "text.default",
       },
     },
     box: {


### PR DESCRIPTION
The component used hardcoded colors. Changed to color tokens