### PR TITLE
Badge: adjust the fontsize down to match design

### DIFF
--- a/.changeset/hip-facts-judge.md
+++ b/.changeset/hip-facts-judge.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Badge: adjust the fontsize down to match design

--- a/packages/spor-react/src/theme/recipes/badge.ts
+++ b/packages/spor-react/src/theme/recipes/badge.ts
@@ -85,21 +85,21 @@ export const badgeRecipie = defineRecipe({
     },
     size: {
       sm: {
-        fontSize: "desktop.xs",
+        fontSize: "desktop.2xs",
         paddingX: "0.5",
         paddingY: "0",
         fontWeight: "normal",
         borderRadius: "xxs",
       },
       md: {
-        fontSize: "desktop.xs",
+        fontSize: "desktop.2xs",
         paddingX: "1",
         paddingY: "0.5",
         fontWeight: "bold",
         borderRadius: "xs",
       },
       lg: {
-        fontSize: "desktop.sm",
+        fontSize: "desktop.xs",
         paddingX: "1.5",
         paddingY: "0.5",
         fontWeight: "bold",


### PR DESCRIPTION
## Background

Adjusts the fontsize down to match the design in Figma. 

