### PR TITLE
Fix: Bugs after upgrading chakra

### DIFF
--- a/packages/spor-react/src/nudge/Nudge.tsx
+++ b/packages/spor-react/src/nudge/Nudge.tsx
@@ -1,11 +1,12 @@
 "use client";
-import { PopoverCloseTrigger, usePopoverContext } from "@ark-ui/react";
 import {
   Box,
   BoxProps,
   chakra,
   Popover as ChakraPopover,
+  PopoverCloseTrigger,
   PopoverRootProps,
+  usePopoverContext,
 } from "@chakra-ui/react";
 import { ArrowRightFill18Icon } from "@vygruppen/spor-icon-react";
 import React, {

--- a/packages/spor-react/src/toast/toast.tsx
+++ b/packages/spor-react/src/toast/toast.tsx
@@ -39,7 +39,7 @@ export const createToast = ({
   toaster.create({
     description: text,
     type: variant,
-    id,
+    id: id ?? crypto.randomUUID(),
     duration,
   });
 


### PR DESCRIPTION
## Background

Nudge, WizardNudge and Toast does not work after updating chakra in a previous version of spor.

## Solution

- Toast needed an id for each toast. Auto generated if not supplied from user.
- Nudge imported usePopoverContext from ark. Now imports from chakra and works. 