### PR TITLE
Submenues for menuItems that are external links

### DIFF
--- a/apps/designmanual-frontend/app/routes/_base.$resources.design-tokens/BrandSwitcher.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$resources.design-tokens/BrandSwitcher.tsx
@@ -25,7 +25,7 @@ export const BrandSwitcher = () => {
 
   return (
     <Stack gap="2">
-      <Heading as="h2" variant="md" fontWeight="bold">
+      <Heading as="h3" variant="md" fontWeight="bold">
         Theme
       </Heading>
       <fetcher.Form method="post" action="/api/brand">

--- a/apps/designmanual-frontend/app/routes/_base.$resources.design-tokens/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$resources.design-tokens/route.tsx
@@ -21,6 +21,22 @@ import { TypographyTokens } from "./TypographyTokens";
 import { ZIndexTokens } from "./ZIndexTokens";
 
 export default function DesignTokensPage() {
+  const fallback = (
+    <Flex gap="6" flexDirection="column" display="none">
+      <Heading as="h2">Color tokens</Heading>
+      <Heading as="h2">Styles</Heading>
+      <Heading as="h2">Pallette</Heading>
+      <Heading as="h2">Rounding</Heading>
+      <Heading as="h2">Typography</Heading>
+      <Heading as="h2">Spacing</Heading>
+      <Heading as="h2">Rounding</Heading>
+      <Heading as="h2">Shadows</Heading>
+      <Heading as="h2">Outlines</Heading>
+      <Heading as="h2">Breakpoints</Heading>
+      <Heading as="h2">Animation</Heading>
+      <Heading as="h2">Z-index</Heading>
+    </Flex>
+  );
   return (
     <Box paddingBottom="8">
       <Heading as="h1" variant="xl-display" marginBottom={2}>
@@ -48,7 +64,7 @@ export default function DesignTokensPage() {
       </Flex>
 
       <Separator marginBottom={8} marginTop={4} />
-      <ClientOnly>
+      <ClientOnly fallback={fallback}>
         <Stack gap={9}>
           <ColorTokens />
           <TypographyTokens />

--- a/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
@@ -116,7 +116,7 @@ export const ContentMenu = ({ refreshKey, handleRefresh, ref }: Props) => {
           const hasSubItems = Boolean(subItems?.length);
           const linkStripped = item.link?.startsWith("/")
             ? item.link
-            : item.link.split(".no")[1];
+            : item.link?.split(".no")[1];
           const isCurrentPage = linkStripped === location.pathname;
 
           if (item.link && !isCurrentPage) {

--- a/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
@@ -114,7 +114,11 @@ export const ContentMenu = ({ refreshKey, handleRefresh, ref }: Props) => {
           }
           const subItems = item.subItems?.filter((subItem) => subItem.url);
           const hasSubItems = Boolean(subItems?.length);
-          const isCurrentPage = item.link === location.pathname;
+          const linkStripped = item.link?.startsWith("/")
+            ? item.link
+            : item.link.split(".no")[1];
+          const isCurrentPage = linkStripped === location.pathname;
+
           if (item.link && !isCurrentPage) {
             return (
               <MenuItem


### PR DESCRIPTION
## Background

Menuitems som lenker til interne lenker skal egentlig vise alle h2-overskrifter på siden som submenues.
Dersom man lenket til en ekstern lenke som likevel er på design.vy.no (slik vi gjør mye i menyen under Ressurser) så ble ikke h2-overskriftene vist som submenues. 

---

## Solution

Submenues blir kun vist dersom menuItem har samme lenke som currentPage som brukeren er på. currentPage er kun en path (for eksempel `/ressurser/design-tokens`), og sjekken ble derfor alltid false når man sammenlignet med eksterne lenker som har design.vy.no foran seg (`/ressurser/design-tokens` !== `https://desgin.vy.no/ressurser/design-tokens`). 

Løsning blir å fjerne "design.vy.no" i eksterne lenker slik at sammenligningen blir riktig. 

Litt hacky løsning for Color Tokens, men det er fordi alle H2 er wrappa i en ClientOnly, så har lagt inn en fallback som har alle de samme h2ene som etter at client-side er rendret. 

<img width="679" height="828" alt="Skjermbilde 2026-04-23 kl  14 08 24" src="https://github.com/user-attachments/assets/06bdca72-bd09-4aa5-a37c-5aaf1a944852" />

