### PR TITLE
Patch lottie-web to work with newer versions of node

### DIFF
--- a/.changeset/two-ants-invent.md
+++ b/.changeset/two-ants-invent.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Patch lottie-web to work with newer versions of node (node > 20)

--- a/package.json
+++ b/package.json
@@ -27,5 +27,10 @@
     "node": ">=18.0.0"
   },
   "prettier": {},
-  "packageManager": "pnpm@10.4.1"
+  "packageManager": "pnpm@10.4.1",
+  "pnpm": {
+    "patchedDependencies": {
+      "lottie-web": "patches/lottie-web.patch"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  lottie-web:
+    hash: af9adf2fec79e00f3de0e463a2d1f97ea616a3178881e1796e2d3a3cc22e6eae
+    path: patches/lottie-web.patch
+
 importers:
 
   .:
@@ -21332,11 +21337,11 @@ snapshots:
 
   lottie-react@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      lottie-web: 5.12.2
+      lottie-web: 5.12.2(patch_hash=af9adf2fec79e00f3de0e463a2d1f97ea616a3178881e1796e2d3a3cc22e6eae)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  lottie-web@5.12.2: {}
+  lottie-web@5.12.2(patch_hash=af9adf2fec79e00f3de0e463a2d1f97ea616a3178881e1796e2d3a3cc22e6eae): {}
 
   loupe@2.3.7:
     dependencies:


### PR DESCRIPTION
## Background
The package `lottie-web` does not work properly with SSR on newer versions of node (node > 20). This is because node has made changes in their navigator api so it is now available on the server as well. This causes a check `lottie-web` has to determine what context it is in to not work as intended, leading to a `document is undefined` error. 

Link to relevant github issue: https://github.com/airbnb/lottie-web/issues/2739

## Solution

Create a patch version of the `lottie-web` package with `pnpm patch`. In the patched version we update the check to see if the document is present instead of the navigator.