### PR TITLE
feat(datepicker): Added isActive and noCalendar prop to datePicker

### DIFF
--- a/.changeset/calm-numbers-relax.md
+++ b/.changeset/calm-numbers-relax.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Added isActive and noCalendar props for datepicker

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -101,6 +101,9 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
     const styles = recipe({ variant });
     const locale = useCurrentLocale();
 
+    const shouldShowCalendar =
+      state.isOpen && !props.isDisabled && !props.noCalendar;
+
     const onFieldClick = () => {
       if (props.noCalendar) return;
       state.setOpen(true);
@@ -173,15 +176,8 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
               </PopoverAnchor>
             </Field>
 
-            {state.isOpen &&
-              !props.isDisabled &&
-              withPortal &&
-              !props.noCalendar && <Portal>{popoverContent}</Portal>}
-            {state.isOpen &&
-              !props.isDisabled &&
-              !withPortal &&
-              !props.noCalendar &&
-              popoverContent}
+            {shouldShowCalendar &&
+              (withPortal ? <Portal>{popoverContent}</Portal> : popoverContent)}
           </ChakraPopover.Root>
         </Box>
       </I18nProvider>

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -10,6 +10,7 @@ import {
   useFieldContext,
   useSlotRecipe,
 } from "@chakra-ui/react";
+import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
 import React, { forwardRef, PropsWithChildren, useId, useRef } from "react";
 import {
   AriaDatePickerProps,
@@ -42,6 +43,9 @@ type DatePickerProps = Omit<AriaDatePickerProps<DateValue>, "onChange"> &
     withPortal?: boolean;
     onChange?: (value: DateValue | null) => void;
     positioning?: PopoverRootProps["positioning"];
+    noCalendar?: boolean;
+    overrideBorderColor?: string;
+    isActive?: boolean;
   } & FieldBaseProps;
 
 /**
@@ -98,6 +102,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
     const locale = useCurrentLocale();
 
     const onFieldClick = () => {
+      if (props.noCalendar) return;
       state.setOpen(true);
     };
 
@@ -135,20 +140,29 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
               <PopoverAnchor>
                 <StyledField
                   variant={variant}
-                  onClick={onFieldClick}
+                  onClick={props.noCalendar ? undefined : onFieldClick}
                   paddingX={3}
                   minHeight={minHeight}
                   isDisabled={props.isDisabled}
+                  isActive={props.isActive}
+                  overrideBorderColor={props.overrideBorderColor}
                 >
-                  <ChakraPopover.Trigger asChild>
-                    <CalendarTriggerButton
-                      paddingLeft={1}
-                      paddingRight={1}
-                      variant={variant}
-                      ref={ref}
-                      {...buttonProps}
-                    />
-                  </ChakraPopover.Trigger>
+                  {props.noCalendar ? (
+                    <Box pr={3} pl={0.5} mr={0.5}>
+                      <CalendarOutline24Icon />
+                    </Box>
+                  ) : (
+                    <ChakraPopover.Trigger asChild>
+                      <CalendarTriggerButton
+                        paddingLeft={1}
+                        paddingRight={1}
+                        variant={variant}
+                        ref={ref}
+                        {...buttonProps}
+                      />
+                    </ChakraPopover.Trigger>
+                  )}
+
                   <DateField
                     label={props.label}
                     labelProps={labelProps}
@@ -159,10 +173,15 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
               </PopoverAnchor>
             </Field>
 
-            {state.isOpen && !props.isDisabled && withPortal && (
-              <Portal>{popoverContent}</Portal>
-            )}
-            {state.isOpen && !props.isDisabled && !withPortal && popoverContent}
+            {state.isOpen &&
+              !props.isDisabled &&
+              withPortal &&
+              !props.noCalendar && <Portal>{popoverContent}</Portal>}
+            {state.isOpen &&
+              !props.isDisabled &&
+              !withPortal &&
+              !props.noCalendar &&
+              popoverContent}
           </ChakraPopover.Root>
         </Box>
       </I18nProvider>

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -39,15 +39,13 @@ export const StyledField = forwardRef<HTMLDivElement, StyledFieldProps>(
     return (
       <Box
         {...otherProps}
-        css={{
-          ...styles.wrapper,
-          ...(isActive
-            ? {
-                outline: "2px solid",
-                outlineColor: overrideBorderColor ?? "outline.focus",
-              }
-            : {}),
-        }}
+        css={styles.wrapper}
+        data-active={isActive ? "" : undefined}
+        style={
+          overrideBorderColor
+            ? { outlineColor: overrideBorderColor }
+            : undefined
+        }
         ref={ref}
         aria-invalid={invalid}
         aria-disabled={isDisabled}

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -14,10 +14,19 @@ type StyledFieldProps = BoxProps &
   PropsWithChildren<DatePickerVariantProps> &
   CalendarVariants & {
     isDisabled?: boolean;
+    isActive?: boolean;
+    overrideBorderColor?: string;
   };
 export const StyledField = forwardRef<HTMLDivElement, StyledFieldProps>(
   function StyledField(props, ref) {
-    const { children, variant, isDisabled, ...otherProps } = props;
+    const {
+      children,
+      variant,
+      isDisabled,
+      isActive,
+      overrideBorderColor,
+      ...otherProps
+    } = props;
     const { invalid } = useFieldContext() ?? {
       isInvalid: false,
     };
@@ -30,7 +39,15 @@ export const StyledField = forwardRef<HTMLDivElement, StyledFieldProps>(
     return (
       <Box
         {...otherProps}
-        css={styles.wrapper}
+        css={{
+          ...styles.wrapper,
+          ...(isActive
+            ? {
+                outline: "2px solid",
+                outlineColor: overrideBorderColor ?? "outline.focus",
+              }
+            : {}),
+        }}
         ref={ref}
         aria-invalid={invalid}
         aria-disabled={isDisabled}

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -28,6 +28,10 @@ export const datePickerSlotRecipe = defineSlotRecipe({
         outline: "2px solid",
         outlineColor: "outline.focus",
       },
+      "&[data-active]": {
+        outline: "2px solid",
+        outlineColor: "outline.focus",
+      },
     },
     inputLabel: {
       fontSize: "mobile.xs",


### PR DESCRIPTION
## Background
Vi trenger en måte å bruke datepicker litt annerledes i lavpriskalenderen. Så det må være mulig å hindre kalendermodalen og å styre om den skal ha fokusringen.


## Solution

- La til isActive prop, slik at den kan styres eksternt.
- La til noCalendar prop, slik at vi kan forhindre kalenderen fra å poppe opp
