### PR TITLE
set width 100% on ChakraAlert.Description

### DIFF
--- a/packages/spor-react/src/alert/Alert.tsx
+++ b/packages/spor-react/src/alert/Alert.tsx
@@ -81,7 +81,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
         </HStack>
         {children && (
           <ChakraAlert.Description
-            width={"100%"}
+            width="100%"
             paddingLeft={title ? 0.5 : 0}
             paddingRight={closable ? 6 : 0}
           >


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://spor.vy.no/guides/how-to-make-new-react-components
📦 How to make a changeset: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background
When using an alert with a "show more" button it did not fill the whole container



## Screenshots

| Before | After |
| ------ | ----- |
|<img width="1051" height="124" alt="image" src="https://github.com/user-attachments/assets/ac34b4a0-8355-4286-91e6-895f78728487" />|<img width="1052" height="164" alt="image" src="https://github.com/user-attachments/assets/09991b01-59e9-4310-8f65-2c296025349c" />|
