### PR TITLE
chore(datepicker): exposed onClick & changed hover style to be focus color when isActive=true

### DIFF
--- a/.changeset/chatty-drinks-prove.md
+++ b/.changeset/chatty-drinks-prove.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+datepicker - exposed onClick & changed hover style to be focus color when isActive=true

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -46,6 +46,7 @@ type DatePickerProps = Omit<AriaDatePickerProps<DateValue>, "onChange"> &
     noCalendar?: boolean;
     overrideBorderColor?: string;
     isActive?: boolean;
+    onClick?: () => void;
   } & FieldBaseProps;
 
 /**
@@ -105,8 +106,10 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       state.isOpen && !props.isDisabled && !props.noCalendar;
 
     const onFieldClick = () => {
-      if (props.noCalendar) return;
-      state.setOpen(true);
+      if (!props.noCalendar) {
+        state.setOpen(true);
+      }
+      props.onClick?.();
     };
 
     const popoverContent = (
@@ -143,7 +146,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
               <PopoverAnchor>
                 <StyledField
                   variant={variant}
-                  onClick={props.noCalendar ? undefined : onFieldClick}
+                  onClick={onFieldClick}
                   paddingX={3}
                   minHeight={minHeight}
                   isDisabled={props.isDisabled}

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -39,13 +39,15 @@ export const StyledField = forwardRef<HTMLDivElement, StyledFieldProps>(
     return (
       <Box
         {...otherProps}
-        css={styles.wrapper}
+        css={{
+          ...styles.wrapper,
+          ...(overrideBorderColor
+            ? {
+                outlineColor: overrideBorderColor,
+              }
+            : {}),
+        }}
         data-active={isActive ? "" : undefined}
-        style={
-          overrideBorderColor
-            ? { outlineColor: overrideBorderColor }
-            : undefined
-        }
         ref={ref}
         aria-invalid={invalid}
         aria-disabled={isDisabled}

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -41,14 +41,7 @@ export const StyledField = forwardRef<HTMLDivElement, StyledFieldProps>(
         {...otherProps}
         css={{
           ...styles.wrapper,
-          ...(overrideBorderColor
-css={{
-  ...styles.wrapper,
-  outlineColor: overrideBorderColor || undefined,
-}}
-                outlineColor: overrideBorderColor,
-              }
-            : {}),
+          outlineColor: overrideBorderColor || undefined,
         }}
         data-active={isActive ? "" : undefined}
         ref={ref}

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -42,7 +42,10 @@ export const StyledField = forwardRef<HTMLDivElement, StyledFieldProps>(
         css={{
           ...styles.wrapper,
           ...(overrideBorderColor
-            ? {
+css={{
+  ...styles.wrapper,
+  outlineColor: overrideBorderColor || undefined,
+}}
                 outlineColor: overrideBorderColor,
               }
             : {}),

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -169,7 +169,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
             "&[data-active]": {
               outline: "2px solid",
               outlineColor: "outline.focus",
-              "&:hover": {
+              _hover: {
                 outlineColor: "outline.focus",
               },
             },
@@ -202,7 +202,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
             "&[data-active]": {
               outline: "2px solid",
               outlineColor: "outline.focus",
-              "&:hover": {
+              _hover: {
                 outlineColor: "outline.focus",
               },
             },
@@ -227,7 +227,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
             "&[data-active]": {
               outline: "2px solid",
               outlineColor: "outline.focus",
-              "&:hover": {
+              _hover: {
                 outlineColor: "outline.focus",
               },
             },

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -165,6 +165,14 @@ export const datePickerSlotRecipe = defineSlotRecipe({
               outline: "1px solid",
               outlineColor: "core.outline",
             },
+
+            "&[data-active]": {
+              outline: "2px solid",
+              outlineColor: "outline.focus",
+              "&:hover": {
+                outlineColor: "outline.focus",
+              },
+            },
           },
           _invalid: {
             outline: "2px solid",
@@ -190,6 +198,14 @@ export const datePickerSlotRecipe = defineSlotRecipe({
               outline: "1px solid",
               outlineColor: "core.outline",
             },
+
+            "&[data-active]": {
+              outline: "2px solid",
+              outlineColor: "outline.focus",
+              "&:hover": {
+                outlineColor: "outline.focus",
+              },
+            },
           },
           _invalid: {
             outline: "2px solid",
@@ -206,6 +222,14 @@ export const datePickerSlotRecipe = defineSlotRecipe({
               backgroundColor: "ghost.surface.active",
               outline: "1px solid",
               outlineColor: "core.outline",
+            },
+
+            "&[data-active]": {
+              outline: "2px solid",
+              outlineColor: "outline.focus",
+              "&:hover": {
+                outlineColor: "outline.focus",
+              },
             },
           },
           _invalid: {

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -31,6 +31,9 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       "&[data-active]": {
         outline: "2px solid",
         outlineColor: "outline.focus",
+        "&:hover": {
+          outlineColor: "outline.focus",
+        },
       },
     },
     inputLabel: {


### PR DESCRIPTION
## Background
We need a way to set onClick for the new lowfare calendar
Also, changed the hover outline color to be the focus color when hovering in isActive mode (to make it clear that you actually "toggeled" if enabled by click
