### PR TITLE
Remove jscodeshift from spor-react package

### DIFF
--- a/.changeset/icy-carrots-sleep.md
+++ b/.changeset/icy-carrots-sleep.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Remove jscodeshift as it is not used in this package

--- a/packages/spor-react/package.json
+++ b/packages/spor-react/package.json
@@ -51,7 +51,6 @@
     "awesome-phonenumber": "^5.11.0",
     "deepmerge": "^4.3.1",
     "framer-motion": "^11.11.17",
-    "jscodeshift": "^17.3.0",
     "lottie-react": "^2.4.1",
     "next-themes": "^0.4.4",
     "react-aria": "^3.33.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,9 +695,6 @@ importers:
       framer-motion:
         specifier: ^11.11.17
         version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      jscodeshift:
-        specifier: ^17.3.0
-        version: 17.3.0(@babel/preset-env@7.29.5(@babel/core@7.29.0))
       lottie-react:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

Closes # <!-- Github issue number -->

<!-- Why this task is needed, context, and problem it solves -->
`jscodeshift` was depending on a vulnerable version of `tmp`. Since `jscodeshift` is not referenced anywhere in the `spor-react` package, it can be removed

---

## Solution

<!-- What has been done and why this approach was chosen -->
Removed `jscodeshift` as a dependency in `spor-react`

---

## General Checklist

- [ ] I have updated documentation if necessary
- [ ] I have verified the design aligns with the latest Figma sketches.
- [ ] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
