### PR TITLE
fix outline on focus

### DIFF
--- a/packages/spor-react/src/theme/slot-recipes/listbox.ts
+++ b/packages/spor-react/src/theme/slot-recipes/listbox.ts
@@ -39,6 +39,7 @@ export const listBoxSlotRecipe = defineSlotRecipe({
         backgroundColor: "ghost.surface.active",
       },
       _focus: {
+        outline: "2px solid",
         outlineColor: "outline.focus",
       },
     },


### PR DESCRIPTION
## Background

Tere was no outline when tabbing down the list
## Solution

added an outline on focus

## UU checks

- [x] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave
- [ ] Sanity documentation has been / will be updated (if neccessary)

If no packages, only docs has been changed:

- [ ] Documentation version has been bumped (package.json in docs)

Everything about making a React component:
https://spor.vy.no/guides/how-to-make-new-react-components

HOW TO MAKE A CHANGESET:
Go here: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package

## Screenshots

| Before | After |
| ------ | ----- |
|<img width="1029" height="383" alt="image" src="https://github.com/user-attachments/assets/2cbaa788-9aa3-4184-9f2a-f9b321a8d526" />|<img width="1062" height="427" alt="image" src="https://github.com/user-attachments/assets/3d3b5231-659a-4ad6-bb55-1f8994603b30" />|
