### PR TITLE
StaticCard colorpalette and color in cargonet-theme

### DIFF
--- a/.changeset/calm-humans-mix.md
+++ b/.changeset/calm-humans-mix.md
@@ -1,0 +1,8 @@
+---
+"@vygruppen/spor-react": minor
+"@vygruppen/spor-design-tokens": patch
+---
+
+Renamed the "white" colorPalette value in StaticCard to "neutral" and updated text.subtle colors in cargonet-theme
+
+Migration: Replace `colorPalette="white"` with `colorPalette="neutral"` in your StaticCard components.

--- a/packages/spor-design-tokens/tokens/color/cargonet.json
+++ b/packages/spor-design-tokens/tokens/color/cargonet.json
@@ -17,7 +17,7 @@
         "subtle": {
           "value": {
             "_light": "colors.dimGrey",
-            "_dark": "colors.white"
+            "_dark": "colors.whiteAlpha.700"
           }
         },
         "disabled": {

--- a/packages/spor-react/src/theme/recipes/static-card.ts
+++ b/packages/spor-react/src/theme/recipes/static-card.ts
@@ -6,7 +6,7 @@ export const staticCardRecipe = defineRecipe({
   },
   variants: {
     colorPalette: {
-      white: {
+      neutral: {
         backgroundColor: "surface",
         color: "text",
       },
@@ -34,6 +34,7 @@ export const staticCardRecipe = defineRecipe({
     },
   },
   defaultVariants: {
-    colorPalette: "white",
+    // @ts-expect-error Chakra gir feilmelding fordi "neutral" ikke eksisterer i built-in ColorPalette-typen
+    colorPalette: "neutral",
   },
 });


### PR DESCRIPTION
## Background

- Rename colorPalette-name in StaticCard from "white" to "neutral"
- Update wrong colortoken value in cargonet-theme. 

