### PR TITLE
Fix table

### DIFF
--- a/.changeset/chilly-dryers-cry.md
+++ b/.changeset/chilly-dryers-cry.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Table: Fix width styling on tableCell.

--- a/packages/spor-react/src/theme/slot-recipes/table.ts
+++ b/packages/spor-react/src/theme/slot-recipes/table.ts
@@ -37,6 +37,7 @@ export const tableSlotRecipe = defineSlotRecipe({
       ...numericStyles,
       paddingX: 1.5,
       paddingY: 1,
+      width: "100%",
     },
     footer: {
       fontWeight: "medium",


### PR DESCRIPTION
## Background

Table had som issues with width
## Solution

Added width=100% to tableCell
## Chakra update checklist

**Delete this checklist if you are not working on Chakra 3/Spor 12**

## Chakra update checklist

- [ ] Updated Sanity documentation in v2 dataset (English, links, component props and content)
- [ ] Updated documentation in the component file
- [ ] Update green-beans-check.md with any major changes
- [ ] Add changeset
- [ ] Double check design in Figma

## UU checks

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Desribe how code reviewer may test your solution (what page, expected result).

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
