### PR TITLE
Change name for downlodable zip file

### DIFF
--- a/apps/docs/app/routes/_base.resources.icon-library.all-icons[.zip]/route.tsx
+++ b/apps/docs/app/routes/_base.resources.icon-library.all-icons[.zip]/route.tsx
@@ -1,5 +1,4 @@
 import { LoaderFunction } from "@remix-run/node";
-
 import { getIconsZipFile } from "~/utils/icons.server";
 
 export const loader: LoaderFunction = async () => {
@@ -8,7 +7,7 @@ export const loader: LoaderFunction = async () => {
     headers: {
       "Content-Type": "application/zip",
       "Content-Length": zipFile.length.toString(),
-      "Content-Disposition": 'attachment; filename="spor-icons.zip"',
+      "Content-Disposition": 'attachment; filename="all-icons.zip"',
     },
   });
 };

--- a/apps/docs/app/routes/_base.resources.icon-library/route.tsx
+++ b/apps/docs/app/routes/_base.resources.icon-library/route.tsx
@@ -7,7 +7,6 @@ import {
   Stack,
   Text,
 } from "@vygruppen/spor-react";
-
 import { SearchBar } from "./SearchBar";
 import { SearchFilterProvider } from "./SearchFilterContext";
 import { SearchResults } from "./SearchResults";


### PR DESCRIPTION
## Background

The all-icons.zip was. not found on server

## Solution

The name of the file exported was not matching the file was downloaded


