### PR TITLE
Add Border to Toast

### DIFF
--- a/.changeset/public-sites-throw.md
+++ b/.changeset/public-sites-throw.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add border to toast

--- a/packages/spor-react/src/toast/toast.tsx
+++ b/packages/spor-react/src/toast/toast.tsx
@@ -45,7 +45,13 @@ export const Toaster = () => {
     <Portal>
       <ChakraToaster toaster={toaster} insetInline={{ mdDown: "4" }}>
         {(toast) => (
-          <Toast.Root width={{ md: toast.meta?.width }} role="alert">
+          <Toast.Root
+            width={{ md: toast.meta?.width }}
+            border="sm"
+            borderColor={`outline.${toast.type}`}
+            boxShadow="sm"
+            role="alert"
+          >
             <AlertIcon variant={toast.type as Variant} />
             <Stack gap="1" flex="1" maxWidth="100%">
               <Toast.Description>{toast.description}</Toast.Description>


### PR DESCRIPTION
## Background

We noticed issues with readability on certain backgrounds for the toasts. After talking with @Es8en  we came to the conclusion that toasts could feature borders based on their outline color using the outline.{variant} color

**Example:**
<img width="1199" height="257" alt="Screenshot 2026-04-27 at 09 13 52" src="https://github.com/user-attachments/assets/8e45e589-3f13-4cc6-826b-4487b9a0f6e0" />


## Solution

- Add a `sm` border with the outline color of the variant for each toast type

## General Checklist

- [x] I have updated documentation if necessary
- [x] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots
| Light mode | Dark mode |
| ---------- | --------- |
| <img width="405" height="189" alt="Screenshot 2026-04-27 at 09 09 20" src="https://github.com/user-attachments/assets/f5b81e76-860e-46f0-8053-3564650aec82" /> | <img width="409" height="201" alt="Screenshot 2026-04-27 at 09 09 33" src="https://github.com/user-attachments/assets/3e6742af-e73c-466e-81e1-b722f4e33da0" /> |
