### PR TITLE
Color token patches

### DIFF
--- a/.changeset/shy-keys-remain.md
+++ b/.changeset/shy-keys-remain.md
@@ -1,0 +1,8 @@
+---
+"@vygruppen/spor-design-tokens": patch
+"@vygruppen/spor-mcp-server": patch
+"@vygruppen/spor-codemods": patch
+"@vygruppen/spor-react": patch
+---
+
+Patches to new color tokens and add support to badge-inverted back

--- a/packages/spor-codemods/transforms/tokens/color-tokens.js
+++ b/packages/spor-codemods/transforms/tokens/color-tokens.js
@@ -112,6 +112,9 @@ export const tokenMap = {
   "alert.success.text.secondary": "text.success.subtle",
   "alert.important.text": "text.warning",
   "alert.important.text.secondary": "text.warning.subtle",
+  "alert.neutral.text.secondary": "text.neutral.subtle",
+  "alert.neutral.surface.active": "surface.neutral.active",
+  "alert.neutral.surface.hover": "surface.neutral.hover",
 
   "badge.surface": "surface",
   "badge.text": "text",
@@ -139,6 +142,7 @@ export const tokenMap = {
   "badge.red.icon": "icon.critical",
   "text.inverted": "text.brand",
   "icon.inverted": "icon.brand",
+  "icon.secondary": "icon.highlight",
   "outline.inverted": "outline.neutral",
 };
 

--- a/packages/spor-design-tokens/tokens/color/cargonet.json
+++ b/packages/spor-design-tokens/tokens/color/cargonet.json
@@ -528,7 +528,7 @@
           "DEFAULT": {
             "value": {
               "_light": "colors.whiteAlpha.200",
-              "_dark": "colors.pine"
+              "_dark": "colors.whiteAlpha.200"
             }
           },
           "hover": {

--- a/packages/spor-design-tokens/tokens/color/vy-digital.json
+++ b/packages/spor-design-tokens/tokens/color/vy-digital.json
@@ -277,7 +277,7 @@
         "subtle": {
           "value": {
             "_light": "colors.lightGrey",
-            "_dark": "colors.jungle"
+            "_dark": "colors.night"
           }
         },
         "brand": {
@@ -556,7 +556,7 @@
           "DEFAULT": {
             "value": {
               "_light": "colors.white",
-              "_dark": "colors.night"
+              "_dark": "colors.interstellar"
             }
           },
           "hover": {

--- a/packages/spor-mcp-server/package.json
+++ b/packages/spor-mcp-server/package.json
@@ -23,8 +23,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@sanity/client": "^7.12.0",
-    "@vygruppen/spor-design-tokens": "4.3.2",
-    "@vygruppen/spor-react": "12.24.16",
+    "@vygruppen/spor-design-tokens": "5.0.0",
+    "@vygruppen/spor-react": "13.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/spor-react/src/theme/recipes/badge.ts
+++ b/packages/spor-react/src/theme/recipes/badge.ts
@@ -25,7 +25,7 @@ export const badgeRecipie = defineRecipe({
         },
       },
       green: {
-        backgroundColor: "surface.subtle",
+        backgroundColor: "surface.success",
         color: "text.success",
         "& svg": {
           color: "icon.success",

--- a/packages/spor-react/src/theme/recipes/badge.ts
+++ b/packages/spor-react/src/theme/recipes/badge.ts
@@ -95,10 +95,176 @@ export const badgeRecipie = defineRecipe({
         borderBottomRadius: "none",
       },
     },
+    inverted: { true: {} },
   },
   defaultVariants: {
     colorPalette: "grey",
     size: "md",
     attached: false,
+    inverted: false,
   },
+  compoundVariants: [
+    {
+      colorPalette: "blue",
+      inverted: true,
+      css: {
+        backgroundColor: {
+          _light: "darkBlue",
+          _dark: "lightBlue",
+        },
+        color: {
+          _light: "icyBlue",
+          _dark: "royal",
+        },
+        "& svg": {
+          color: {
+            _light: "royal",
+            _dark: "icyBlue",
+          },
+        },
+      },
+    },
+    {
+      colorPalette: "green",
+      inverted: true,
+      css: {
+        backgroundColor: {
+          _light: "darkTeal",
+          _dark: "seaMist",
+        },
+        color: {
+          _light: "mint",
+          _dark: "jungle",
+        },
+        "& svg": {
+          color: {
+            _light: "mint",
+            _dark: "jungle",
+          },
+        },
+      },
+    },
+    {
+      colorPalette: "grey",
+      inverted: true,
+      css: {
+        backgroundColor: {
+          _light: "carbon",
+          _dark: "platinum",
+        },
+        color: {
+          _light: "white",
+          _dark: "darkGrey",
+        },
+        "& svg": {
+          color: {
+            _light: "white",
+            _dark: "darkGrey",
+          },
+        },
+      },
+    },
+    {
+      // @ts-expect-error Chakra gir feilmelding fordi "cream" ikke eksisterer i built-in ColorPalette-typen
+      colorPalette: "cream",
+      inverted: true,
+      css: {
+        backgroundColor: {
+          _light: "coffee",
+          _dark: "blonde",
+        },
+        color: {
+          _light: "cornsilk",
+          _dark: "coffee",
+        },
+        "& svg": {
+          color: {
+            _light: "cornsilk",
+            _dark: "coffee",
+          },
+        },
+      },
+    },
+    {
+      colorPalette: "yellow",
+      inverted: true,
+      css: {
+        backgroundColor: {
+          _light: "bronze",
+          _dark: "banana",
+        },
+        color: {
+          _light: "cornsilk",
+          _dark: "coffee",
+        },
+        "& svg": {
+          color: {
+            _light: "cornsilk",
+            _dark: "coffee",
+          },
+        },
+      },
+    },
+    {
+      colorPalette: "orange",
+      inverted: true,
+      css: {
+        backgroundColor: {
+          _light: "wood",
+          _dark: "champagne",
+        },
+        color: {
+          _light: "bisque",
+          _dark: "wood",
+        },
+        "& svg": {
+          color: {
+            _light: "bisque",
+            _dark: "wood",
+          },
+        },
+      },
+    },
+    {
+      colorPalette: "red",
+      inverted: true,
+      css: {
+        backgroundColor: {
+          _light: "burgundy",
+          _dark: "lightRed",
+        },
+        color: {
+          _light: "pink",
+          _dark: "maroon",
+        },
+        "& svg": {
+          color: {
+            _light: "pink",
+            _dark: "maroon",
+          },
+        },
+      },
+    },
+    {
+      // @ts-expect-error Chakra gir feilmelding fordi "neutral" ikke eksisterer i built-in typen
+      colorPalette: "neutral",
+      inverted: true,
+      css: {
+        backgroundColor: {
+          _light: "ink",
+          _dark: "white",
+        },
+        color: {
+          _light: "white",
+          _dark: "darkGrey",
+        },
+        "& svg": {
+          color: {
+            _light: "white",
+            _dark: "darkGrey",
+          },
+        },
+      },
+    },
+  ],
 });

--- a/packages/spor-react/src/theme/recipes/badge.ts
+++ b/packages/spor-react/src/theme/recipes/badge.ts
@@ -95,104 +95,10 @@ export const badgeRecipie = defineRecipe({
         borderBottomRadius: "none",
       },
     },
-    inverted: { true: {} },
   },
   defaultVariants: {
     colorPalette: "grey",
     size: "md",
     attached: false,
-    inverted: false,
   },
-  compoundVariants: [
-    {
-      colorPalette: "blue",
-      inverted: true,
-      css: {
-        backgroundColor: "badge.blue.surface.inverted",
-        color: "badge.blue.text.inverted",
-        "& svg": {
-          color: "badge.blue.icon.inverted",
-        },
-      },
-    },
-    {
-      colorPalette: "green",
-      inverted: true,
-      css: {
-        backgroundColor: "badge.green.surface.inverted",
-        color: "badge.green.text.inverted",
-        "& svg": {
-          color: "badge.green.icon.inverted",
-        },
-      },
-    },
-    {
-      colorPalette: "grey",
-      inverted: true,
-      css: {
-        backgroundColor: "badge.grey.surface.inverted",
-        color: "badge.grey.text.inverted",
-        "& svg": {
-          color: "badge.grey.icon.inverted",
-        },
-      },
-    },
-    {
-      // @ts-expect-error Chakra gir feilmelding fordi "cream" ikke eksisterer i built-in ColorPalette-typen
-      colorPalette: "cream",
-      inverted: true,
-      css: {
-        backgroundColor: "badge.cream.surface.inverted",
-        color: "badge.cream.text.inverted",
-        "& svg": {
-          color: "badge.cream.icon.inverted",
-        },
-      },
-    },
-    {
-      colorPalette: "yellow",
-      inverted: true,
-      css: {
-        backgroundColor: "badge.yellow.surface.inverted",
-        color: "badge.yellow.text.inverted",
-        "& svg": {
-          color: "badge.yellow.icon.inverted",
-        },
-      },
-    },
-    {
-      colorPalette: "orange",
-      inverted: true,
-      css: {
-        backgroundColor: "badge.orange.surface.inverted",
-        color: "badge.orange.text.inverted",
-        "& svg": {
-          color: "badge.orange.icon.inverted",
-        },
-      },
-    },
-    {
-      colorPalette: "red",
-      inverted: true,
-      css: {
-        backgroundColor: "badge.red.surface.inverted",
-        color: "badge.red.text.inverted",
-        "& svg": {
-          color: "badge.red.icon.inverted",
-        },
-      },
-    },
-    {
-      // @ts-expect-error Chakra gir feilmelding fordi "neutral" ikke eksisterer i built-in typen
-      colorPalette: "neutral",
-      inverted: true,
-      css: {
-        backgroundColor: "badge.surface.inverted",
-        color: "badge.text.inverted",
-        "& svg": {
-          color: "badge.icon.inverted",
-        },
-      },
-    },
-  ],
 });

--- a/packages/spor-react/src/typography/Badge.tsx
+++ b/packages/spor-react/src/typography/Badge.tsx
@@ -6,27 +6,20 @@ import {
 } from "@chakra-ui/react";
 import { IconComponent } from "@vygruppen/spor-icon-react";
 
-import { useColorMode } from "@/color-mode";
-
 export type BadgeProps = ChakraBadgeProps & {
   icon?: IconComponent;
-  inverted?: boolean;
 };
 
 export const Badge = function Badge({
   ref,
   icon,
   children,
-  inverted = false,
   ...props
 }: BadgeProps & {
   ref?: React.Ref<HTMLSpanElement>;
 }) {
-  const { colorMode } = useColorMode();
-  const shouldInvert = inverted ? colorMode !== "dark" : colorMode === "dark";
-  const className = shouldInvert ? "dark" : "light";
   return (
-    <ChakraBadge ref={ref} className={className} {...props}>
+    <ChakraBadge ref={ref} {...props}>
       {children}
       {icon && <Box as={icon} />}
     </ChakraBadge>

--- a/packages/spor-react/src/typography/Badge.tsx
+++ b/packages/spor-react/src/typography/Badge.tsx
@@ -16,7 +16,7 @@ export const Badge = function Badge({
   ref,
   icon,
   children,
-  inverted,
+  inverted = false,
   ...props
 }: BadgeProps & {
   ref?: React.Ref<HTMLSpanElement>;

--- a/packages/spor-react/src/typography/Badge.tsx
+++ b/packages/spor-react/src/typography/Badge.tsx
@@ -6,6 +6,8 @@ import {
 } from "@chakra-ui/react";
 import { IconComponent } from "@vygruppen/spor-icon-react";
 
+import { useColorMode } from "@/color-mode";
+
 export type BadgeProps = ChakraBadgeProps & {
   icon?: IconComponent;
 };
@@ -14,12 +16,16 @@ export const Badge = function Badge({
   ref,
   icon,
   children,
+  inverted,
   ...props
 }: BadgeProps & {
   ref?: React.Ref<HTMLSpanElement>;
 }) {
+  const { colorMode } = useColorMode();
+  const shouldInvert = inverted ? colorMode !== "dark" : colorMode === "dark";
+  const className = shouldInvert ? "dark" : "light";
   return (
-    <ChakraBadge ref={ref} {...props}>
+    <ChakraBadge ref={ref} className={className} {...props}>
       {children}
       {icon && <Box as={icon} />}
     </ChakraBadge>

--- a/packages/spor-react/src/typography/Badge.tsx
+++ b/packages/spor-react/src/typography/Badge.tsx
@@ -10,6 +10,7 @@ import { useColorMode } from "@/color-mode";
 
 export type BadgeProps = ChakraBadgeProps & {
   icon?: IconComponent;
+  inverted?: boolean;
 };
 
 export const Badge = function Badge({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,11 +609,11 @@ importers:
         specifier: ^7.12.0
         version: 7.16.0
       '@vygruppen/spor-design-tokens':
-        specifier: 4.3.2
-        version: 4.3.2
+        specifier: 5.0.0
+        version: 5.0.0
       '@vygruppen/spor-react':
-        specifier: 12.24.16
-        version: 12.24.16(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        specifier: 13.1.0
+        version: 13.1.0(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -6047,26 +6047,23 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vygruppen/spor-design-tokens@4.3.2':
-    resolution: {integrity: sha512-gVvJhQlvBEVLFEhaNgTb31XrqEUlW+AeGZPxxji86dzPI/1hvrhh7w8Ij+bfgViOEaOmIUSSKkbnt7fpkKwDgg==}
+  '@vygruppen/spor-design-tokens@5.0.0':
+    resolution: {integrity: sha512-tt5nryswrtFvoLm6CICrbagRi/FmbdLD1scDbjQ+G63SO3Xfqa3MnyCWKlhPtsHat2mzFoNv87mDWx4lWrgJpw==}
 
-  '@vygruppen/spor-design-tokens@4.3.3':
-    resolution: {integrity: sha512-CvtcfPZ5NRXuuZflxhSlgXLkB2xOP8hn0cFcDLNI+vmfA8U86yFQzmF4L/dhn/aYG93zCbS2bfH/rqrPVHOqhw==}
-
-  '@vygruppen/spor-icon-react@4.5.3':
-    resolution: {integrity: sha512-a//d/kB/Kx1BU5eJL/6vqVqyk1VDuYnffEdcNYbh+FyEvs/5ulFZqNpNp3dz/CxajWEFvC5e2UyqumplRyeAWw==}
+  '@vygruppen/spor-icon-react@5.0.0':
+    resolution: {integrity: sha512-ruWPczYXR8GvvMaPVJUT8l+UlH1X8HQK2eh+I4qT3725uEJD4txdYcj6qKuy/4icR6T0R9G7l+6c9LS8t/wGPQ==}
     peerDependencies:
-      react: '>=18.0.0 <19.0.0'
-      react-dom: '>=18.0.0 <19.0.0'
+      react: '>=19.0.0'
+      react-dom: '>=19.0.0'
 
   '@vygruppen/spor-loader@0.7.0':
     resolution: {integrity: sha512-aLp9Wr6yQAuGKXRvnIKac14zuyrBW+uYQR6RwO/A51rzyAygLAoTl8oPGDJZlGe642jafxKiWw2cRsKcjydiFw==}
 
-  '@vygruppen/spor-react@12.24.16':
-    resolution: {integrity: sha512-saKtbwQL5r3hNYdZaTBDTpVNy2c6z1U4a8wOk/9l1H6AFu6tie1JmtcLJ4sedQUF8pwwNCjCCxNjO9UDvYAZkg==}
+  '@vygruppen/spor-react@13.1.0':
+    resolution: {integrity: sha512-2UYDKIy32s5GVd5YZXD40/YjgJl9KUVO+q3GI79nt3LwCffSJSHn0kBFQtGp/XdfUq/yZrLio2d91taiiAo7Kw==}
     peerDependencies:
-      react: '>=18.0.0 <19.0.0'
-      react-dom: '>=18.0.0 <19.0.0'
+      react: '>=19.0.0'
+      react-dom: '>=19.0.0'
 
   '@xstate/react@6.1.0':
     resolution: {integrity: sha512-ep9F0jGTI63B/jE8GHdMpUqtuz7yRebNaKv8EMUaiSi29NOglywc2X2YSOV/ygbIK+LtmgZ0q9anoEA2iBSEOw==}
@@ -21339,18 +21336,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vygruppen/spor-design-tokens@4.3.2': {}
+  '@vygruppen/spor-design-tokens@5.0.0': {}
 
-  '@vygruppen/spor-design-tokens@4.3.3': {}
-
-  '@vygruppen/spor-icon-react@4.5.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@vygruppen/spor-icon-react@5.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
   '@vygruppen/spor-loader@0.7.0': {}
 
-  '@vygruppen/spor-react@12.24.16(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)':
+  '@vygruppen/spor-react@13.1.0(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)':
     dependencies:
       '@ark-ui/react': 4.9.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@chakra-ui/anatomy': 2.3.4
@@ -21365,12 +21360,13 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.3)(react@19.2.3)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.3)(react@19.2.3))(@types/react@19.2.3)(react@19.2.3)
       '@internationalized/date': 3.12.0
-      '@vygruppen/spor-design-tokens': 4.3.3
-      '@vygruppen/spor-icon-react': 4.5.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@vygruppen/spor-design-tokens': 5.0.0
+      '@vygruppen/spor-icon-react': 5.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@vygruppen/spor-loader': 0.7.0
       awesome-phonenumber: 5.11.0
       deepmerge: 4.3.1
       framer-motion: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      jscodeshift: 17.3.0(@babel/preset-env@7.29.0(@babel/core@7.29.0))
       lottie-react: 2.4.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
@@ -21381,6 +21377,7 @@ snapshots:
       react-swipeable: 7.0.2(react@19.2.3)
       usehooks-ts: 3.1.1(react@19.2.3)
     transitivePeerDependencies:
+      - '@babel/preset-env'
       - '@emotion/is-prop-valid'
       - '@types/react'
       - supports-color


### PR DESCRIPTION
## Background

Retter opp i noen feil i det nye farge-token systemet: 
- Badge inverted brukte tokens som ikke eksisterer lenger. Må derfor heller bruke useColorMode og bruke light theme og darkmode, og vice versa. 
- Noen fargerverdier var feil
- manglet mapping mellom noen av de gamle tokensene og de nye. 

---
