### PR TITLE
fix: Set borderRadius to sm for CardSelect

### DIFF
--- a/packages/spor-react/src/input/CardSelect.tsx
+++ b/packages/spor-react/src/input/CardSelect.tsx
@@ -29,6 +29,7 @@ export const CardSelectContent = forwardRef<HTMLDivElement, StaticCardProps>(
                 bg="bg"
                 border="sm"
                 borderColor="floating.outline"
+                borderRadius="sm"
                 {...props}
               >
                 {children}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://spor.vy.no/guides/how-to-make-new-react-components
📦 How to make a changeset: https://spor.vy.no/guides/how-to-make-new-react-components#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

Closes #2065 

Fixes borderRadius

---

## Solution

---

## General Checklist

- [ ] I have updated documentation if necessary
- [ ] I have verified the design aligns with the latest Figma sketches.
- [ ] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|   <img width="2449" height="1201" alt="Screenshot 2026-01-14 at 15 27 26" src="https://github.com/user-attachments/assets/875f2414-b5b3-4f23-9daf-0f9990b48888" /> |  <img width="1525" height="776" alt="Screenshot 2026-01-14 at 15 51 29" src="https://github.com/user-attachments/assets/47c9eec1-85de-4302-b111-683065a6698e" /> |
