### PR TITLE
fix(UI): Correct icon color for alt-transport LineTags.

### DIFF
--- a/.changeset/silent-experts-cry.md
+++ b/.changeset/silent-experts-cry.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Correct icon color for alt-transport LineTags.

--- a/packages/spor-react/src/theme/slot-recipes/line-icon.ts
+++ b/packages/spor-react/src/theme/slot-recipes/line-icon.ts
@@ -74,6 +74,10 @@ export const lineIconSlotRecipe = defineSlotRecipe({
         iconContainer: {
           backgroundColor: "linjetag.altTransport",
         },
+        icon: {
+          // eslint-disable-next-line spor/use-semantic-tokens
+          color: "darkGrey",
+        },
       },
       walk: {
         title: {


### PR DESCRIPTION
## Background

Closes #1918

## Solution

Adjust recipe

## General Checklist

- [X] I have updated documentation if necessary
- [X] I have verified the design aligns with the latest Figma sketches.
- [X] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [X] It is possible to use the keyboard to reach your changes
- [X] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [X] It works with VoiceOver
- [X] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|     <img width="206" height="53" alt="image" src="https://github.com/user-attachments/assets/7d1c440c-db88-42b7-a1fd-171a8d12ac60" />   |    <img width="206" height="53" alt="image" src="https://github.com/user-attachments/assets/1f17a8db-e6f9-4f03-b0c0-50ee1a53fccd" />   |
