### PR TITLE
feat(spor-react): add backgroundColor prop to TravelTag component

### DIFF
--- a/.changeset/slick-peaches-itch.md
+++ b/.changeset/slick-peaches-itch.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add backgroundColor to travelTag

--- a/packages/spor-react/src/linjetag/TravelTag.tsx
+++ b/packages/spor-react/src/linjetag/TravelTag.tsx
@@ -124,6 +124,7 @@ export const TravelTag = forwardRef<HTMLDivElement, TravelTagProps>(
         aria-disabled={disabled}
         ref={ref}
         className={clsx("light", rest.className)}
+        backgroundColor={backgroundColor}
         {...rest}
       >
         <LineIcon


### PR DESCRIPTION
## Background

Was not working. Not sure when it broke.

## Solution

Add it back

## General Checklist

- [X] I have updated documentation if necessary
- [X] I have verified the design aligns with the latest Figma sketches.
- [X] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [X] It is possible to use the keyboard to reach your changes
- [X] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [X] It works with VoiceOver
- [X] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|     <img width="384" height="147" alt="image" src="https://github.com/user-attachments/assets/ff6c048d-9a6a-4790-9bfc-f1363469c66c" />   |   <img width="384" height="147" alt="image" src="https://github.com/user-attachments/assets/25532de6-9459-4b5d-ae0d-9dccf368c367" />    |

