### PR TITLE
Exclude the H2 inside the image card from the menu listing

### DIFF
--- a/apps/designmanual-frontend/app/utils/useHeadingsMenu.ts
+++ b/apps/designmanual-frontend/app/utils/useHeadingsMenu.ts
@@ -16,7 +16,11 @@ export const useHeadingsMenu = (): Array<HeadingsMenu> | [] => {
   useEffect(() => {
     const headings: Array<{ text: string; id?: string }> = [];
     const h2Elements =
-      typeof document === "undefined" ? [] : document.querySelectorAll("h2");
+      typeof document === "undefined"
+        ? []
+        : document.querySelectorAll(
+            'h2:not([data-testid="image-card-list"] h2)',
+          );
 
     if (h2Elements.length > 0) {
       for (const element of h2Elements) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://spor.vy.no/guides/how-to-make-new-react-components
📦 How to make a changeset: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

Closes # <!-- Github issue number -->

The left side menu of the documentation, built from the existing H2 on the page, collect also the H2 from the image card list, which is something we do not want to do

<!-- Why this task is needed, context, and problem it solves -->

---

## Solution

<!-- What has been done and why this approach was chosen -->

---

improve the selector to exclude the unexpected H2 

## General Checklist

- [ ] I have updated documentation if necessary
- [x] I have verified the design aligns with the latest Figma sketches.
- [ ] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave

