### PR TITLE
fix(Datepicker): set min height to ensure calendar popover fits content

### DIFF
--- a/.changeset/cold-chairs-flash.md
+++ b/.changeset/cold-chairs-flash.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix min height on datepicker popover, making sure it fits content.

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -72,6 +72,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       outlineColor: "floating.outline",
       boxShadow: "md",
       backgroundColor: "floating.surface",
+      minHeight: "min-content",
     },
     rangeCalendarPopover: {
       width: "43rem",


### PR DESCRIPTION
## Background

<img width="1405" height="958" alt="image" src="https://github.com/user-attachments/assets/5216c3fc-2b50-4cc7-b7aa-58fe37708407" /> 

Happend when datepicker is forced above input field with withPortal =false

## Solution

Add min-height: fit-content 

## General Checklist

- [X] I have updated documentation if necessary
- [X] I have verified the design aligns with the latest Figma sketches.
- [X] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [X] It is possible to use the keyboard to reach your changes
- [X] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [X] It works with VoiceOver
- [X] There are no errors in aXe / SiteImprove-plugins / Wave
