### PR TITLE
fix(Alert): Prevent crash when no variant is specified

### DIFF
--- a/.changeset/chatty-shoes-thank.md
+++ b/.changeset/chatty-shoes-thank.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix bug where no specified variant crashed alert

--- a/packages/spor-react/src/alert/Alert.tsx
+++ b/packages/spor-react/src/alert/Alert.tsx
@@ -70,7 +70,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
         <HStack gap="1" alignItems="flex-start">
           {showIndicator && (
             <ChakraAlert.Indicator asChild>
-              <AlertIcon variant={props.variant} customIcon={icon} />
+              <AlertIcon variant={props.variant ?? "info"} customIcon={icon} />
             </ChakraAlert.Indicator>
           )}
           {title && (


### PR DESCRIPTION
## Background

No specified alert caused crash

## Solution

default variant for AlertIcon

closes #1781 