### PR TITLE
Copy patches folder

### DIFF
--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -31,6 +31,7 @@ ENV NODE_ENV=production
 WORKDIR /app
 
 # Copy only production dependencies
+COPY patches ./patches
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/docs/package.json apps/docs/
 


### PR DESCRIPTION
## Background

The pipeline crashes because it is not able to find the `app/patches` folder

## Solution

Copy the `patches` folder to `app/patches` in Dockerfile
