### PR TITLE
fix(Switch): Prevent empty space when switch has no label

### DIFF
--- a/.changeset/light-melons-strive.md
+++ b/.changeset/light-melons-strive.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix issue where switch without label has empty space on right

--- a/packages/spor-react/src/input/Switch.tsx
+++ b/packages/spor-react/src/input/Switch.tsx
@@ -78,7 +78,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
           <ChakraSwitch.Control css={styles.control}>
             <ChakraSwitch.Thumb />
           </ChakraSwitch.Control>
-          <ChakraSwitch.Label>{label}</ChakraSwitch.Label>
+          {label && <ChakraSwitch.Label>{label}</ChakraSwitch.Label>}
         </ChakraSwitch.Root>
       </Field>
     );


### PR DESCRIPTION
## Background

Closes #1927

## Solution

Conditionally render label

## General Checklist

- [X] I have updated documentation if necessary
- [X] I have verified the design aligns with the latest Figma sketches.
- [X] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [X] It is possible to use the keyboard to reach your changes
- [X] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [X] It works with VoiceOver
- [X] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|      <img width="371" height="77" alt="image" src="https://github.com/user-attachments/assets/fd228f0c-0541-4f01-8944-d92cec2a837c" />  | <img width="266" height="77" alt="image" src="https://github.com/user-attachments/assets/a2f28aef-3014-401b-9447-8b08861d1e1e" /> |
