### PR TITLE
Track tab-navigation in component docs

### DIFF
--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
@@ -36,6 +36,7 @@ import invariant from "tiny-invariant";
 import { PortableText } from "~/features/portable-text/PortableText";
 import { SiteSettings } from "~/root/layout/SiteSettings";
 import { ComponentDocs } from "~/routes/_base.$section.$category.$slug/component-docs/ComponentDocs";
+import { sendCustomEvent } from "~/utils/analytics/metabase";
 import { useBrand } from "~/utils/brand";
 import { getClient } from "~/utils/sanity/client";
 import {
@@ -230,6 +231,7 @@ export default function ArticlePage() {
           <ComponentSections
             id={article._id}
             sections={article.componentSections}
+            component={article.title}
           />
         ) : (
           <Box>
@@ -276,10 +278,15 @@ const mapLinkToIcon = (linkType: ResourceLink["linkType"]) => {
 };
 
 type ComponentSectionsProps = {
+  component: string;
   sections: ComponentSection[];
   id: string;
 };
-const ComponentSections = ({ sections, id }: ComponentSectionsProps) => {
+const ComponentSections = ({
+  component,
+  sections,
+  id,
+}: ComponentSectionsProps) => {
   return (
     <Tabs
       variant="accent"
@@ -292,7 +299,19 @@ const ComponentSections = ({ sections, id }: ComponentSectionsProps) => {
     >
       <TabsList>
         {sections.map((section) => (
-          <TabsTrigger key={section.title} value={section.title}>
+          <TabsTrigger
+            key={section.title}
+            value={section.title}
+            onClick={() =>
+              sendCustomEvent({
+                event: "component_tab_visited",
+                properties: {
+                  tab: section.title,
+                  component: component,
+                },
+              })
+            }
+          >
             {`${section.title.charAt(0).toUpperCase()}${section.title.slice(1)}`}
           </TabsTrigger>
         ))}

--- a/apps/designmanual-frontend/app/utils/analytics/metabase.ts
+++ b/apps/designmanual-frontend/app/utils/analytics/metabase.ts
@@ -37,8 +37,17 @@ const useSearch = z.object({
   }),
 });
 
+const component_tab_visited = z.object({
+  event: z.literal("component_tab_visited"),
+  properties: z.object({
+    tab: z.string(),
+    component: z.string(),
+  }),
+});
+
 export const MetabaseCustomEventSchema = z.discriminatedUnion("event", [
   useSearch,
+  component_tab_visited,
 ]);
 
 export type MetabaseCustomEvent = z.infer<typeof MetabaseCustomEventSchema>;


### PR DESCRIPTION
## Background

When the user navigates through the tabs in the component docs we send a custom event to metabase so that we can get insight into how frequently the tabs (mostly guidelines and code) are visited. 

<img width="1067" height="129" alt="Skjermbilde 2026-05-20 kl  08 11 34" src="https://github.com/user-attachments/assets/0ce0a410-8c35-4c6b-a38a-b021578a0f79" />

---

## Solution

Added a customEvent that is is called the tabTrigger's onClick-event. 

---

