### PR TITLE
fix(spor-react): Issues with unused ref in forwardref functions

### DIFF
--- a/.changeset/happy-coats-allow.md
+++ b/.changeset/happy-coats-allow.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix Issues with unused ref in forwardref functions creating console errors for users.

--- a/apps/docs/app/root/layout/SearchDocs/SearchDocsInput.tsx
+++ b/apps/docs/app/root/layout/SearchDocs/SearchDocsInput.tsx
@@ -90,7 +90,6 @@ export const SearchDocsInput = ({ onSearchSelect, onClose }: Props) => {
             startElement={<SearchOutline24Icon />}
             type="text"
             label="Search the docs"
-            value={searchQuery}
           />
         </Combobox.Input>
       </Combobox.Control>

--- a/packages/spor-react/src/alert/AlertIcon.tsx
+++ b/packages/spor-react/src/alert/AlertIcon.tsx
@@ -12,6 +12,7 @@ import {
   SuccessFill24Icon,
   WarningFill24Icon,
 } from "@vygruppen/spor-icon-react";
+import { forwardRef } from "react";
 
 import { createTexts, useTranslation } from "../i18n";
 import { AlertProps } from "./Alert";
@@ -24,19 +25,24 @@ type AlertIconProps = {
 /**
  * Internal component that shows the correct icon for the alert
  */
-export const AlertIcon = ({ variant, customIcon }: AlertIconProps) => {
-  const { t } = useTranslation();
+export const AlertIcon = forwardRef<SVGSVGElement, AlertIconProps>(
+  ({ variant, customIcon }, ref) => {
+    const { t } = useTranslation();
 
-  const icon = customIcon ?? getIcon(variant);
+    const Icon = customIcon ?? getIcon(variant);
 
-  return (
-    <Box
-      as={icon}
-      aria-label={t(texts[variant as keyof typeof texts])}
-      color={customIcon ? `alert.${variant}.icon` : undefined}
-    />
-  );
-};
+    return (
+      <Box
+        as={Icon}
+        ref={ref}
+        aria-label={t(texts[variant as keyof typeof texts])}
+        color={customIcon ? `alert.${variant}.icon` : undefined}
+      />
+    );
+  },
+);
+
+AlertIcon.displayName = "AlertIcon";
 
 const getIcon = (variant: AlertProps["variant"]) => {
   switch (variant) {

--- a/packages/spor-react/src/button/CloseButton.tsx
+++ b/packages/spor-react/src/button/CloseButton.tsx
@@ -32,19 +32,19 @@ export const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>(
     const { t } = useTranslation();
     return (
       <IconButton
-        ref={ref}
         variant="ghost"
-        icon={getIcon(size)}
+        icon={<CloseIcon size={size} />}
         size={size}
         aria-label={props["aria-label"] || t(texts.close)}
         {...props}
+        ref={ref}
       />
     );
   },
 );
 CloseButton.displayName = "CloseButton";
 
-const getIcon = (size: CloseButtonProps["size"]) => {
+const CloseIcon = ({ size }: { size: CloseButtonProps["size"] }) => {
   switch (size) {
     case "xs":
     case "sm": {
@@ -55,6 +55,9 @@ const getIcon = (size: CloseButtonProps["size"]) => {
     }
     case "lg": {
       return <CloseFill30Icon />;
+    }
+    default: {
+      return <CloseFill18Icon />;
     }
   }
 };

--- a/packages/spor-react/src/button/IconButton.tsx
+++ b/packages/spor-react/src/button/IconButton.tsx
@@ -63,9 +63,9 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
       <ChakraIconButton
         aria-label={props["aria-label"]}
         size={size}
-        ref={ref}
         position={"relative"}
         {...rest}
+        ref={ref}
       >
         {loading ? <ColorSpinner width="2em" height="2em" margin={1} /> : icon}
       </ChakraIconButton>

--- a/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
+++ b/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
@@ -24,7 +24,7 @@ type CalendarTriggerButtonProps = AriaButtonProps<"button"> &
 export const CalendarTriggerButton = forwardRef<
   HTMLDivElement,
   CalendarTriggerButtonProps
->(({ variant, disabled, ariaLabelledby, ...buttonProps }) => {
+>(({ variant, disabled, ariaLabelledby, ...buttonProps }, ref) => {
   const { t } = useTranslation();
   const recipe = useSlotRecipe({
     key: "datePicker",
@@ -33,7 +33,7 @@ export const CalendarTriggerButton = forwardRef<
   const styles = recipe({ variant });
 
   return (
-    <PopoverAnchor {...buttonProps}>
+    <PopoverAnchor {...buttonProps} ref={ref}>
       <IconButton
         icon={<CalendarOutline24Icon />}
         aria-label={t(texts.openCalendar)}

--- a/packages/spor-react/src/input/Combobox.tsx
+++ b/packages/spor-react/src/input/Combobox.tsx
@@ -1,12 +1,5 @@
 "use client";
-import React, {
-  forwardRef,
-  ReactNode,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react";
+import React, { ReactNode, useEffect, useId, useRef, useState } from "react";
 import { AriaComboBoxProps, useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
 
@@ -57,163 +50,162 @@ export type ComboboxProps<T> = Exclude<
  * ```
  */
 
-export const Combobox = forwardRef<HTMLDivElement, ComboboxProps<object>>(
-  (props) => {
-    const {
-      label,
-      loading,
-      lefticon,
-      righticon,
-      borderBottomLeftRadius = "sm",
-      borderBottomRightRadius = "sm",
-      borderTopLeftRadius = "sm",
-      borderTopRightRadius = "sm",
-      marginBottom,
-      marginTop,
-      marginX,
-      marginY,
-      marginRight,
-      marginLeft,
-      paddingBottom,
-      paddingRight,
-      paddingTop,
-      paddingLeft,
-      paddingX,
-      paddingY,
-      emptyContent,
-      inputRef: externalInputRef,
-      children,
-      variant,
-    } = props;
-    const { contains } = useFilter({ sensitivity: "base" });
+export const Combobox = (props: ComboboxProps<object>) => {
+  const {
+    label,
+    loading,
+    lefticon,
+    righticon,
+    borderBottomLeftRadius = "sm",
+    borderBottomRightRadius = "sm",
+    borderTopLeftRadius = "sm",
+    borderTopRightRadius = "sm",
+    marginBottom,
+    marginTop,
+    marginX,
+    marginY,
+    marginRight,
+    marginLeft,
+    paddingBottom,
+    paddingRight,
+    paddingTop,
+    paddingLeft,
+    paddingX,
+    paddingY,
+    emptyContent,
+    inputRef: externalInputRef,
+    children,
+    variant,
+  } = props;
+  const { contains } = useFilter({ sensitivity: "base" });
 
-    const fallbackInputRef = useRef<HTMLInputElement>(null);
-    const inputRef = externalInputRef ?? fallbackInputRef;
-    const listBoxRef = useRef<HTMLUListElement>(null);
-    const popoverRef = useRef(null);
+  const fallbackInputRef = useRef<HTMLInputElement>(null);
+  const inputRef = externalInputRef ?? fallbackInputRef;
+  const listBoxRef = useRef<HTMLUListElement>(null);
+  const popoverRef = useRef(null);
 
-    const listboxId = `${useId()}-listbox`;
+  const listboxId = `${useId()}-listbox`;
 
-    const inputWidth = useInputWidth(inputRef);
+  const inputWidth = useInputWidth(inputRef);
 
-    const state = useComboBoxState({
-      defaultFilter: contains,
-      shouldCloseOnBlur: true,
+  const state = useComboBoxState({
+    defaultFilter: contains,
+    shouldCloseOnBlur: true,
+    ...props,
+  });
+
+  const comboBoxProps = {
+    borderTopLeftRadius,
+    borderTopRightRadius,
+    marginBottom,
+    marginTop,
+    marginRight,
+    marginLeft,
+    marginX,
+    marginY,
+    paddingBottom,
+    paddingRight,
+    paddingTop,
+    paddingLeft,
+    paddingX,
+    paddingY,
+    lefticon,
+  };
+
+  const {
+    inputProps: { ...inputProps },
+    listBoxProps,
+  } = useComboBox(
+    {
       ...props,
-    });
-
-    const comboBoxProps = {
-      borderTopLeftRadius,
-      borderTopRightRadius,
-      marginBottom,
-      marginTop,
-      marginRight,
-      marginLeft,
-      marginX,
-      marginY,
-      paddingBottom,
-      paddingRight,
-      paddingTop,
-      paddingLeft,
-      paddingX,
-      paddingY,
-      lefticon,
-    };
-
-    const {
-      inputProps: { ...inputProps },
-      listBoxProps,
-    } = useComboBox(
-      {
-        ...props,
-        inputRef,
-        listBoxRef,
-        popoverRef,
-        label,
-      },
-      state,
-    );
-    return (
-      <>
-        <Input
-          {...styleProps(comboBoxProps)}
-          aria-haspopup="listbox"
-          ref={inputRef}
-          role="combobox"
-          errorText={props.errorText}
-          helperText={props.helperText}
-          required={props.required}
-          disabled={props.disabled}
-          invalid={props.invalid}
-          label={label}
-          variant={variant}
-          aria-expanded={state.isOpen}
-          aria-autocomplete="list"
-          aria-controls={listboxId}
-          borderBottomLeftRadius={
-            state.isOpen && !loading ? 0 : borderBottomLeftRadius
-          }
-          borderBottomRightRadius={
-            state.isOpen && !loading ? 0 : borderBottomRightRadius
-          }
-          _active={{ backgroundColor: "core.surface.active" }}
-          {...inputProps}
-          endElement={
-            loading ? (
-              <ColorSpinner
-                width="1.5rem"
-                alignSelf="center"
-                paddingRight={paddingRight}
-                css={{
-                  div: {
-                    display: "flex",
-                    alignItems: "center",
-                  },
-                }}
-              />
-            ) : (
-              righticon
-            )
-          }
-          placeholder=""
-        />
-        <span aria-hidden="true" data-trigger="multiselect"></span>
-        {state.isOpen && !loading && (
-          <Popover
-            state={state}
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            triggerRef={inputRef as any} /* Find a way to not use type any */
-            ref={popoverRef}
-            isNonModal
-            placement="bottom start"
-            shouldFlip={false}
-            hasBackdrop={false}
-            // The minimum padding should be 0, because the popover always should be
-            // aligned with the input field regardless of the left padding in the container.
-            containerPadding={0}
-          >
-            <ListBox
-              {...{
-                autoFocus:
-                  typeof listBoxProps.autoFocus === "boolean"
-                    ? listBoxProps.autoFocus
-                    : undefined,
+      inputRef,
+      listBoxRef,
+      popoverRef,
+      label,
+    },
+    state,
+  );
+  return (
+    <>
+      <Input
+        {...styleProps(comboBoxProps)}
+        aria-haspopup="listbox"
+        ref={inputRef}
+        role="combobox"
+        errorText={props.errorText}
+        helperText={props.helperText}
+        required={props.required}
+        disabled={props.disabled}
+        invalid={props.invalid}
+        label={label}
+        variant={variant}
+        aria-expanded={state.isOpen}
+        aria-autocomplete="list"
+        aria-controls={listboxId}
+        borderBottomLeftRadius={
+          state.isOpen && !loading ? 0 : borderBottomLeftRadius
+        }
+        borderBottomRightRadius={
+          state.isOpen && !loading ? 0 : borderBottomRightRadius
+        }
+        _active={{ backgroundColor: "core.surface.active" }}
+        {...inputProps}
+        endElement={
+          loading ? (
+            <ColorSpinner
+              width="1.5rem"
+              alignSelf="center"
+              paddingRight={paddingRight}
+              css={{
+                div: {
+                  display: "flex",
+                  alignItems: "center",
+                },
               }}
-              state={state}
-              id={listboxId}
-              listBoxRef={listBoxRef}
-              emptyContent={emptyContent}
-              maxWidth={inputWidth}
-              variant={variant}
-            >
-              {children}
-            </ListBox>
-          </Popover>
-        )}
-      </>
-    );
-  },
-);
+            />
+          ) : (
+            righticon
+          )
+        }
+        placeholder=""
+      />
+      <span aria-hidden="true" data-trigger="multiselect"></span>
+      {state.isOpen && !loading && (
+        <Popover
+          state={state}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          triggerRef={inputRef as any} /* Find a way to not use type any */
+          ref={popoverRef}
+          isNonModal
+          placement="bottom start"
+          shouldFlip={false}
+          hasBackdrop={false}
+          // The minimum padding should be 0, because the popover always should be
+          // aligned with the input field regardless of the left padding in the container.
+          containerPadding={0}
+        >
+          <ListBox
+            {...{
+              autoFocus:
+                typeof listBoxProps.autoFocus === "boolean"
+                  ? listBoxProps.autoFocus
+                  : undefined,
+            }}
+            state={state}
+            id={listboxId}
+            listBoxRef={listBoxRef}
+            emptyContent={emptyContent}
+            maxWidth={inputWidth}
+            variant={variant}
+          >
+            {children}
+          </ListBox>
+        </Popover>
+      )}
+    </>
+  );
+};
+
 Combobox.displayName = "Combobox";
 
 const useInputWidth = (inputRef: React.RefObject<HTMLInputElement>) => {

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -8,13 +8,7 @@ import {
   useSlotRecipe,
 } from "@chakra-ui/react";
 import type { Node } from "@react-types/shared";
-import React, {
-  forwardRef,
-  PropsWithChildren,
-  useContext,
-  useEffect,
-  useRef,
-} from "react";
+import React, { PropsWithChildren, useContext, useEffect, useRef } from "react";
 import {
   AriaListBoxProps,
   useListBox,
@@ -84,33 +78,32 @@ type ListBoxProps<T> = AriaListBoxProps<T> &
  * ```
  */
 
-export const ListBox = forwardRef<HTMLDivElement, ListBoxProps<object>>(
-  (props) => {
-    const { loading, listBoxRef, state, maxWidth, variant, children } = props;
-    const { listBoxProps } = useListBox(props, state, listBoxRef);
-    const recipe = useSlotRecipe({ key: "listBox" });
-    const styles = recipe({ variant });
-    return (
-      <List
-        {...listBoxProps}
-        ref={listBoxRef}
-        css={styles.root}
-        aria-busy={loading}
-        maxWidth={maxWidth}
-      >
-        {state.collection.size === 0 && props.emptyContent}
-        {[...state.collection].map((item) =>
-          item.type === "section" ? (
-            <ListBoxSection key={item.key} section={item} state={state} />
-          ) : (
-            <Option key={item.key} item={item} state={state} />
-          ),
-        )}
-        {children}
-      </List>
-    );
-  },
-);
+export const ListBox = (props: ListBoxProps<object>) => {
+  const { loading, listBoxRef, state, maxWidth, variant, children } = props;
+  const { listBoxProps } = useListBox(props, state, listBoxRef);
+  const recipe = useSlotRecipe({ key: "listBox" });
+  const styles = recipe({ variant });
+  return (
+    <List
+      {...listBoxProps}
+      ref={listBoxRef}
+      css={styles.root}
+      aria-busy={loading}
+      maxWidth={maxWidth}
+    >
+      {state.collection.size === 0 && props.emptyContent}
+      {[...state.collection].map((item) =>
+        item.type === "section" ? (
+          <ListBoxSection key={item.key} section={item} state={state} />
+        ) : (
+          <Option key={item.key} item={item} state={state} />
+        ),
+      )}
+      {children}
+    </List>
+  );
+};
+
 ListBox.displayName = "ListBox";
 
 /**

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -69,7 +69,7 @@ export type NumericStepperProps = BoxProps &
 export const NumericStepper = React.forwardRef<
   HTMLDivElement,
   NumericStepperProps
->((props: NumericStepperProps) => {
+>((props: NumericStepperProps, ref) => {
   const {
     name: nameProp,
     id: idProp,
@@ -102,7 +102,7 @@ export const NumericStepper = React.forwardRef<
   };
 
   return (
-    <Field css={styles.root} width="auto" {...rest}>
+    <Field css={styles.root} width="auto" {...rest} ref={ref}>
       <VerySmallButton
         icon={<SubtractIcon stepLabel={clampedStepSize} />}
         aria-label={t(

--- a/packages/spor-react/src/input/Switch.tsx
+++ b/packages/spor-react/src/input/Switch.tsx
@@ -45,39 +45,41 @@ export type SwitchProps = Exclude<
  * ```
  */
 
-export const Switch = forwardRef<HTMLInputElement, SwitchProps>((props) => {
-  const {
-    rootRef,
-    size = "md",
-    label,
-    invalid,
-    errorText,
-    helperText,
-    ...rest
-  } = props;
-  const recipe = useSlotRecipe({ key: "switch" });
-  const styles = recipe({ size });
+export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
+  (props, ref) => {
+    const {
+      rootRef,
+      size = "md",
+      label,
+      invalid,
+      errorText,
+      helperText,
+      ...rest
+    } = props;
+    const recipe = useSlotRecipe({ key: "switch" });
+    const styles = recipe({ size });
 
-  return (
-    <Field
-      style={{ width: "auto" }}
-      invalid={invalid}
-      errorText={errorText}
-      helperText={helperText}
-    >
-      <ChakraSwitch.Root
-        ref={rootRef}
-        {...rest}
-        checked={props.checked}
-        css={styles.root}
+    return (
+      <Field
+        style={{ width: "auto" }}
+        invalid={invalid}
+        errorText={errorText}
+        helperText={helperText}
       >
-        <ChakraSwitch.Label>{label}</ChakraSwitch.Label>
-        <ChakraSwitch.HiddenInput />
-        <ChakraSwitch.Control css={styles.control}>
-          <ChakraSwitch.Thumb />
-        </ChakraSwitch.Control>
-      </ChakraSwitch.Root>
-    </Field>
-  );
-});
+        <ChakraSwitch.Root
+          ref={rootRef}
+          {...rest}
+          checked={props.checked}
+          css={styles.root}
+        >
+          <ChakraSwitch.Label>{label}</ChakraSwitch.Label>
+          <ChakraSwitch.HiddenInput ref={ref} />
+          <ChakraSwitch.Control css={styles.control}>
+            <ChakraSwitch.Thumb />
+          </ChakraSwitch.Control>
+        </ChakraSwitch.Root>
+      </Field>
+    );
+  },
+);
 Switch.displayName = "Switch";

--- a/packages/spor-react/src/linjetag/LineIcon.tsx
+++ b/packages/spor-react/src/linjetag/LineIcon.tsx
@@ -63,17 +63,20 @@ export type LineIconProps = Exclude<BoxProps, "variant"> &
  */
 
 export const LineIcon = forwardRef<HTMLDivElement, LineIconProps>(
-  function LineIcon({
-    variant,
-    size = "md",
-    foregroundColor,
+  function LineIcon(
+    {
+      variant,
+      size = "md",
+      foregroundColor,
 
-    disabled,
-    style,
-    target = "lineIcon",
-    label,
-    ...rest
-  }) {
+      disabled,
+      style,
+      target = "lineIcon",
+      label,
+      ...rest
+    },
+    ref,
+  ) {
     const recipe = useSlotRecipe({ key: "lineIcon" });
     const styles = recipe({ variant, size, ...rest });
 
@@ -112,6 +115,7 @@ export const LineIcon = forwardRef<HTMLDivElement, LineIconProps>(
         borderWidth={borderContainer()}
         borderColor={variant === "walk" ? "core.outline" : "transparent"}
         aria-label={label}
+        ref={ref}
       >
         <Icon css={styles.icon} />
       </Box>

--- a/packages/spor-react/src/loader/ProgressLoader.tsx
+++ b/packages/spor-react/src/loader/ProgressLoader.tsx
@@ -88,14 +88,17 @@ const ProgressLoaderWrapper = chakra("div", progressLoaderRecipe);
  */
 
 export const ProgressLoader = forwardRef<HTMLDivElement, ProgressLoaderProps>(
-  ({
-    value,
-    label,
-    labelRotationDelay = 5000,
-    "aria-label": ariaLabel,
-    width,
-    ...rest
-  }: ProgressLoaderProps) => {
+  (
+    {
+      value,
+      label,
+      labelRotationDelay = 5000,
+      "aria-label": ariaLabel,
+      width,
+      ...rest
+    },
+    ref,
+  ) => {
     const { t } = useTranslation();
     const currentLoadingText = useRotatingLabel({
       label,
@@ -124,6 +127,7 @@ export const ProgressLoader = forwardRef<HTMLDivElement, ProgressLoaderProps>(
         aria-valuemax={100}
         aria-label={ariaLabel ?? t(texts.fallbackLabel(value ?? "?"))}
         {...rest}
+        ref={ref}
       >
         <chakra.svg as="svg" viewBox="0 0 246 78" fill="none">
           <path

--- a/packages/spor-react/src/progress-indicator/ProgressIndicator.tsx
+++ b/packages/spor-react/src/progress-indicator/ProgressIndicator.tsx
@@ -35,7 +35,7 @@ export type ProgressIndicatorProps = BoxProps &
 export const ProgressIndicator = forwardRef<
   HTMLDivElement,
   ProgressIndicatorProps
->(({ numberOfSteps, activeStep }) => {
+>(({ numberOfSteps, activeStep }, ref) => {
   const { t } = useTranslation();
   const recipe = useSlotRecipe({
     key: "progressIndicator",
@@ -51,6 +51,7 @@ export const ProgressIndicator = forwardRef<
       aria-valuemax={numberOfSteps}
       aria-valuenow={activeStep}
       aria-valuetext={t(texts.stepsOf(activeStep, numberOfSteps))}
+      ref={ref}
     >
       <Box css={styles.container}>
         {Array.from({ length: numberOfSteps }, (_, i) => (


### PR DESCRIPTION
## Background

![image](https://github.com/user-attachments/assets/b2430877-7529-487b-9c4a-888375c98198)

## Solution

Checked all uses of forwardref and fixed ref. 
Removed forwardref for combobox and listbox, as they take input ref as prop which is passed. 

