### PR TITLE
fix: update background color for floating datepicker and timepicker

### DIFF
--- a/.changeset/tidy-squids-peel.md
+++ b/.changeset/tidy-squids-peel.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Fix bg color for floating datepicker

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -182,10 +182,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       },
       floating: {
         wrapper: {
-          backgroundColor: {
-            _light: "bg",
-            _dark: `color-mix(in srgb, white 10%, var(--spor-colors-bg))`,
-          },
+          bg: "floating.surface",
           outline: "1px solid",
           outlineColor: "floating.outline",
           boxShadow: "sm",


### PR DESCRIPTION
## Background

Closes # <!-- Github issue number -->

https://trello.com/c/kJYpnWkh/6887-datovelger-og-tidsvelger-har-litt-merkelig-bakgrunnsfarge

## Solution

Use floating bg color 

## Screenshots

| Before | After |
| ------ | ----- |
|   <img width="231" height="247" alt="image" src="https://github.com/user-attachments/assets/5ac0b25d-eeb4-4637-81d7-22f91fe0f0f3" />     |  <img width="231" height="247" alt="image" src="https://github.com/user-attachments/assets/c4a59a6e-d2b4-4b2b-834a-a01758119654" />     |
