### PR TITLE
fix(Icons): Error when rendering with remix 

### DIFF
--- a/.changeset/stupid-snails-call.md
+++ b/.changeset/stupid-snails-call.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react": patch
+---
+
+Fix so all icons are client only

--- a/packages/spor-icon-react/bin/componentTemplate.ts
+++ b/packages/spor-icon-react/bin/componentTemplate.ts
@@ -15,7 +15,7 @@ ${variables.exports};
 export const componentTemplate: Config["template"] = (variables, { tpl }) => {
   return tpl`
 ${variables.imports};
-import { Box } from "@chakra-ui/react";
+import { Box, ClientOnly } from "@chakra-ui/react";
 
 ${variables.interfaces};
 

--- a/packages/spor-icon-react/bin/generate.ts
+++ b/packages/spor-icon-react/bin/generate.ts
@@ -138,8 +138,9 @@ async function generateComponent(iconData: IconData) {
     },
   );
   jsCode = jsCode
-    .replace("<svg", '<Box as="svg" display="block"')
-    .replace("</svg>", "</Box>");
+    .replace("<svg", '<ClientOnly><Box as="svg" display="block"')
+    .replace("</svg>", "</Box></ClientOnly>");
+
   return createComponentFile(iconData, jsCode);
 }
 


### PR DESCRIPTION
## Background

Remix gives
useContext returned `undefined`. Seems you forgot to wrap component within <ChakraProvider />

## Solution

Wrap icons with <ClientOnly>