### PR TITLE
remove custom visualediting component in favour of native

### DIFF
--- a/apps/designmanual-frontend/app/features/SanityVisualEditing.tsx
+++ b/apps/designmanual-frontend/app/features/SanityVisualEditing.tsx
@@ -2,17 +2,11 @@
 import { VisualEditing } from "@sanity/visual-editing/react-router";
 
 //import { getClient } from "~/utils/sanity/client";
-import { DisablePreviewMode } from "./DisablePreviewMode";
 
 //const stegaClient = getClient().withConfig({ stega: true });
 
 export function SanityVisualEditing() {
   //useLiveMode({ client: stegaClient });
 
-  return (
-    <>
-      <VisualEditing />
-      <DisablePreviewMode />
-    </>
-  );
+  return <VisualEditing />;
 }


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

Closes # <!-- Github issue number -->

the visual editing had a custom component that the new version has implemented as native, the old one added also an unwanted "disable preview mode"

<!-- Why this task is needed, context, and problem it solves -->

---

## Solution

<!-- What has been done and why this approach was chosen -->

---

remove the custom component and use the native

## General Checklist

- [ ] I have updated documentation if necessary
- [ ] I have verified the design aligns with the latest Figma sketches.
- [ ] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
