### PR TITLE
Add domain handling and version selection to navigation components

### DIFF
--- a/apps/docs/app/root.tsx
+++ b/apps/docs/app/root.tsx
@@ -108,11 +108,14 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     request.headers.get("user-agent") ?? "",
   );
 
+  const domain = request.headers.get("host") ?? "";
+
   return {
     initialSanityData,
     cookies: request.headers.get("cookie") ?? "",
     brand,
     isMac,
+    domain,
   };
 };
 

--- a/apps/docs/app/root/layout/SiteHeader.tsx
+++ b/apps/docs/app/root/layout/SiteHeader.tsx
@@ -2,11 +2,11 @@ import { Link, useLocation, useRouteLoaderData } from "@remix-run/react";
 import {
   HamburgerFill24Icon,
   SearchFill24Icon,
-  SearchOutline24Icon,
 } from "@vygruppen/spor-icon-react";
 import {
   Box,
   Button,
+  CardSelect,
   DarkMode,
   Drawer,
   DrawerBody,
@@ -132,6 +132,7 @@ const DesktopNavigation = ({ onSearchClick }: SearchFieldProps) => {
         justifyContent="flex-end"
         alignItems="center"
       >
+        <ChangeVersion />
         <SiteSettings showLabel={true} />
       </Flex>
     </>
@@ -159,6 +160,7 @@ const MobileNavigation = ({ onSearchClick }: SearchFieldProps) => {
             onClick={onSearchClick}
           />
         </DarkMode>
+        <ChangeVersion />
         <SiteSettings showLabel={false} />
         <DarkMode>
           <IconButton
@@ -183,5 +185,36 @@ const MobileNavigation = ({ onSearchClick }: SearchFieldProps) => {
         </DrawerContent>
       </Drawer>
     </Flex>
+  );
+};
+
+const ChangeVersion = () => {
+  const domain = useRouteLoaderData<typeof loader>("root")?.domain;
+  const isOldVersion = domain?.includes("spor-v1");
+
+  return (
+    <DarkMode>
+      <CardSelect size="md" label="v1" variant="base">
+        <Button
+          variant="ghost"
+          size="md"
+          marginBottom={2}
+          as="a"
+          href="https://spor.vy.no"
+          disabled={!isOldVersion}
+        >
+          Spor V2 - ver.12.xx
+        </Button>
+        <Button
+          variant="ghost"
+          size="md"
+          as="a"
+          href="https://spor-v1.test.vylabs.io/"
+          disabled={isOldVersion}
+        >
+          Spor V1 - ver.11.xx
+        </Button>
+      </CardSelect>
+    </DarkMode>
   );
 };


### PR DESCRIPTION
## Background

The previous version, Spor 11, needed also the chance to navigate to the main version

## Solution

Add the select drop down to choose between the version in documentation

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Run application locally and check http://localhost:3000

## Screenshots
![Skjermbilde 2025-04-28 kl  14 42 21](https://github.com/user-attachments/assets/6ac9b390-d843-4cfb-b101-947fcb675cab)
