### PR TITLE
fix links in sidemenu

### DIFF
--- a/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
@@ -157,10 +157,7 @@ export const ContentMenu = ({ refreshKey, ref }: Props) => {
                     {subItems?.map((subItem) => (
                       <MenuItem
                         key={subItem.url}
-                        url={handleExternalMenu(
-                          item.link ?? item.url ?? "",
-                          isPreview,
-                        )}
+                        url={handleExternalMenu(subItem.url ?? "", isPreview)}
                         title={subItem.title}
                       />
                     ))}


### PR DESCRIPTION
## Background

Fikser lenkene i sidemenyen. 
Det ble brukt feil lenker, som gjorde at man bare ble sendt til forsiden når man trykket på dem. 
