### PR TITLE
fix(field): position errorText below input when absolute

### DIFF
--- a/.changeset/bright-rules-deny.md
+++ b/.changeset/bright-rules-deny.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix positioning of errorText in field so it does not overlap input.

--- a/packages/spor-react/src/theme/slot-recipes/field.ts
+++ b/packages/spor-react/src/theme/slot-recipes/field.ts
@@ -31,7 +31,7 @@ export const fieldSlotRecipe = defineSlotRecipe({
       textStyle: "xs",
       width: "fit-content",
       position: "absolute",
-      bottom: -5,
+      top: "100%", // position below parent
       left: 3,
       zIndex: "dropdown",
       maxWidth: "50ch",


### PR DESCRIPTION
Set errorText to use absolute positioning with top: 100% so multi-line errors no longer overlap the input field.

Closes #1818 