### PR TITLE
fix(Drawer): change title prop to children in DrawerFullScreenHeader

### DIFF
--- a/.changeset/tricky-squids-tickle.md
+++ b/.changeset/tricky-squids-tickle.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Drawer: Change title in DrawerFullScreenHeader from being type string, to being child.

--- a/packages/spor-react/src/dialog/Drawer.tsx
+++ b/packages/spor-react/src/dialog/Drawer.tsx
@@ -145,7 +145,7 @@ export const DrawerFullScreenHeader = forwardRef<
   HTMLDivElement,
   DrawerFullScreenHeaderProps
 >((props, ref) => {
-  const { backTrigger = true, closeTrigger = true, title } = props;
+  const { backTrigger = true, closeTrigger = true, children } = props;
   return (
     <ChakraDrawer.Header {...props} ref={ref} asChild>
       <Grid templateColumns="1fr auto 1fr" height="auto" paddingX="8">
@@ -153,7 +153,7 @@ export const DrawerFullScreenHeader = forwardRef<
           {backTrigger && <DrawerBackTrigger />}
         </GridItem>
         <GridItem width="full" alignSelf="end" asChild>
-          {title && <DrawerTitle>{title}</DrawerTitle>}
+          {children && <DrawerTitle>{children}</DrawerTitle>}
         </GridItem>
         {closeTrigger && (
           <GridItem width="full" alignSelf="end">

--- a/packages/spor-react/src/dialog/types.ts
+++ b/packages/spor-react/src/dialog/types.ts
@@ -1,5 +1,5 @@
 import { Drawer as ChakraDrawer, RecipeVariantProps } from "@chakra-ui/react";
-import { PropsWithChildren, ReactNode } from "react";
+import { PropsWithChildren } from "react";
 
 import { drawerSlotRecipe } from "@/theme/slot-recipes/drawer";
 
@@ -21,8 +21,10 @@ export type DrawerProps = Omit<
     children: React.ReactNode;
   };
 
-export type DrawerFullScreenHeaderProps = ChakraDrawer.HeaderProps & {
+export type DrawerFullScreenHeaderProps = Omit<
+  ChakraDrawer.HeaderProps,
+  "title"
+> & {
   backTrigger?: boolean;
   closeTrigger?: boolean;
-  title?: ReactNode;
 };


### PR DESCRIPTION
## Background

Previously, title was string. Makes more sense that is is children. Consistent with Modal etc.

## Solution

Change type from string to child of DrawerFullScreenHeader component
---

## General Checklist

- [X] I have updated documentation if necessary
- [X] I have verified the design aligns with the latest Figma sketches.
- [X] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [X] It is possible to use the keyboard to reach your changes
- [X] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [X] It works with VoiceOver
- [X] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

<img width="1296" height="688" alt="image" src="https://github.com/user-attachments/assets/80fd574d-9664-4419-8929-0ac17bd0188a" />