### PR TITLE
Fix double colorspinner loader

### DIFF
--- a/packages/spor-react/src/loader/ColorSpinner.tsx
+++ b/packages/spor-react/src/loader/ColorSpinner.tsx
@@ -35,11 +35,6 @@ export const ColorSpinner = ({
           <Lottie animationData={spinnerColorData} />
         </ClientOnly>
       </Box>
-      <Box width={width} maxWidth={maxWidth}>
-        <ClientOnly>
-          <Lottie animationData={spinnerColorData} />
-        </ClientOnly>
-      </Box>
       <VisuallyHidden>Loading...</VisuallyHidden>
       {children && (
         <Box marginTop={3} fontWeight="bold">


### PR DESCRIPTION
## Background

Colorspinner showed twice as loader in iconButton and probably in all places where used

## Solution

Remove double writing of component

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [x] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [x] Updated documentation in the component file
- [x] Update green-beans-check.md with any major changes
- [x] Add changeset
- [x] Double check design in Figma

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

run application locally and check http://localhost:3000/components/icon-button the loader should show once
