### PR TITLE
fix(CalendarCell): prevent form submission by setting button type

### DIFF
--- a/.changeset/major-badgers-act.md
+++ b/.changeset/major-badgers-act.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Prevent calendar cell button from performing form submittion by setting type to button.

--- a/packages/spor-react/src/datepicker/CalendarCell.tsx
+++ b/packages/spor-react/src/datepicker/CalendarCell.tsx
@@ -11,6 +11,8 @@ import { PropsWithChildren, useEffect, useRef } from "react";
 import { useCalendarCell } from "react-aria";
 import { CalendarState, RangeCalendarState } from "react-stately";
 
+import { spor } from "@/util";
+
 import { DatePickerVariantProps } from "./DatePicker";
 import { CalendarVariants } from "./types";
 
@@ -72,10 +74,13 @@ export function CalendarCell({
     );
   }, []);
 
+  console.log(buttonProps);
+  console.log(stateProps);
+
   return (
     <Box as="td" {...cellProps} textAlign="center" css={styles.cell}>
-      <Box
-        as="button"
+      <spor.button
+        type="button" // Prevents form submission
         {...buttonProps}
         {...stateProps}
         ref={ref}
@@ -83,7 +88,7 @@ export function CalendarCell({
         hidden={isOutsideVisibleRange}
       >
         {date.day}
-      </Box>
+      </spor.button>
     </Box>
   );
 }


### PR DESCRIPTION
## Background

Closes #1844


## Solution

prevent form submission by setting button type to "button"

## General Checklist

- [X] I have updated documentation if necessary
- [X] I have verified the design aligns with the latest Figma sketches.
- [X] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [X] It is possible to use the keyboard to reach your changes
- [X] It is possible to enlarge the text 400% without losing functionality
- [X] It works on both mobile and desktop
- [X] It works in both Chrome, Safari and Firefox
- [X] It works with VoiceOver
- [X] There are no errors in aXe / SiteImprove-plugins / Wave
