### PR TITLE
fix(Button): Scaling of loading indicator

### DIFF
--- a/.changeset/twenty-tools-return.md
+++ b/.changeset/twenty-tools-return.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix scaling of loading indicator.

--- a/packages/spor-react/src/button/Button.tsx
+++ b/packages/spor-react/src/button/Button.tsx
@@ -86,7 +86,7 @@ const LoadingContent = ({
       {children}
     </Flex>
     <Center position="absolute" inset="1px 0">
-      <ColorInlineLoader width="80%" marginX={2} marginY={2} />
+      <ColorInlineLoader maxWidth="8" marginX={2} marginY={2} />
       {loadingText && <Box>{loadingText}</Box>}
     </Center>
   </>


### PR DESCRIPTION
## Background

![image](https://github.com/user-attachments/assets/ecf6247e-0846-4b21-a98d-b275bc1db60f)

## Solution

Set a fixed maxsize (maxwidth 8)

