### PR TITLE
fix: Omit value from InputProps type to get correct typing

### DIFF
--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -11,7 +11,7 @@ export type CountryCodeAndPhoneNumber = {
   nationalNumber: string;
 };
 
-type PhoneNumberInputProps = InputProps & {
+type PhoneNumberInputProps = Omit<InputProps, "value"> & {
   /** The label. Defaults to a localized version of "Phone number" */
   label?: string;
   /** Callback for when the country code or phone number changes */


### PR DESCRIPTION
## Background

When using PhoneNumberInput in our project, the expected type on the value field is a mix of HtmlInput value (string | number | readonly string[]) and the CountryCodeAndPhoneNumber type. This does not work as the union of those types is not usable. 

## Solution
I omit the InputProp value field so it is not mixed. You can confirm this by removing my fix and hovering over the externalValue declaration on props to see the mixed type. 


## How to test
See solution above on how to test. Simply try to remove fix and add it back again.

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
