### PR TITLE
Fix phoneNumberInput

### DIFF
--- a/.changeset/many-apples-tie.md
+++ b/.changeset/many-apples-tie.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+PhoneNumberInput: Wrapped CountryCodeSelect and Input in Box and added Flex values

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box, useControllableState } from "@chakra-ui/react";
+import { useControllableState } from "@chakra-ui/react";
 import { forwardRef } from "react";
 
 import { createTexts, Input, InputProps, useTranslation } from "..";

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -86,42 +86,39 @@ export const PhoneNumberInput = forwardRef<
       outline={invalid ? "1px solid" : "none"}
       outlineColor={invalid ? "outline.error" : "none"}
       borderRadius={invalid ? "sm" : "none"}
-      display="flex"
+      display="grid"
+      gridTemplateColumns="1fr 10fr"
     >
       <>
-        <Box flex={"1"}>
-          <CountryCodeSelect
-            value={[value.countryCode]}
-            onValueChange={handleCountryCodeChange}
-            height="100%"
-            width="6.25rem"
-            variant={variant}
-            allowedCountryCodes={allowedCountryCodes}
-            data-state="on"
-          />
-        </Box>
-        <Box flex={"10"}>
-          <Input
-            ref={ref}
-            type="tel"
-            value={value.nationalNumber}
-            invalid={invalid}
-            errorText={errorText}
-            onChange={(e) => {
-              const target = e.target as HTMLInputElement;
-              // Removes everything but numbers, spaces and dashes
-              const strippedValue = target.value.replaceAll(/[^\d\s-]/g, "");
-              onChange({
-                countryCode: value.countryCode,
-                nationalNumber: strippedValue,
-              });
-            }}
-            variant={variant}
-            data-state="on"
-            {...props}
-            label={label}
-          />
-        </Box>
+        <CountryCodeSelect
+          value={[value.countryCode]}
+          onValueChange={handleCountryCodeChange}
+          height="100%"
+          width="6.25rem"
+          variant={variant}
+          allowedCountryCodes={allowedCountryCodes}
+          data-state="on"
+        />
+        <Input
+          ref={ref}
+          type="tel"
+          value={value.nationalNumber}
+          invalid={invalid}
+          errorText={errorText}
+          onChange={(e) => {
+            const target = e.target as HTMLInputElement;
+            // Removes everything but numbers, spaces and dashes
+            const strippedValue = target.value.replaceAll(/[^\d\s-]/g, "");
+            onChange({
+              countryCode: value.countryCode,
+              nationalNumber: strippedValue,
+            });
+          }}
+          variant={variant}
+          data-state="on"
+          {...props}
+          label={label}
+        />
       </>
     </AttachedInputs>
   );

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useControllableState } from "@chakra-ui/react";
+import { Box, useControllableState } from "@chakra-ui/react";
 import { forwardRef } from "react";
 
 import { createTexts, Input, InputProps, useTranslation } from "..";
@@ -86,37 +86,42 @@ export const PhoneNumberInput = forwardRef<
       outline={invalid ? "1px solid" : "none"}
       outlineColor={invalid ? "outline.error" : "none"}
       borderRadius={invalid ? "sm" : "none"}
+      display="flex"
     >
       <>
-        <CountryCodeSelect
-          value={[value.countryCode]}
-          onValueChange={handleCountryCodeChange}
-          height="100%"
-          width="6.25rem"
-          variant={variant}
-          allowedCountryCodes={allowedCountryCodes}
-          data-state="on"
-        />
-        <Input
-          ref={ref}
-          type="tel"
-          value={value.nationalNumber}
-          invalid={invalid}
-          errorText={errorText}
-          onChange={(e) => {
-            const target = e.target as HTMLInputElement;
-            // Removes everything but numbers, spaces and dashes
-            const strippedValue = target.value.replaceAll(/[^\d\s-]/g, "");
-            onChange({
-              countryCode: value.countryCode,
-              nationalNumber: strippedValue,
-            });
-          }}
-          variant={variant}
-          data-state="on"
-          {...props}
-          label={label}
-        />
+        <Box flex={"1"}>
+          <CountryCodeSelect
+            value={[value.countryCode]}
+            onValueChange={handleCountryCodeChange}
+            height="100%"
+            width="6.25rem"
+            variant={variant}
+            allowedCountryCodes={allowedCountryCodes}
+            data-state="on"
+          />
+        </Box>
+        <Box flex={"10"}>
+          <Input
+            ref={ref}
+            type="tel"
+            value={value.nationalNumber}
+            invalid={invalid}
+            errorText={errorText}
+            onChange={(e) => {
+              const target = e.target as HTMLInputElement;
+              // Removes everything but numbers, spaces and dashes
+              const strippedValue = target.value.replaceAll(/[^\d\s-]/g, "");
+              onChange({
+                countryCode: value.countryCode,
+                nationalNumber: strippedValue,
+              });
+            }}
+            variant={variant}
+            data-state="on"
+            {...props}
+            label={label}
+          />
+        </Box>
       </>
     </AttachedInputs>
   );


### PR DESCRIPTION
## Background

An error occured from a previous merge. PhoneNumberInput was "split in half"
## Solution

Wrapped CountryCodeSelect and Input in Box and added Flex values. It was not possible to put the flex values directly on CountryCodeSelect and Input. 
## Chakra update checklist

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test
http://localhost:3000/components/phone-number-input

## Screenshots

| Before | After |
| ------ | ----- |
|![image](https://github.com/user-attachments/assets/74b75b62-507c-4db0-881f-c1e13cfc0680)|![image](https://github.com/user-attachments/assets/f65e3148-21d6-4b75-9410-c3849353ecf3)|
