### PR TITLE
feat(Text): add fontSize and lineHeight support for <Text/>

### DIFF
--- a/.changeset/famous-cherries-guess.md
+++ b/.changeset/famous-cherries-guess.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Allow fontSize and lineHeight for <Text/>

--- a/packages/spor-react/src/typography/Text.tsx
+++ b/packages/spor-react/src/typography/Text.tsx
@@ -14,16 +14,42 @@ export type TextProps = Omit<ChakraTextProps, "textStyle"> & {
 };
 
 /**
+ * Determines the correct props to pass to ChakraText,
+ * based on the user's intent and sensible defaults.
+ */
+function resolveTextProps({
+  variant,
+  fontSize,
+  lineHeight,
+}: Pick<TextProps, "variant" | "fontSize" | "lineHeight">) {
+  // If user provides a variant, use it (overrides fontSize/lineHeight)
+  if (variant) return { textStyle: variant };
+
+  // If neither fontSize nor lineHeight is provided, default to "sm"
+  if (!fontSize && !lineHeight) return { textStyle: "sm" };
+
+  // If only lineHeight is provided, default fontSize to "sm"
+  if (lineHeight && !fontSize) return { lineHeight, fontSize: "sm" };
+
+  // If only fontSize is provided, use it and let Chakra handle lineHeight
+  if (fontSize && !lineHeight) return { fontSize };
+
+  // If both are provided, use both
+  return { fontSize, lineHeight };
+}
+
+/**
  * A paragraph of text.
  *
  * ```tsx
  * <Text>Welcome to this paragraph of text.</Text>
  * ```
  */
-
 export const Text = forwardRef<HTMLParagraphElement, TextProps>(
   function Text(props, ref) {
-    const { variant = "sm", ...rest } = props;
-    return <ChakraText {...rest} textStyle={variant} ref={ref} />;
+    const { variant, lineHeight, fontSize, ...rest } = props;
+    const resolvedProps = resolveTextProps({ variant, fontSize, lineHeight });
+
+    return <ChakraText {...resolvedProps} {...rest} ref={ref} />;
   },
 );


### PR DESCRIPTION
## Background:
Previously, the <Text /> component in spor-react defaulted to the sm textStyle unless a variant was provided. This made it difficult for users to override only fontSize or lineHeight without unintentionally resetting both to the default.

## Solution:
Refactored the prop resolution logic for <Text /> to allow users to specify fontSize and/or lineHeight independently. The component now only applies the sm default when neither is provided, and respects user-supplied values otherwise.

Closes #1763 