### PR TITLE
fix(FullScreenDrawer): Button placements and overflow in header

### DIFF
--- a/.changeset/twenty-sites-swim.md
+++ b/.changeset/twenty-sites-swim.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix layout on full screen drawer header.

--- a/packages/spor-react/src/button/ResponsiveButton.tsx
+++ b/packages/spor-react/src/button/ResponsiveButton.tsx
@@ -13,7 +13,7 @@ type Props = IconButtonProps &
 export const ResponsiveButton = ({ label, ...props }: Props) => {
   return (
     <>
-      <Button display={["none", "flex"]} {...props} leftIcon={props.icon}>
+      <Button display={["none", "flex"]} leftIcon={props.icon} {...props}>
         {label}
       </Button>
       <IconButton display={["flex", "none"]} aria-label={label} {...props} />

--- a/packages/spor-react/src/button/ResponsiveButton.tsx
+++ b/packages/spor-react/src/button/ResponsiveButton.tsx
@@ -10,13 +10,18 @@ type Props = IconButtonProps &
     label: string;
   };
 
-export const ResponsiveButton = ({ label, ...props }: Props) => {
+export const ResponsiveButton = ({ label, icon, ...props }: Props) => {
   return (
     <>
-      <Button display={["none", "flex"]} leftIcon={props.icon} {...props}>
+      <Button display={["none", "flex"]} leftIcon={icon} {...props}>
         {label}
       </Button>
-      <IconButton display={["flex", "none"]} aria-label={label} {...props} />
+      <IconButton
+        display={["flex", "none"]}
+        aria-label={label}
+        icon={icon}
+        {...props}
+      />
     </>
   );
 };

--- a/packages/spor-react/src/button/ResponsiveButton.tsx
+++ b/packages/spor-react/src/button/ResponsiveButton.tsx
@@ -1,0 +1,22 @@
+import { Button, ButtonProps } from "./Button";
+import { IconButton, IconButtonProps } from "./IconButton";
+
+/**
+ * For internal use
+ */
+
+type Props = IconButtonProps &
+  Omit<ButtonProps, "leftIcon" | "rightIcon"> & {
+    label: string;
+  };
+
+export const ResponsiveButton = ({ label, ...props }: Props) => {
+  return (
+    <>
+      <Button display={["none", "flex"]} {...props} leftIcon={props.icon}>
+        {label}
+      </Button>
+      <IconButton display={["flex", "none"]} aria-label={label} {...props} />
+    </>
+  );
+};

--- a/packages/spor-react/src/dialog/Drawer.tsx
+++ b/packages/spor-react/src/dialog/Drawer.tsx
@@ -154,7 +154,7 @@ export const DrawerFullScreenHeader = forwardRef<
     <ChakraDrawer.Header {...props} ref={ref}>
       {backTrigger && <DrawerBackTrigger />}
       {children && <DrawerTitle>{children}</DrawerTitle>}
-      {closeTrigger && <DrawerCloseTrigger justifySelf="end" top="0" />}
+      {closeTrigger && <DrawerCloseTrigger />}
     </ChakraDrawer.Header>
   );
 });

--- a/packages/spor-react/src/dialog/Drawer.tsx
+++ b/packages/spor-react/src/dialog/Drawer.tsx
@@ -16,7 +16,7 @@ import { useSwipeable } from "react-swipeable";
 
 import { ResponsiveButton } from "@/button/ResponsiveButton";
 
-import { Button, CloseButton } from "../button";
+import { CloseButton } from "../button";
 import { createTexts, useTranslation } from "../i18n";
 import {
   DrawerContentProps,

--- a/packages/spor-react/src/dialog/Drawer.tsx
+++ b/packages/spor-react/src/dialog/Drawer.tsx
@@ -4,8 +4,6 @@ import {
   Box,
   createContext,
   Drawer as ChakraDrawer,
-  Grid,
-  GridItem,
   Portal,
   useDialogContext,
 } from "@chakra-ui/react";
@@ -15,6 +13,8 @@ import {
 } from "@vygruppen/spor-icon-react";
 import { forwardRef } from "react";
 import { useSwipeable } from "react-swipeable";
+
+import { ResponsiveButton } from "@/button/ResponsiveButton";
 
 import { Button, CloseButton } from "../button";
 import { createTexts, useTranslation } from "../i18n";
@@ -116,9 +116,11 @@ export const DrawerCloseTrigger = forwardRef<
   return (
     <ChakraDrawer.CloseTrigger ref={ref} {...props} asChild>
       {size === "full" ? (
-        <Button variant="ghost" leftIcon={<CloseFill24Icon />}>
-          {t(texts.close)}
-        </Button>
+        <ResponsiveButton
+          variant="ghost"
+          icon={<CloseFill24Icon />}
+          label={t(texts.close)}
+        />
       ) : (
         <CloseButton size="md" />
       )}
@@ -132,10 +134,12 @@ export const DrawerBackTrigger = forwardRef<
 >((props, ref) => {
   const { t } = useTranslation();
   return (
-    <ChakraDrawer.CloseTrigger asChild {...props} ref={ref} top="0">
-      <Button variant="ghost" leftIcon={<ArrowLeftFill24Icon />}>
-        {t(texts.back)}
-      </Button>
+    <ChakraDrawer.CloseTrigger asChild {...props} ref={ref}>
+      <ResponsiveButton
+        variant="ghost"
+        icon={<ArrowLeftFill24Icon />}
+        label={t(texts.back)}
+      />
     </ChakraDrawer.CloseTrigger>
   );
 });
@@ -147,20 +151,10 @@ export const DrawerFullScreenHeader = forwardRef<
 >((props, ref) => {
   const { backTrigger = true, closeTrigger = true, children } = props;
   return (
-    <ChakraDrawer.Header {...props} ref={ref} asChild>
-      <Grid templateColumns="1fr auto 1fr" height="auto" paddingX="8">
-        <GridItem width="full" alignSelf="center">
-          {backTrigger && <DrawerBackTrigger />}
-        </GridItem>
-        <GridItem width="full" alignSelf="end" asChild>
-          {children && <DrawerTitle>{children}</DrawerTitle>}
-        </GridItem>
-        {closeTrigger && (
-          <GridItem width="full" alignSelf="end">
-            <DrawerCloseTrigger justifySelf="end" top="0" />
-          </GridItem>
-        )}
-      </Grid>
+    <ChakraDrawer.Header {...props} ref={ref}>
+      {backTrigger && <DrawerBackTrigger />}
+      {children && <DrawerTitle>{children}</DrawerTitle>}
+      {closeTrigger && <DrawerCloseTrigger justifySelf="end" top="0" />}
     </ChakraDrawer.Header>
   );
 });

--- a/packages/spor-react/src/dialog/Drawer.tsx
+++ b/packages/spor-react/src/dialog/Drawer.tsx
@@ -152,9 +152,9 @@ export const DrawerFullScreenHeader = forwardRef<
   const { backTrigger = true, closeTrigger = true, children } = props;
   return (
     <ChakraDrawer.Header {...props} ref={ref}>
-      {backTrigger && <DrawerBackTrigger />}
-      {children && <DrawerTitle>{children}</DrawerTitle>}
-      {closeTrigger && <DrawerCloseTrigger />}
+      <Box>{backTrigger && <DrawerBackTrigger />}</Box>
+      {<DrawerTitle>{children}</DrawerTitle>}
+      <Box> {closeTrigger && <DrawerCloseTrigger />}</Box>
     </ChakraDrawer.Header>
   );
 });

--- a/packages/spor-react/src/theme/slot-recipes/drawer.ts
+++ b/packages/spor-react/src/theme/slot-recipes/drawer.ts
@@ -59,7 +59,9 @@ export const drawerSlotRecipe = defineSlotRecipe({
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
-      paddingX: ["3", null, null, "5"],
+      paddingX: ["2", null, null, "5"],
+
+      gap: "1",
       paddingBottom: "1",
     },
     body: {

--- a/packages/spor-react/src/theme/slot-recipes/drawer.ts
+++ b/packages/spor-react/src/theme/slot-recipes/drawer.ts
@@ -60,7 +60,6 @@ export const drawerSlotRecipe = defineSlotRecipe({
       alignItems: "center",
       justifyContent: "space-between",
       paddingX: ["2", null, null, "5"],
-
       gap: "1",
       paddingBottom: "1",
     },


### PR DESCRIPTION
## Background

Closes #1935

## Solution

Rewrite layout logic. Make buttons responsive, so only icons on mobile. As in Figma.

## General Checklist

- [X] I have updated documentation if necessary
- [X] I have verified the design aligns with the latest Figma sketches.
- [X] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [X] It is possible to use the keyboard to reach your changes
- [X] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [X] It works with VoiceOver
- [X] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|   <img width="396" height="698" alt="image" src="https://github.com/user-attachments/assets/e7f7fcc7-bb94-4efc-b2ac-c208de33c467" />     |      <img width="396" height="698" alt="image" src="https://github.com/user-attachments/assets/8cd94e74-2b98-4331-86ee-5d20727149de" /> |
