### PR TITLE
Add Chakra's AccordionItem-props to the ExpandableItem

### DIFF
--- a/.changeset/orange-ravens-flash.md
+++ b/.changeset/orange-ravens-flash.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add Chakra's AccordionItem-props to the ExpandableItem

--- a/packages/spor-react/src/accordion/types.ts
+++ b/packages/spor-react/src/accordion/types.ts
@@ -1,5 +1,6 @@
 import {
   Accordion as ChakraAccordion,
+  AccordionItemProps,
   AccordionRootProps as ChakraAccordionProps,
   RecipeVariantProps,
 } from "@chakra-ui/react";
@@ -59,9 +60,10 @@ export type ExpandableProps = Omit<
     title: ReactNode;
   };
 
-export type ExpandableItemProps = HeadingLevel & {
-  value: string;
-  title: ReactNode;
-  children?: React.ReactNode;
-  startElement?: React.ReactNode;
-};
+export type ExpandableItemProps = HeadingLevel &
+  Omit<AccordionItemProps, "title"> & {
+    value: string;
+    title: ReactNode;
+    children?: React.ReactNode;
+    startElement?: React.ReactNode;
+  };


### PR DESCRIPTION
## Background

ExpandableItem is an AccordionItem "behind the scene", and it should therefore include all the props from AccordionItem that Chakra allows. 
