### PR TITLE
fix(UI): Correct padding and overflow issue with ServiceAlert on phone screens. Also adjust some stylings that are inconsistent with figma. 

### DIFF
--- a/.changeset/every-walls-serve.md
+++ b/.changeset/every-walls-serve.md
@@ -2,4 +2,6 @@
 "@vygruppen/spor-react": patch
 ---
 
-asdasd
+Resolved padding and overflow issues in the ServiceAlert component
+
+Also adjust some stylings that were inconsistent with figma for other components.

--- a/.changeset/every-walls-serve.md
+++ b/.changeset/every-walls-serve.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+asdasd

--- a/packages/spor-react/src/alert/ServiceAlert.tsx
+++ b/packages/spor-react/src/alert/ServiceAlert.tsx
@@ -127,7 +127,7 @@ export const ServiceAlert = forwardRef<HTMLDivElement, ServiceAlertProps>(
           </Accordion.ItemTrigger>
 
           <Accordion.ItemContent css={styles.itemContent}>
-            <Accordion.ItemBody width={contentWidth} css={styles.itemBody}>
+            <Accordion.ItemBody maxWidth={contentWidth} css={styles.itemBody}>
               {children}
             </Accordion.ItemBody>
           </Accordion.ItemContent>

--- a/packages/spor-react/src/alert/ServiceAlert.tsx
+++ b/packages/spor-react/src/alert/ServiceAlert.tsx
@@ -6,7 +6,6 @@ import {
   HStack,
   RecipeVariantProps,
   Span,
-  Stack,
   Text,
   useSlotRecipe,
 } from "@chakra-ui/react";
@@ -127,16 +126,10 @@ export const ServiceAlert = forwardRef<HTMLDivElement, ServiceAlertProps>(
             </HStack>
           </Accordion.ItemTrigger>
 
-          <Accordion.ItemContent asChild>
-            <Stack flexDirection="row" width="100%">
-              <Accordion.ItemBody
-                as={Stack}
-                width={contentWidth}
-                css={styles.itemBody}
-              >
-                {children}
-              </Accordion.ItemBody>
-            </Stack>
+          <Accordion.ItemContent css={styles.itemContent}>
+            <Accordion.ItemBody width={contentWidth} css={styles.itemBody}>
+              {children}
+            </Accordion.ItemBody>
           </Accordion.ItemContent>
         </Accordion.Item>
       </Accordion.Root>

--- a/packages/spor-react/src/datepicker/CalendarHeader.tsx
+++ b/packages/spor-react/src/datepicker/CalendarHeader.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box, Flex } from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/react";
 import { getLocalTimeZone } from "@internationalized/date";
 import {
   ArrowLeftOutline24Icon,

--- a/packages/spor-react/src/datepicker/CalendarHeader.tsx
+++ b/packages/spor-react/src/datepicker/CalendarHeader.tsx
@@ -7,6 +7,8 @@ import {
 } from "@vygruppen/spor-icon-react";
 import { CalendarState, RangeCalendarState } from "react-stately";
 
+import { Text } from "@/typography";
+
 import { createTexts, useTranslation } from "../i18n";
 import { CalendarNavigationButton } from "./CalendarNavigationButton";
 import { useCurrentLocale } from "./utils";
@@ -103,16 +105,16 @@ export const CalendarNavigator = ({
         icon={<ArrowLeftOutline24Icon />}
         aria-label={`${t(texts.previous)} ${t(texts[unit])}`}
       />
-      <Box
+      <Text
         role="heading"
-        fontSize="sm"
+        variant="md"
         fontWeight="bold"
         flex="1"
         textAlign="center"
         color={"core.text"}
       >
         {capitalize(title)}
-      </Box>
+      </Text>
       <CalendarNavigationButton
         onPress={onNext}
         isDisabled={isNextDisabled}

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -63,11 +63,7 @@ export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
             position="absolute"
             paddingTop="2px"
           >
-            <Label
-              padding="0"
-              fontSize={["mobile.xs", "desktop.xs"]}
-              {...props.labelProps}
-            >
+            <Label padding="0" {...props.labelProps}>
               {props.label} <Field.RequiredIndicator />
             </Label>
           </Box>

--- a/packages/spor-react/src/input/Field.tsx
+++ b/packages/spor-react/src/input/Field.tsx
@@ -104,7 +104,7 @@ export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
           )}
         </ChakraField.Root>
         {helperText && (
-          <Text fontSize="sm" color="text.tertiary">
+          <Text variant="sm" color="text.tertiary">
             {helperText}
           </Text>
         )}

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -127,7 +127,11 @@ export function ItemDescription({ children }: { children: React.ReactNode }) {
   const recipe = useSlotRecipe({ key: "listbox" });
   const styles = recipe({});
   return (
-    <Box {...descriptionProps} css={styles} fontSize={"xs"}>
+    <Box
+      {...descriptionProps}
+      css={styles}
+      fontSize={["mobile.xs", "desktop.xs"]}
+    >
       {children}
     </Box>
   );
@@ -233,7 +237,7 @@ function ListBoxSection({ section, state }: ListBoxSectionProps) {
       >
         {section.rendered && (
           <Box
-            fontSize="mobile.xs"
+            fontSize={["mobile.sm", "desktop.sm"]}
             color={titleColor}
             paddingTop={1}
             marginTop={isFirstSection ? 0 : 2}
@@ -242,7 +246,7 @@ function ListBoxSection({ section, state }: ListBoxSectionProps) {
             fontWeight="bold"
             {...headingProps}
           >
-            {section.rendered}
+            {section.rendered} 123
           </Box>
         )}
         <List {...groupProps} padding={0} listStyleType="none">

--- a/packages/spor-react/src/input/ListBox.tsx
+++ b/packages/spor-react/src/input/ListBox.tsx
@@ -246,7 +246,7 @@ function ListBoxSection({ section, state }: ListBoxSectionProps) {
             fontWeight="bold"
             {...headingProps}
           >
-            {section.rendered} 123
+            {section.rendered}
           </Box>
         )}
         <List {...groupProps} padding={0} listStyleType="none">

--- a/packages/spor-react/src/stepper/StepperStep.tsx
+++ b/packages/spor-react/src/stepper/StepperStep.tsx
@@ -44,7 +44,6 @@ export const StepperStep = ({
       {disabled ? (
         <Text
           variant="xs"
-          fontSize="1rem"
           color={disabledTextColor}
           cursor="default"
           paddingX={2}

--- a/packages/spor-react/src/theme/slot-recipes/accordion.ts
+++ b/packages/spor-react/src/theme/slot-recipes/accordion.ts
@@ -22,13 +22,13 @@ export const accordionSlotRecipe = defineSlotRecipe({
       textAlign: "left",
       width: "full",
       alignItems: "center",
-      fontSize: ["mobile.sm", null, "desktop.sm"],
+      fontSize: ["mobile.sm", "desktop.sm"],
       fontFamily: "body",
       fontWeight: "bold",
       outlineOffset: "-2px",
-      paddingX: [2, null, 3],
-      paddingY: [1, null, 1.5],
-      minHeight: [6, null, 7],
+      paddingX: [2, 3],
+      paddingY: [1, 1.5],
+      minHeight: [6, 7],
       cursor: "pointer",
       _disabled: {
         pointerEvents: "none",
@@ -37,7 +37,7 @@ export const accordionSlotRecipe = defineSlotRecipe({
     },
     itemContent: {
       borderBottomRadius: "sm",
-      fontSize: ["mobile.sm", null, "desktop.sm"],
+      fontSize: ["mobile.sm", "desktop.sm"],
       color: "text",
       height: "auto",
       overflow: "hidden",
@@ -52,7 +52,7 @@ export const accordionSlotRecipe = defineSlotRecipe({
     },
     itemBody: {
       paddingY: 2,
-      paddingX: [2, null, 3],
+      paddingX: [2, 3],
     },
     itemIndicator: {
       transition: "rotate 0.2s",

--- a/packages/spor-react/src/theme/slot-recipes/alert-service.ts
+++ b/packages/spor-react/src/theme/slot-recipes/alert-service.ts
@@ -22,7 +22,8 @@ export const alertServiceSlotRecipe = defineSlotRecipe({
       display: "flex",
       flexDirection: "column",
       justifyContent: "center",
-      padding: [2, null, null, 2],
+      padding: ["2", "3"],
+      paddingBottom: "1",
       borderBottomRadius: "md",
       borderTopRadius: "none",
       width: "full",
@@ -39,27 +40,41 @@ export const alertServiceSlotRecipe = defineSlotRecipe({
       },
     },
     itemTriggerTitle: {
-      fontSize: ["xs", null, null, "sm"],
+      fontSize: ["mobile.sm", "desktop.sm"],
     },
     notificationText: {
       fontWeight: "400",
-      fontSize: ["2xs", null, null, "xs"],
+      fontSize: ["mobile.xs", "desktop.xs"],
       textWrap: "nowrap",
+      color: "alert.service.text.secondary",
     },
+
+    itemContent: {
+      paddingX: ["2", "3"],
+      paddingBottom: ["2", "3"],
+      paddingTop: ["1", "2"],
+    },
+
     itemBody: {
       marginX: "auto",
       padding: "0 !important",
-      paddingBottom: ["0.5", null, null, "1"],
-      color: "text.inverted",
+      color: "alert.service.text.secondary",
+      gap: 0,
+      flexDirection: "column",
+      display: "flex",
       "& > p": {
-        gap: 2,
         width: "full",
         borderBottom: "1px dashed",
         borderColor: "outline.inverted",
-        paddingBottom: "3",
-        paddingTop: "2",
+
+        paddingY: ["1", "1.5"],
+
+        _first: {
+          paddingTop: 0,
+        },
         _last: {
           borderBottom: "none",
+          paddingBottom: 0,
         },
       },
     },

--- a/packages/spor-react/src/theme/slot-recipes/choice-chip.ts
+++ b/packages/spor-react/src/theme/slot-recipes/choice-chip.ts
@@ -10,7 +10,6 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
       display: "inline-flex",
       alignItems: "center",
       boxAlign: "center",
-      fontSize: "xs",
       cursor: "pointer",
       transitionProperty: "all",
       borderRadius: "xl",
@@ -69,7 +68,6 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
       display: "flex",
       alignItems: "center",
       gap: "1",
-      fontSize: "xs",
     },
   },
 
@@ -83,6 +81,10 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
           height: 5,
           paddingX: 1.5,
         },
+        label: {
+          fontSize: { base: "mobile.sm", sm: "desktop.sm" },
+          fontWeight: "medium",
+        },
       },
       sm: {
         root: {
@@ -91,6 +93,10 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
           },
           height: 6,
           paddingX: 2,
+        },
+        label: {
+          fontSize: { base: "mobile.sm", sm: "desktop.sm" },
+          fontWeight: "bold",
         },
       },
       md: {
@@ -101,6 +107,10 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
           height: 7,
           paddingX: 2,
         },
+        label: {
+          fontSize: { base: "mobile.md", sm: "desktop.md" },
+          fontWeight: "bold",
+        },
       },
       lg: {
         root: {
@@ -109,6 +119,10 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
           },
           height: 8,
           paddingX: 3,
+        },
+        label: {
+          fontSize: { base: "mobile.md", sm: "desktop.md" },
+          fontWeight: "bold",
         },
       },
     },
@@ -176,7 +190,7 @@ export const choiceChipSlotRecipe = defineSlotRecipe({
   },
 
   defaultVariants: {
-    size: "md",
+    size: "sm",
     variant: "core",
     chipType: "choice",
   },

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -37,7 +37,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       },
     },
     inputLabel: {
-      fontSize: "mobile.xs",
+      fontSize: ["mobile.xs", "desktop.xs"],
       margin: 0,
       cursor: "text",
     },


### PR DESCRIPTION
## Background

Closes #1929

## Screenshots

| Before | After |
| ------ | ----- |
|     <img width="238" height="103" alt="image" src="https://github.com/user-attachments/assets/7c474335-6e10-42ba-a20b-b2cdc85ca281" />   |    <img width="272" height="181" alt="image" src="https://github.com/user-attachments/assets/fd5a23e1-950c-4ade-a7df-51a6b5a92185" />   |
