### PR TITLE
add missing mappings + fix badge inverted

### DIFF
--- a/packages/spor-codemods/transforms/tokens/color-tokens.js
+++ b/packages/spor-codemods/transforms/tokens/color-tokens.js
@@ -45,6 +45,9 @@ export const tokenMap = {
   "alert.service.surface": "surface.service",
   "alert.service.surface.active": "surface.service.active",
   "alert.service.text.secondary": "text.service.subtle",
+  "alert.neutral.text.secondary": "text.neutral.subtle",
+  "alert.neutral.surface.active": "surface.neutral.active",
+  "alert.neutral.surface.hover": "surface.neutral.hover",
 
   "accent.surface.active": "surface.accent.active",
   "accent.surface": "surface.accent",
@@ -139,6 +142,7 @@ export const tokenMap = {
   "badge.red.icon": "icon.critical",
   "text.inverted": "text.brand",
   "icon.inverted": "icon.brand",
+  "icon.secondary": "icon.highlight",
   "outline.inverted": "outline.neutral",
 };
 

--- a/packages/spor-design-tokens/tokens/color/cargonet.json
+++ b/packages/spor-design-tokens/tokens/color/cargonet.json
@@ -528,7 +528,7 @@
           "DEFAULT": {
             "value": {
               "_light": "colors.whiteAlpha.200",
-              "_dark": "colors.pine"
+              "_dark": "colors.whiteAlpha.200"
             }
           },
           "hover": {

--- a/packages/spor-design-tokens/tokens/color/vy-digital.json
+++ b/packages/spor-design-tokens/tokens/color/vy-digital.json
@@ -277,7 +277,7 @@
         "subtle": {
           "value": {
             "_light": "colors.lightGrey",
-            "_dark": "colors.jungle"
+            "_dark": "colors.night"
           }
         },
         "brand": {
@@ -556,7 +556,7 @@
           "DEFAULT": {
             "value": {
               "_light": "colors.white",
-              "_dark": "colors.night"
+              "_dark": "colors.interstellar"
             }
           },
           "hover": {

--- a/packages/spor-react/src/typography/Badge.tsx
+++ b/packages/spor-react/src/typography/Badge.tsx
@@ -6,6 +6,8 @@ import {
 } from "@chakra-ui/react";
 import { IconComponent } from "@vygruppen/spor-icon-react";
 
+import { useColorMode } from "@/color-mode";
+
 export type BadgeProps = ChakraBadgeProps & {
   icon?: IconComponent;
 };
@@ -14,12 +16,16 @@ export const Badge = function Badge({
   ref,
   icon,
   children,
+  inverted,
   ...props
 }: BadgeProps & {
   ref?: React.Ref<HTMLSpanElement>;
 }) {
+  const { colorMode } = useColorMode();
+  const shouldInvert = inverted ? colorMode !== "dark" : colorMode === "dark";
+  const className = shouldInvert ? "dark" : "light";
   return (
-    <ChakraBadge ref={ref} {...props}>
+    <ChakraBadge ref={ref} {...props} className={className}>
       {children}
       {icon && <Box as={icon} />}
     </ChakraBadge>


### PR DESCRIPTION
## Background

- Add some missing mappings between old and new token-structure. 
- Fix color values that were wrong
- Add support on badge that are inverted. 
