### PR TITLE
Spor fix menu scrolling

### DIFF
--- a/apps/designmanual-frontend/app/root/layout/Footer.tsx
+++ b/apps/designmanual-frontend/app/root/layout/Footer.tsx
@@ -5,12 +5,13 @@ import {
   useColorModeValue,
   VyLogo,
 } from "@vygruppen/spor-react";
+import { type Ref } from "react";
 import { Link, useRouteLoaderData } from "react-router";
 
 import { PortableText } from "~/features/portable-text/PortableText";
 import { loader } from "~/root";
 
-export const Footer = () => {
+export const Footer = ({ ref }: { ref?: Ref<HTMLDivElement> }) => {
   const borderColor = useColorModeValue("blackAlpha.200", "whiteAlpha.200");
   const routeData = useRouteLoaderData<typeof loader>("root");
   const footerItems =
@@ -18,6 +19,7 @@ export const Footer = () => {
 
   return (
     <Flex
+      ref={ref}
       as="footer"
       justifyContent="space-between"
       backgroundColor="surface.subtle"

--- a/apps/designmanual-frontend/app/root/layout/Footer.tsx
+++ b/apps/designmanual-frontend/app/root/layout/Footer.tsx
@@ -35,7 +35,7 @@ export const Footer = ({ ref }: { ref?: Ref<HTMLDivElement> }) => {
       marginX="auto"
       minHeight="12rem"
       flexDirection={["column", null, "row"]}
-      zIndex="banner"
+      zIndex="sticky"
     >
       <Box alignSelf="start" marginTop="4">
         <Link to="/" aria-label="Go to the front page">

--- a/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
+++ b/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex } from "@chakra-ui/react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useLocation } from "react-router";
 
 import { useStickymenu } from "~/routes/_base/content-menu/utils";
@@ -26,7 +26,24 @@ function usePageTracking() {
 }
 export const RootLayout = ({ children }: BaseLayoutProps) => {
   const [headerOffset, setHeaderOffset] = useState(0);
+  const footerRef = useRef<HTMLDivElement>(null);
   const { asideRef, forceFixed, fixedRect } = useStickymenu();
+
+  useEffect(() => {
+    const footer = footerRef.current;
+    if (!footer || globalThis.window === undefined) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        document.documentElement.style.setProperty(
+          "--footer-height",
+          `${Math.round(entry.intersectionRect.height)}px`,
+        );
+      },
+      { threshold: Array.from({ length: 101 }, (_, index) => index / 100) },
+    );
+    observer.observe(footer);
+    return () => observer.disconnect();
+  }, []);
 
   usePageTracking();
 
@@ -74,7 +91,7 @@ export const RootLayout = ({ children }: BaseLayoutProps) => {
 
         {children}
       </Flex>
-      <Footer />
+      <Footer ref={footerRef} />
     </Flex>
   );
 };

--- a/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
+++ b/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
@@ -70,7 +70,7 @@ export const RootLayout = ({ children }: BaseLayoutProps) => {
           as="aside"
           maxHeight={`calc(100vh - ${headerOffset}px - ${footerHeight}px)`}
           overflowY="auto"
-          overflowX="hidden"
+          sx={{ scrollbarGutter: "stable" }}
           style={
             forceFixed && fixedRect
               ? { left: `${fixedRect.left}px`, width: `${fixedRect.width}px` }

--- a/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
+++ b/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex } from "@chakra-ui/react";
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router";
 
 import { useStickymenu } from "~/routes/_base/content-menu/utils";
@@ -26,24 +26,18 @@ function usePageTracking() {
 }
 export const RootLayout = ({ children }: BaseLayoutProps) => {
   const [headerOffset, setHeaderOffset] = useState(0);
-  const [footerHeight, setFooterHeight] = useState(0);
-  const footerRef = useRef<HTMLDivElement>(null);
   const { asideRef, forceFixed, fixedRect } = useStickymenu();
-
-  useEffect(() => {
-    const footer = footerRef.current;
-    if (!footer) return;
-    const observer = new ResizeObserver(([entry]) => {
-      setFooterHeight(entry.contentRect.height);
-    });
-    observer.observe(footer);
-    return () => observer.disconnect();
-  }, []);
 
   usePageTracking();
 
   return (
-    <Flex direction="column" minHeight="100vh" bg="bg" fontFamily="Vy Sans">
+    <Flex
+      direction="column"
+      minHeight="100vh"
+      bg="bg"
+      fontFamily="Vy Sans"
+      style={{ "--header-height": `${headerOffset}px` } as React.CSSProperties}
+    >
       <SiteHeader onHeightChange={setHeaderOffset} />
 
       <Flex
@@ -68,9 +62,6 @@ export const RootLayout = ({ children }: BaseLayoutProps) => {
           position={forceFixed ? "fixed" : "sticky"}
           top={headerOffset}
           as="aside"
-          maxHeight={`calc(100vh - ${headerOffset}px - ${footerHeight}px)`}
-          overflowY="auto"
-          sx={{ scrollbarGutter: "stable" }}
           style={
             forceFixed && fixedRect
               ? { left: `${fixedRect.left}px`, width: `${fixedRect.width}px` }
@@ -83,7 +74,7 @@ export const RootLayout = ({ children }: BaseLayoutProps) => {
 
         {children}
       </Flex>
-      <Footer ref={footerRef} />
+      <Footer />
     </Flex>
   );
 };

--- a/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
+++ b/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation } from "react-router";
 
 import { useStickymenu } from "~/routes/_base/content-menu/utils";
@@ -26,7 +26,19 @@ function usePageTracking() {
 }
 export const RootLayout = ({ children }: BaseLayoutProps) => {
   const [headerOffset, setHeaderOffset] = useState(0);
+  const [footerHeight, setFooterHeight] = useState(0);
+  const footerRef = useRef<HTMLDivElement>(null);
   const { asideRef, forceFixed, fixedRect } = useStickymenu();
+
+  useEffect(() => {
+    const footer = footerRef.current;
+    if (!footer) return;
+    const observer = new ResizeObserver(([entry]) => {
+      setFooterHeight(entry.contentRect.height);
+    });
+    observer.observe(footer);
+    return () => observer.disconnect();
+  }, []);
 
   usePageTracking();
 
@@ -56,6 +68,8 @@ export const RootLayout = ({ children }: BaseLayoutProps) => {
           position={forceFixed ? "fixed" : "sticky"}
           top={headerOffset}
           as="aside"
+          maxHeight={`calc(100vh - ${headerOffset}px - ${footerHeight}px)`}
+          overflowY="auto"
           style={
             forceFixed && fixedRect
               ? { left: `${fixedRect.left}px`, width: `${fixedRect.width}px` }
@@ -68,7 +82,7 @@ export const RootLayout = ({ children }: BaseLayoutProps) => {
 
         {children}
       </Flex>
-      <Footer />
+      <Footer ref={footerRef} />
     </Flex>
   );
 };

--- a/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
+++ b/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
@@ -32,17 +32,25 @@ export const RootLayout = ({ children }: BaseLayoutProps) => {
   useEffect(() => {
     const footer = footerRef.current;
     if (!footer || globalThis.window === undefined) return;
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        document.documentElement.style.setProperty(
-          "--footer-height",
-          `${Math.round(entry.intersectionRect.height)}px`,
-        );
-      },
-      { threshold: Array.from({ length: 101 }, (_, index) => index / 100) },
-    );
-    observer.observe(footer);
-    return () => observer.disconnect();
+
+    const update = () => {
+      const visible = Math.max(
+        0,
+        globalThis.window.innerHeight - footer.getBoundingClientRect().top,
+      );
+      document.documentElement.style.setProperty(
+        "--footer-height",
+        `${Math.round(visible)}px`,
+      );
+    };
+
+    update();
+    globalThis.window.addEventListener("scroll", update, { passive: true });
+    globalThis.window.addEventListener("resize", update, { passive: true });
+    return () => {
+      globalThis.window.removeEventListener("scroll", update);
+      globalThis.window.removeEventListener("resize", update);
+    };
   }, []);
 
   usePageTracking();

--- a/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
+++ b/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
@@ -70,6 +70,7 @@ export const RootLayout = ({ children }: BaseLayoutProps) => {
           as="aside"
           maxHeight={`calc(100vh - ${headerOffset}px - ${footerHeight}px)`}
           overflowY="auto"
+          overflowX="hidden"
           style={
             forceFixed && fixedRect
               ? { left: `${fixedRect.left}px`, width: `${fixedRect.width}px` }

--- a/apps/designmanual-frontend/app/routes/_base/left-sidebar/LeftSidebar.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/left-sidebar/LeftSidebar.tsx
@@ -6,8 +6,9 @@ export const LeftSidebar = () => {
   return (
     <Box
       width={["100vw", null, null, "20rem"]}
-      height={["100vh", null, null, "auto"]}
+      maxHeight={["100vh", null, null, "calc(100vh - var(--header-height, 0px))"]}
       minWidth={["100%", null, null, "20rem"]}
+      overflowY={["auto", null, null, "auto"]}
       display={["none", null, null, "block"]}
     >
       <SearchableContentMenu />

--- a/apps/designmanual-frontend/app/routes/_base/left-sidebar/LeftSidebar.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/left-sidebar/LeftSidebar.tsx
@@ -6,7 +6,7 @@ export const LeftSidebar = () => {
   return (
     <Box
       width={["100vw", null, null, "20rem"]}
-      maxHeight={["100vh", null, null, "calc(100vh - var(--header-height, 0px))"]}
+      maxHeight={["100vh", null, null, "calc(100vh - var(--header-height, 0px) - var(--footer-height, 0px))"]}
       minWidth={["100%", null, null, "20rem"]}
       overflowY={["auto", null, null, "auto"]}
       display={["none", null, null, "block"]}

--- a/apps/designmanual-frontend/app/routes/_base/left-sidebar/LeftSidebar.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/left-sidebar/LeftSidebar.tsx
@@ -6,7 +6,12 @@ export const LeftSidebar = () => {
   return (
     <Box
       width={["100vw", null, null, "20rem"]}
-      maxHeight={["100vh", null, null, "calc(100vh - var(--header-height, 0px) - var(--footer-height, 0px))"]}
+      maxHeight={[
+        "100vh",
+        null,
+        null,
+        "calc(100vh - var(--header-height, 0px) - var(--footer-height, 0px))",
+      ]}
       minWidth={["100%", null, null, "20rem"]}
       overflowY={["auto", null, null, "auto"]}
       display={["none", null, null, "block"]}


### PR DESCRIPTION
 ## Background
It is not possible to scroll down to the bottom of the left menu.

## Solution
Make sure we take into account the footer height when scrolling the menu.

## Screenshots

`Before`

https://github.com/user-attachments/assets/30685122-9bc2-476d-a510-d926acb63c95

`After`

https://github.com/user-attachments/assets/4faa8449-99ea-4189-86da-c12464649386


