### PR TITLE
fix(build): Correct path for native icons main file 

### DIFF
--- a/.changeset/fuzzy-spoons-knock.md
+++ b/.changeset/fuzzy-spoons-knock.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react-native": patch
+---
+
+Fix path for main file

--- a/packages/spor-icon-react-native/package.json
+++ b/packages/spor-icon-react-native/package.json
@@ -2,7 +2,7 @@
   "name": "@vygruppen/spor-icon-react-native",
   "version": "2.15.4",
   "type": "module",
-  "main": "./dist/index.mjs",
+  "main": "./dist/index.js",
   "types": "./dist/types.d.ts",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
## Background

```
Error: While trying to resolve module `@vygruppen/spor-icon-react-native` from file `/Users/ane.rake/Projects/VY/salgsapp-react-native/app/screens/deviation-sweden/SwedishTrainDeviationScreen.tsx`, the package `/Users/ane.rake/Projects/VY/salgsapp-react-native/node_modules/@vygruppen/spor-icon-react-native/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/ane.rake/Projects/VY/salgsapp-react-native/node_modules/@vygruppen/spor-icon-react-native/dist/index.mjs`. Indeed, none of these files exist:
  * /Users/ane.rake/Projects/VY/salgsapp-react-native/node_modules/@vygruppen/spor-icon-react-native/dist/index.mjs(.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx|.ios.mjs|.native.mjs|.mjs|.ios.js|.native.js|.js|.ios.jsx|.native.jsx|.jsx|.ios.json|.native.json|.json|.ios.cjs|.native.cjs|.cjs|.ios.scss|.native.scss|.scss|.ios.sass|.native.sass|.sass|.ios.css|.native.css|.css)
  * /Users/ane.rake/Projects/VY/salgsapp-react-native/node_modules/@vygruppen/spor-icon-react-native/dist/index.mjs/index(.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx|.ios.mjs|.native.mjs|.mjs|.ios.js|.native.js|.js|.ios.jsx|.native.jsx|.jsx|.ios.json|.native.json|.json|.ios.cjs|.native.cjs|.cjs|.ios.scss|.native.scss|.scss|.ios.sass|.native.sass|.sass|.ios.css|.native.css|.css)
```

## Solution

Package.json was pointing to main.mjs, but in dist main.js was generated. Update path. 