### PR TITLE
fix(input): resolve missing label error when specifying id on inputs

### DIFF
--- a/.changeset/ten-planets-peel.md
+++ b/.changeset/ten-planets-peel.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix bug where specifying id on inputs gives missing label error.

--- a/packages/spor-react/src/input/Field.tsx
+++ b/packages/spor-react/src/input/Field.tsx
@@ -65,6 +65,7 @@ export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
       readOnly,
       required,
       direction,
+      id,
       ...rest
     } = props;
     const recipe = useSlotRecipe({ key: "field" });
@@ -79,6 +80,7 @@ export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
           required={required}
           css={styles.root}
           direction={direction}
+          id={id}
         >
           {label && !floatingLabel && (
             <Label>

--- a/packages/spor-react/src/input/Input.tsx
+++ b/packages/spor-react/src/input/Input.tsx
@@ -79,6 +79,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         helperText={helperText}
         required={required}
         errorText={errorText}
+        id={props.id}
         label={
           // Render startElement invisibly to align label text with input content when an icon is present
           <Flex>

--- a/packages/spor-react/src/input/NativeSelect.tsx
+++ b/packages/spor-react/src/input/NativeSelect.tsx
@@ -66,6 +66,7 @@ export const NativeSelect = React.forwardRef<
       required={required}
       helperText={helperText}
       errorText={errorText}
+      id={rest.id}
       floatingLabel={true}
     >
       <ChakraNativeSelect.Root

--- a/packages/spor-react/src/input/NumericStepper.tsx
+++ b/packages/spor-react/src/input/NumericStepper.tsx
@@ -101,7 +101,7 @@ export const NumericStepper = React.forwardRef<
   };
 
   return (
-    <Field css={styles.root} width="auto" {...rest} ref={ref}>
+    <Field css={styles.root} width="auto" {...rest} id={idProp} ref={ref}>
       <VerySmallButton
         icon={<SubtractIcon stepLabel={clampedStepSize} />}
         aria-label={t(

--- a/packages/spor-react/src/input/Select.tsx
+++ b/packages/spor-react/src/input/Select.tsx
@@ -77,6 +77,7 @@ export const Select = React.forwardRef<HTMLDivElement, SelectProps>(
         invalid={invalid}
         helperText={helperText}
         required={props.required}
+        id={rest.id}
       >
         <ChakraSelect.Root
           {...rest}

--- a/packages/spor-react/src/input/Switch.tsx
+++ b/packages/spor-react/src/input/Switch.tsx
@@ -66,6 +66,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
         errorText={errorText}
         helperText={helperText}
         required={props.required}
+        id={rest.id}
       >
         <ChakraSwitch.Root
           ref={rootRef}


### PR DESCRIPTION
##Background
The id for a field is typically auto-generated. However, when an id is explicitly specified (e.g., in an Input component), it is not correctly passed to the Field component, causing the label to be improperly linked.

##Solution
Ensure the id is properly passed to the Field component to establish the correct connection with the label.

