### PR TITLE
fix(dialog): Adjust height for modal cover for better scroll handling

### DIFF
--- a/.changeset/beige-ears-deny.md
+++ b/.changeset/beige-ears-deny.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix cover modal not handling overflow with scroll

--- a/packages/spor-react/src/theme/slot-recipes/dialog.ts
+++ b/packages/spor-react/src/theme/slot-recipes/dialog.ts
@@ -97,11 +97,8 @@ export const dialogSlotRecipe = defineSlotRecipe({
   variants: {
     placement: {
       center: {
-        positioner: {
-          alignItems: "center",
-        },
         content: {
-          marginX: "auto",
+          margin: "auto",
         },
       },
       top: {
@@ -179,10 +176,9 @@ export const dialogSlotRecipe = defineSlotRecipe({
         },
         content: {
           width: "100%",
-          height: "100%",
+          minHeight: "100%",
           "--dialog-margin": "0",
           margin: "0",
-          overflow: "auto",
         },
       },
     },

--- a/packages/spor-react/src/theme/slot-recipes/dialog.ts
+++ b/packages/spor-react/src/theme/slot-recipes/dialog.ts
@@ -182,6 +182,7 @@ export const dialogSlotRecipe = defineSlotRecipe({
           height: "100%",
           "--dialog-margin": "0",
           margin: "0",
+          overflow: "auto",
         },
       },
     },


### PR DESCRIPTION
## Background

Closes #1919

## General Checklist

- [X] I have updated documentation if necessary
- [X] I have verified the design aligns with the latest Figma sketches.
- [X] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [X] It is possible to use the keyboard to reach your changes
- [X] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [X] It works with VoiceOver
- [X] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|    <img width="714" height="466" alt="image" src="https://github.com/user-attachments/assets/fc71b5ae-78f5-4f68-ada9-634a11bb8d64" />    |    <img width="714" height="466" alt="image" src="https://github.com/user-attachments/assets/7b6b7360-0c47-4f8d-9d5a-9b291de8854a" />   |
