### PR TITLE
fix(generate): unwrap client only from icons, as it cause layout shift in hydrations step

### DIFF
--- a/packages/spor-icon-react/bin/generate.ts
+++ b/packages/spor-icon-react/bin/generate.ts
@@ -72,19 +72,13 @@ function getMetadata({ fileName, category }: GetMetadataArgs): IconMetadata {
     size = additionalSize;
   }
   size = getPixelSizeOrFallback(size);
-  return {
-    name,
-    modifier,
-    size,
-    category,
-    fileName,
-  };
+  return { name, modifier, size, category, fileName };
 }
 
 /** Gets the number of pixels of a size, or returns the argument */
 function getPixelSizeOrFallback(size: string) {
   const sizeInPixelsRegex = /^\d+x\d+$/; // matches ie. "16x16", "30x30"
-  return sizeInPixelsRegex.test(size) ? size.substring(0, 2) : size;
+  return sizeInPixelsRegex.test(size) ? size.slice(0, 2) : size;
 }
 
 /** Creates the lookup key for a given icon */
@@ -109,37 +103,26 @@ async function generateComponent(iconData: IconData) {
       expandProps: "end",
       ref: true,
       titleProp: false,
-      svgProps: {
-        role: "img",
-        "aria-hidden": "true",
-      },
+      svgProps: { role: "img", "aria-hidden": "true" },
       svgo: true,
       svgoConfig: {
         plugins: [
           {
             name: "preset-default",
-            params: {
-              overrides: {
-                removeViewBox: false,
-              },
-            },
+            params: { overrides: { removeViewBox: false } },
           },
         ],
       },
       dimensions: true,
       template: componentTemplate,
       plugins: ["@svgr/plugin-svgo", "@svgr/plugin-jsx"],
-      replaceAttrValues: {
-        "#2B2B2C": "currentColor",
-      },
+      replaceAttrValues: { "#2B2B2C": "currentColor" },
     },
-    {
-      componentName: iconData.componentName,
-    },
+    { componentName: iconData.componentName },
   );
   jsCode = jsCode
-    .replace("<svg", '<ClientOnly><Box as="svg" display="block"')
-    .replace("</svg>", "</Box></ClientOnly>");
+    .replace("<svg", '<Box as="svg" display="block"')
+    .replace("</svg>", "</Box>");
 
   return createComponentFile(iconData, jsCode);
 }
@@ -170,10 +153,7 @@ function generateIndexFiles(icons: IconData[]) {
 
 function getUniqueCategories(icons: IconData[]) {
   return Object.keys(
-    icons.reduce(
-      (prev, icon) => ({ ...prev, [icon.metadata.category]: true }),
-      {},
-    ),
+    Object.fromEntries(icons.map((icon) => [icon.metadata.category, true])),
   );
 }
 


### PR DESCRIPTION
## Background

I noticed in Spor v2 that when refreshing a page, icons only appear after the hydration step is completed. This causes a Cumulative Layout Shift (CLS) issue, where the layout shifts when icons finally load in.

## Solution

I removed the ClientOnly wrapper from the icon generation process, allowing SVG icons to be rendered directly as part of the initial HTML.

## Chakra update checklist

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [ ] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [ ] Updated documentation in the component file
- [ ] Update green-beans-check.md with any major changes
- [ ] Add changeset
- [ ] Double check design in Figma

## UU checks

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Desribe how code reviewer may test your solution (what page, expected result).

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
