### PR TITLE
fix: asChild support for `Button` and `TextLink`

### DIFF
--- a/.changeset/few-buttons-compete.md
+++ b/.changeset/few-buttons-compete.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+`asChild` support for Button and TextLink #1669

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/display-name */
 import {
   Box,
   Button as ChakraButton,
@@ -93,6 +92,7 @@ const LoadingContent = ({
   </>
 );
 
+// eslint-disable-next-line react/display-name
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
@@ -116,21 +116,26 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       ? String(loadingText ?? t(texts.loadingText))
       : (rest["aria-label"] as string);
 
-    const content = asChild
-      ? (children as React.ReactElement).props.children
-      : children;
+    const renderContent = () => {
+      const content = asChild
+        ? (children as React.ReactElement).props.children
+        : children;
 
-    const finalContent = loading ? (
-      <LoadingContent size={size} loadingText={loadingText}>
+      if (loading)
+        return (
+          <LoadingContent size={size} loadingText={loadingText}>
+            <ButtonContent leftIcon={leftIcon} rightIcon={rightIcon}>
+              {content}
+            </ButtonContent>
+          </LoadingContent>
+        );
+
+      return (
         <ButtonContent leftIcon={leftIcon} rightIcon={rightIcon}>
           {content}
         </ButtonContent>
-      </LoadingContent>
-    ) : (
-      <ButtonContent leftIcon={leftIcon} rightIcon={rightIcon}>
-        {content}
-      </ButtonContent>
-    );
+      );
+    };
 
     return (
       <ChakraButton
@@ -146,9 +151,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       >
         {asChild
           ? cloneElement(children as React.ReactElement, {
-              children: finalContent,
+              children: renderContent(),
             })
-          : finalContent}
+          : renderContent()}
       </ChakraButton>
     );
   },

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -29,7 +29,7 @@ export type ButtonProps = Exclude<
     /* Display icon to the right */
     rightIcon?: React.ReactNode;
     /* "primary" | "secondary" | "tertiary" | "ghost" | "floating". Defaults to primary. */
-    variant: "primary" | "secondary" | "tertiary" | "ghost" | "floating";
+    variant?: "primary" | "secondary" | "tertiary" | "ghost" | "floating";
     /* "lg" | "md" | "sm" | "xs". Defaults to md. */
     size?: "lg" | "md" | "sm" | "xs";
     /* Link to a downloadable resource. */
@@ -105,7 +105,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       rightIcon,
       type = "button",
       children,
-      asChild = false,
       ...rest
     },
     ref,
@@ -117,7 +116,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       : (rest["aria-label"] as string);
 
     const renderContent = () => {
-      const content = asChild
+      const content = rest.asChild
         ? (children as React.ReactElement).props.children
         : children;
 
@@ -149,7 +148,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         size={size}
         {...rest}
       >
-        {asChild
+        {rest.asChild
           ? cloneElement(children as React.ReactElement, {
               children: renderContent(),
             })

--- a/packages/spor-react/src/theme/recipes/button.ts
+++ b/packages/spor-react/src/theme/recipes/button.ts
@@ -14,6 +14,7 @@ export const buttonRecipe = defineRecipe({
     transitionDuration: "normal",
     cursor: "pointer",
     textWrap: "wrap",
+    width: "fit-content",
     paddingX: 3,
     paddingY: 1,
     _disabled: {
@@ -120,5 +121,9 @@ export const buttonRecipe = defineRecipe({
         fontWeight: "bold",
       },
     },
+  },
+  defaultVariants: {
+    variant: "primary",
+    size: "md",
   },
 });


### PR DESCRIPTION
## Background

Components did not support asChild attribute, because they either used react fragment between children and element, or because they rendered multiple children

## Solution

clone element and some react magic 
