### PR TITLE
Fix uneven width cell table

### DIFF
--- a/.changeset/rotten-things-wave.md
+++ b/.changeset/rotten-things-wave.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Table: fix table cells width to avoid render conflict with tableLayout fixed

--- a/apps/designmanual-frontend/app/features/portable-text/components/TableChart.tsx
+++ b/apps/designmanual-frontend/app/features/portable-text/components/TableChart.tsx
@@ -44,7 +44,7 @@ export function TableChart({ children, title, description }: TableProps) {
       )}
       {description && <Text marginBottom={1}>{description}</Text>}
       <Box width="100%" minWidth={0} overflowX="auto">
-        <Table size="md" tableLayout="fixed" width="100%" colorPalette="white">
+        <Table size="md" width="100%" colorPalette="white">
           {tHeadValues.length > 0 && (
             <TableHeader>
               <TableRow>

--- a/packages/spor-react/src/theme/slot-recipes/table.ts
+++ b/packages/spor-react/src/theme/slot-recipes/table.ts
@@ -34,7 +34,6 @@ export const tableSlotRecipe = defineSlotRecipe({
       ...numericStyles,
       paddingX: 1.5,
       paddingY: 1,
-      width: "100%",
     },
     footer: {
       fontWeight: "medium",


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

Closes # <!-- Github issue number -->

The table did render with uneven width on cell due to a mismatch on rendering to 100% and tableLayout on fixed

<!-- Why this task is needed, context, and problem it solves -->

---

## Solution

<!-- What has been done and why this approach was chosen -->

Remove the 100% width in cell to avoid conflict in reload

---

## General Checklist

- [ ] I have updated documentation if necessary
- [ ] I have verified the design aligns with the latest Figma sketches.
- [ ] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
