### PR TITLE
build: Refactored theme setup in `spor-react` for type support and extending theme support + update eslint 

### DIFF
--- a/.changeset/afraid-carrots-smoke.md
+++ b/.changeset/afraid-carrots-smoke.md
@@ -1,0 +1,9 @@
+---
+"@vygruppen/spor-react": minor
+"@vygruppen/spor-design-tokens": patch
+"@vygruppen/eslint-config": patch
+---
+
+- Removed unused `patch-package` from `spor-design-tokens`.
+- Refactored theme setup in `spor-react` for type support and extending theme support.
+- Updated `eslint-config` to better support React 17+ adding jsx runtime rules.

--- a/apps/docs/app/root.tsx
+++ b/apps/docs/app/root.tsx
@@ -18,7 +18,7 @@ import {
   useLoaderData,
   useRouteError,
 } from "@remix-run/react";
-import { Brand, Language, SporProvider } from "@vygruppen/spor-react";
+import { Brand, Language, SporProvider, themes } from "@vygruppen/spor-react";
 import { ReactNode, useContext, useEffect, useRef } from "react";
 
 import { RootLayout } from "./root/layout/RootLayout";
@@ -40,6 +40,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (!data || !data.initialSanityData) {
     return [];
   }
+
   const { title, description, keywords, socialImage } =
     data.initialSanityData.siteSettings;
 
@@ -186,7 +187,10 @@ const Document = withEmotionCache(
           ))}
         </head>
         <body>
-          <SporProvider language={Language.English} brand={brand}>
+          <SporProvider
+            language={Language.English}
+            theme={themes[brand ?? "VyDigital"]}
+          >
             <SkipToContent />
             {children}
           </SporProvider>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "turbo run build",
     "test": "turbo run test --parallel",
     "dev": "turbo run dev typegen:watch",
-    "postinstall": "patch-package",
+    "postinstall": "pnpm typegen",
     "lint": "turbo run lint",
     "prerelease": "pnpm build",
     "release": "turbo run build && changeset publish",
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.27.5",
-    "patch-package": "^8.0.0",
     "prettier": "^3.3.1",
     "react-icons": "^5.4.0",
     "rimraf": "^5.0.7",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "build": "turbo run build",
     "test": "turbo run test --parallel",
     "dev": "turbo run dev typegen:watch",
-    "postinstall": "pnpm typegen",
     "lint": "turbo run lint",
     "prerelease": "pnpm build",
     "release": "turbo run build && changeset publish",

--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -33,6 +33,7 @@ export default defineConfig([
   js.configs.recommended,
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
+  pluginReact.configs.flat["jsx-runtime"],
   reactHooks.configs["recommended-latest"],
   jsxA11y.flatConfigs.recommended,
   eslintConfigPrettier,

--- a/packages/spor-design-tokens/package.json
+++ b/packages/spor-design-tokens/package.json
@@ -38,7 +38,6 @@
     "chokidar-cli": "^3.0.0",
     "eslint": "9.25.1",
     "json-to-ts": "^1.7.0",
-    "patch-package": "^6.4.7",
     "prettier": "^2.4.1",
     "style-dictionary": "^4.3.3",
     "ts-node": "^10.9.2",

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "sideEffects": false,
   "scripts": {
-    "build": "pnpm typegen && tsup",
+    "build": "tsup",
     "dev": "tsup --watch",
     "typegen": "npx @chakra-ui/cli typegen src/theme/index.ts",
     "typegen:watch": "npx @chakra-ui/cli typegen src/theme/index.ts --watch",

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "sideEffects": false,
   "scripts": {
-    "build": "tsup",
+    "build": "pnpm typegen && tsup",
     "dev": "tsup --watch",
     "typegen": "npx @chakra-ui/cli typegen src/theme/index.ts",
     "typegen:watch": "npx @chakra-ui/cli typegen src/theme/index.ts --watch",

--- a/packages/spor-react/src/provider/SporProvider.tsx
+++ b/packages/spor-react/src/provider/SporProvider.tsx
@@ -1,16 +1,20 @@
 "use client";
-import { ChakraProvider, ChakraProviderProps } from "@chakra-ui/react";
+import {
+  ChakraProvider,
+  ChakraProviderProps,
+  SystemContext,
+} from "@chakra-ui/react";
 import { Global } from "@emotion/react";
 import React from "react";
 
-import { Language, LanguageProvider, system, themes } from "..";
+import { Language, LanguageProvider, system } from "..";
 import { ColorModeProvider } from "../color-mode";
-import { Brand, fontFaces } from "../theme/brand";
+import { fontFaces } from "../theme/brand";
 import { Toaster } from "../toast/toast";
 
 type SporProviderProps = Omit<ChakraProviderProps, "value"> & {
   language?: Language;
-  brand?: Brand;
+  theme?: SystemContext;
 };
 
 /**
@@ -52,12 +56,12 @@ import { theme } from '../../../../apps/docs/app/features/portable-text/code-blo
  */
 export const SporProvider = ({
   language = Language.NorwegianBokmal,
-  brand = Brand.VyDigital,
+  theme = system,
   children,
 }: SporProviderProps) => {
   return (
     <LanguageProvider language={language}>
-      <ChakraProvider value={themes[brand] ?? system}>
+      <ChakraProvider value={theme}>
         <ColorModeProvider>
           <Toaster />
           <Global styles={fontFaces} />

--- a/packages/spor-react/src/theme/index.ts
+++ b/packages/spor-react/src/theme/index.ts
@@ -16,6 +16,8 @@ import { globalCss } from "./tokens/global-css";
 import { keyframes } from "./tokens/keyframes";
 import { textStyles } from "./tokens/text-styles";
 
+export { createSystem, defineConfig } from "@chakra-ui/react";
+
 const generateTheme = (brand: Brand) => {
   return defineConfig({
     ...config,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       eslint:
         specifier: ^9.25.1
         version: 9.25.1(jiti@2.4.2)
-      patch-package:
-        specifier: ^8.0.0
-        version: 8.0.0
       prettier:
         specifier: ^3.3.1
         version: 3.5.1
@@ -277,9 +274,6 @@ importers:
       json-to-ts:
         specifier: ^1.7.0
         version: 1.7.0
-      patch-package:
-        specifier: ^6.4.7
-        version: 6.5.1
       prettier:
         specifier: ^2.4.1
         version: 2.8.8
@@ -5929,10 +5923,6 @@ packages:
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
-  cross-spawn@6.0.6:
-    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
-    engines: {node: '>=4.8'}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -7477,10 +7467,6 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
-  is-ci@2.0.0:
-    resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==}
-    hasBin: true
-
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
@@ -8585,9 +8571,6 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  nice-try@1.0.5:
-    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
-
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
@@ -8992,11 +8975,6 @@ packages:
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
-  patch-package@6.5.1:
-    resolution: {integrity: sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==}
-    engines: {node: '>=10', npm: '>5'}
-    hasBin: true
-
   patch-package@8.0.0:
     resolution: {integrity: sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==}
     engines: {node: '>=14', npm: '>5'}
@@ -9016,10 +8994,6 @@ packages:
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
-
-  path-key@2.0.1:
-    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
-    engines: {node: '>=4'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -9928,17 +9902,9 @@ packages:
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
-  shebang-command@1.2.0:
-    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
-    engines: {node: '>=0.10.0'}
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
-
-  shebang-regex@1.0.0:
-    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
-    engines: {node: '>=0.10.0'}
 
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
@@ -11229,10 +11195,6 @@ packages:
   which-typed-array@1.1.18:
     resolution: {integrity: sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==}
     engines: {node: '>= 0.4'}
-
-  which@1.3.1:
-    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
-    hasBin: true
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -18386,14 +18348,6 @@ snapshots:
 
   crelt@1.0.6: {}
 
-  cross-spawn@6.0.6:
-    dependencies:
-      nice-try: 1.0.5
-      path-key: 2.0.1
-      semver: 5.7.2
-      shebang-command: 1.2.0
-      which: 1.3.1
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -20331,10 +20285,6 @@ snapshots:
 
   is-callable@1.2.7: {}
 
-  is-ci@2.0.0:
-    dependencies:
-      ci-info: 2.0.0
-
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
@@ -21761,8 +21711,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  nice-try@1.0.5: {}
-
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
@@ -22129,23 +22077,6 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
 
-  patch-package@6.5.1:
-    dependencies:
-      '@yarnpkg/lockfile': 1.1.0
-      chalk: 4.1.2
-      cross-spawn: 6.0.6
-      find-yarn-workspace-root: 2.0.0
-      fs-extra: 9.1.0
-      is-ci: 2.0.0
-      klaw-sync: 6.0.0
-      minimist: 1.2.8
-      open: 7.4.2
-      rimraf: 2.7.1
-      semver: 5.7.2
-      slash: 2.0.0
-      tmp: 0.0.33
-      yaml: 1.10.2
-
   patch-package@8.0.0:
     dependencies:
       '@yarnpkg/lockfile': 1.1.0
@@ -22174,8 +22105,6 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
-
-  path-key@2.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -23384,15 +23313,9 @@ snapshots:
 
   shallowequal@1.1.0: {}
 
-  shebang-command@1.2.0:
-    dependencies:
-      shebang-regex: 1.0.0
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
-
-  shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
 
@@ -24860,10 +24783,6 @@ snapshots:
       for-each: 0.3.5
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-
-  which@1.3.1:
-    dependencies:
-      isexe: 2.0.0
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
- Removed unused `patch-package` from `spor-design-tokens`.
- Refactored theme setup in `spor-react` for type support and extending theme support.
- Updated `eslint-config` to better support React 17+ adding jsx runtime rules.
