### PR TITLE
Semantic color token for icons

### DIFF
--- a/.changeset/modern-jeans-refuse.md
+++ b/.changeset/modern-jeans-refuse.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react-native": patch
+---
+
+Switched the default icon color in React Native to use a semantic color token.

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -148,7 +148,7 @@ async function generateComponent(iconData: IconData) {
   jsCode = "import { Box, useTheme } from 'app/spor';\n" + jsCode;
   jsCode = jsCode
     .replace("{...props}", "")
-    .replace("props", '{ color = "darkGrey", width, height, ...props }')
+    .replace("props", '{ color = "icon.default", width, height, ...props }')
     // Weird regex alert!
     // Replaces `width={18}` with
     // `width={props.style?.width ?? width ?? 18}`


### PR DESCRIPTION
## Background

The React Native icons need support for dark mode. Therefore the default value should be a semantic color token.

## Solution

Changed to a semantic color token. 

---

## General Checklist

- [x] I have updated documentation if necessary
- [x] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

Will behave as the icon next to "Utviklerverktøy":
https://github.com/user-attachments/assets/1875507a-9f95-4b9b-9946-9c71e3176440


