### PR TITLE
Remove designmanual.vylabs.io and use design.vy.no as domain name in cloudfront

### DIFF
--- a/apps/designmanual-frontend/terraform/template/main.tf
+++ b/apps/designmanual-frontend/terraform/template/main.tf
@@ -1,9 +1,9 @@
 locals {
   application_name = "digitalekanaler-designmanual"
-  base_domain      = var.environment == "prod" ? "vylabs.io" : "${var.environment}.vylabs.io"
-  domain_name      = "designmanual.${local.base_domain}"
+  base_domain      = var.environment == "prod" ? "vy.no" : "${var.environment}.vy.no"
+  domain_name      = var.environment == "prod" ? "design.vy.no" : "${var.environment}.design.vy.no"
 
-  alb_domain_name       = "lb.${local.base_domain}"
+  alb_domain_name       = var.environment == "prod" ? "lb.vylabs.io" : "lb.${var.environment}.vylabs.io"
   alb_listener_arn      = nonsensitive(data.aws_ssm_parameter.alb_listener_arn.value)
   alb_test_listener_arn = nonsensitive(data.aws_ssm_parameter.alb_test_listener_arn.value)
   alb_security_group_id = nonsensitive(data.aws_ssm_parameter.alb_security_group_id.value)
@@ -93,10 +93,6 @@ module "ssr_task" {
 # Cloudfront + S3 static files #
 #                              # 
 ################################
-
-data "aws_route53_zone" "parent" {
-  name = local.base_domain
-}
 
 # Hosted zone for design system domains
 resource "aws_route53_zone" "this" {


### PR DESCRIPTION
- **Update Cloudfront module to use the correct hosted zone ID**
- **Remove designmanual.vylabs.io and use design.vy.no as domain name im cloudfront**

## Background

While using the [SSR page Terraform module](github.com/nsbno/terraform-aws-ssr-site) there was an issue validating both the designmanual.vylabs.io and design.vy.no domain because they are located in different hosted zones in AWS. 

---

## Solution

Using only design.vy.no as domain name for the Cloudfront fixes this.
