### PR TITLE
Autocomplete: Remove default emptyLabel

### DIFF
--- a/packages/spor-react/src/input/Autocomplete.tsx
+++ b/packages/spor-react/src/input/Autocomplete.tsx
@@ -120,10 +120,8 @@ export const Autocomplete = ({
       </Combobox.Control>
       <Combobox.Positioner>
         <Combobox.Content>
-          {!loading && (
-            <Combobox.Empty>
-              {emptyLabel ?? t(texts.noItemsFound)}
-            </Combobox.Empty>
+          {!loading && emptyLabel && (
+            <Combobox.Empty>{emptyLabel}</Combobox.Empty>
           )}
           {loading ? <ColorSpinner width="1.5rem" p="2" /> : filteredChildren}
         </Combobox.Content>
@@ -215,12 +213,6 @@ const extractItemsFromChildren = (children: React.ReactNode): Item[] => {
 };
 
 const texts = createTexts({
-  noItemsFound: {
-    nb: "Ingen resultater",
-    nn: "Ingen resultat",
-    sv: "Inga resultat",
-    en: "No results found",
-  },
   clearValue: {
     nb: "Tøm verdi",
     nn: "Tøm verdi",


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

If you use Autocomplete combined with useSwr to fetch options, the emptyLabel is sometimes shown between loading and showing results. This can be misleading to the user. 

---

## Solution

Remove the default emptyLabel so that we can better control when the empty label is shown.

---

## General Checklist

- [ ] I have updated documentation if necessary
- [ ] I have verified the design aligns with the latest Figma sketches.
- [ ] I have created a changeset if publishing is required

---

