### PR TITLE
fix [object object], and UU problem

### DIFF
--- a/.changeset/perfect-nails-rule.md
+++ b/.changeset/perfect-nails-rule.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+CountryCodeSelect: Fixed onValueChange and UU styling in select.

--- a/packages/spor-react/src/input/CountryCodeSelect.tsx
+++ b/packages/spor-react/src/input/CountryCodeSelect.tsx
@@ -58,7 +58,7 @@ export const CountryCodeSelect = forwardRef<
       variant={"rightSideSquare"}
     >
       {callingCodes.items.map((code) => (
-        <SelectItem key={code.label} item={code}>
+        <SelectItem as={"option"} key={code.label} item={code}>
           {code.label}
         </SelectItem>
       ))}

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -102,6 +102,7 @@ export const PhoneNumberInput = forwardRef<
         <Input
           ref={ref}
           type="tel"
+          {...props}
           value={value.nationalNumber}
           invalid={invalid}
           errorText={errorText}
@@ -116,7 +117,6 @@ export const PhoneNumberInput = forwardRef<
           }}
           variant={variant}
           data-state="on"
-          {...props}
           label={label}
         />
       </>

--- a/packages/spor-react/src/theme/slot-recipes/select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/select.ts
@@ -2,6 +2,14 @@ import { defineSlotRecipe } from "@chakra-ui/react";
 
 import { selectAnatomy } from "./anatomy";
 
+/* const itemFocusStyles = {
+  "html[data-keyboard-input] &[data-highlighted]": {
+    outline: "2px solid red",
+    outlineOffset: "2px",
+    backgroundColor: "ghost.surface.hover",
+  },
+} as const; */
+
 export const selectSlotRecipe = defineSlotRecipe({
   slots: selectAnatomy.keys(),
   className: "spor-select",
@@ -94,6 +102,7 @@ export const selectSlotRecipe = defineSlotRecipe({
         animationStyle: "slide-fade-in",
         animationDuration: "fast",
         zIndex: "popover",
+        outline: "none",
       },
       _closed: {
         animationStyle: "slide-fade-out",
@@ -113,20 +122,17 @@ export const selectSlotRecipe = defineSlotRecipe({
       color: "ghost.text",
       cursor: "pointer",
       outline: "none",
-      "&[data-highlighted]": {
-        outline: "2px solid outline.focus",
+      "&[data-highlighted]:hover": {
         outlineOffset: "2px",
+        outline: "2px solid",
+        outlineColor: "outline.focus",
         backgroundColor: "ghost.surface.hover",
       },
-
-      _focusVisible: {
-        outline: "2px solid red",
+      "&[data-highlighted]": {
         outlineOffset: "2px",
+        outline: "2px solid",
+        outlineColor: "outline.focus",
       },
-      /* _focus: {
-        outline: "2px solid red",
-        outlineOffset: "2px",
-      }, */
       _active: {
         backgroundColor: "ghost.surface.active",
         color: "green",

--- a/packages/spor-react/src/theme/slot-recipes/select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/select.ts
@@ -113,7 +113,20 @@ export const selectSlotRecipe = defineSlotRecipe({
       color: "ghost.text",
       cursor: "pointer",
       outline: "none",
+      "&[data-highlighted]": {
+        outline: "2px solid outline.focus",
+        outlineOffset: "2px",
+        backgroundColor: "ghost.surface.hover",
+      },
 
+      _focusVisible: {
+        outline: "2px solid red",
+        outlineOffset: "2px",
+      },
+      /* _focus: {
+        outline: "2px solid red",
+        outlineOffset: "2px",
+      }, */
       _active: {
         backgroundColor: "ghost.surface.active",
         color: "green",

--- a/packages/spor-react/src/theme/slot-recipes/select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/select.ts
@@ -2,14 +2,6 @@ import { defineSlotRecipe } from "@chakra-ui/react";
 
 import { selectAnatomy } from "./anatomy";
 
-/* const itemFocusStyles = {
-  "html[data-keyboard-input] &[data-highlighted]": {
-    outline: "2px solid red",
-    outlineOffset: "2px",
-    backgroundColor: "ghost.surface.hover",
-  },
-} as const; */
-
 export const selectSlotRecipe = defineSlotRecipe({
   slots: selectAnatomy.keys(),
   className: "spor-select",


### PR DESCRIPTION
## Background

1.  onValueChange did not work and returned |Object object]
2. focus was set on select content when using tab to navigate. Therefore select item was not reachable. 

## Solution
1. moved {...props} higher up in the code under Input
2. added the necessary styling

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [x] Sanity documentation has been / will be updated (if neccessary)

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## How to test

Go to http://localhost:3000/components/phone-number-input and check the example code
## Screenshots

| 1. Before | 1. After |
| ------ | ----- |
|<img width="363" alt="image" src="https://github.com/user-attachments/assets/4c78945d-e814-4ce1-8aea-0c53967366e2" />|<img width="381" alt="image" src="https://github.com/user-attachments/assets/739b187c-c5d3-4745-9385-073547ebf1b3" />|

| 2. Before | 2. After |
| ------ | ----- |
|<img width="258" alt="image" src="https://github.com/user-attachments/assets/386d621a-0c61-48aa-85c5-3bfcde3ef4c2" />|<img width="227" alt="image" src="https://github.com/user-attachments/assets/4ef2c1ac-2a65-4357-a772-1055ac192f6d" />|