### PR TITLE
Add colorPalette disabled to badge

### DIFF
--- a/.changeset/angry-crabs-appear.md
+++ b/.changeset/angry-crabs-appear.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add disabled colorPalette to badge

--- a/packages/spor-react/src/theme/recipes/badge.ts
+++ b/packages/spor-react/src/theme/recipes/badge.ts
@@ -13,74 +13,52 @@ export const badgeRecipie = defineRecipe({
       neutral: {
         backgroundColor: "surface",
         color: "text",
-        "& svg": {
-          color: "icon",
-        },
+        "& svg": { color: "icon" },
       },
       grey: {
         backgroundColor: "surface.neutral",
         color: "text.neutral",
-        "& svg": {
-          color: "icon.neutral",
-        },
+        "& svg": { color: "icon.neutral" },
       },
       green: {
         backgroundColor: "surface.success",
         color: "text.success",
-        "& svg": {
-          color: "icon.success",
-        },
+        "& svg": { color: "icon.success" },
       },
       blue: {
         backgroundColor: "surface.info",
         color: "text.info",
-        "& svg": {
-          color: "icon.info",
-        },
+        "& svg": { color: "icon.info" },
       },
       cream: {
         backgroundColor: "surface.warning",
         color: "text.warning",
-        "& svg": {
-          color: "icon.warning",
-        },
+        "& svg": { color: "icon.warning" },
       },
       yellow: {
         backgroundColor: "surface.notice",
         color: "text.notice",
-        "& svg": {
-          color: "icon.notice",
-        },
+        "& svg": { color: "icon.notice" },
       },
       orange: {
         backgroundColor: "surface.caution",
         color: "text.caution",
-        "& svg": {
-          color: "icon.caution",
-        },
+        "& svg": { color: "icon.caution" },
       },
       red: {
         backgroundColor: "surface.critical",
         color: "text.critical",
-        "& svg": {
-          color: "icon.critical",
-        },
+        "& svg": { color: "icon.critical" },
       },
       brightRed: {
-        backgroundColor: {
-          _light: "brightRed",
-          _dark: "brightRed",
-        },
-        color: {
-          _light: "pink",
-          _dark: "pink",
-        },
-        "& svg": {
-          color: {
-            _light: "pink",
-            _dark: "pink",
-          },
-        },
+        backgroundColor: { _light: "brightRed", _dark: "brightRed" },
+        color: { _light: "pink", _dark: "pink" },
+        "& svg": { color: { _light: "pink", _dark: "pink" } },
+      },
+      disabled: {
+        backgroundColor: "surface.disabled",
+        color: "text.disabled",
+        "& svg": { color: "icon.disabled" },
       },
     },
     size: {
@@ -106,11 +84,7 @@ export const badgeRecipie = defineRecipe({
         borderRadius: "xs",
       },
     },
-    attached: {
-      true: {
-        borderBottomRadius: "none",
-      },
-    },
+    attached: { true: { borderBottomRadius: "none" } },
     inverted: { true: {} },
   },
   defaultVariants: {
@@ -124,60 +98,27 @@ export const badgeRecipie = defineRecipe({
       colorPalette: "blue",
       inverted: true,
       css: {
-        backgroundColor: {
-          _light: "darkBlue",
-          _dark: "lightBlue",
-        },
-        color: {
-          _light: "icyBlue",
-          _dark: "royal",
-        },
-        "& svg": {
-          color: {
-            _light: "royal",
-            _dark: "icyBlue",
-          },
-        },
+        backgroundColor: { _light: "darkBlue", _dark: "lightBlue" },
+        color: { _light: "icyBlue", _dark: "royal" },
+        "& svg": { color: { _light: "royal", _dark: "icyBlue" } },
       },
     },
     {
       colorPalette: "green",
       inverted: true,
       css: {
-        backgroundColor: {
-          _light: "darkTeal",
-          _dark: "seaMist",
-        },
-        color: {
-          _light: "mint",
-          _dark: "jungle",
-        },
-        "& svg": {
-          color: {
-            _light: "mint",
-            _dark: "jungle",
-          },
-        },
+        backgroundColor: { _light: "darkTeal", _dark: "seaMist" },
+        color: { _light: "mint", _dark: "jungle" },
+        "& svg": { color: { _light: "mint", _dark: "jungle" } },
       },
     },
     {
       colorPalette: "grey",
       inverted: true,
       css: {
-        backgroundColor: {
-          _light: "carbon",
-          _dark: "platinum",
-        },
-        color: {
-          _light: "white",
-          _dark: "darkGrey",
-        },
-        "& svg": {
-          color: {
-            _light: "white",
-            _dark: "darkGrey",
-          },
-        },
+        backgroundColor: { _light: "carbon", _dark: "platinum" },
+        color: { _light: "white", _dark: "darkGrey" },
+        "& svg": { color: { _light: "white", _dark: "darkGrey" } },
       },
     },
     {
@@ -185,80 +126,36 @@ export const badgeRecipie = defineRecipe({
       colorPalette: "cream",
       inverted: true,
       css: {
-        backgroundColor: {
-          _light: "coffee",
-          _dark: "blonde",
-        },
-        color: {
-          _light: "cornsilk",
-          _dark: "coffee",
-        },
-        "& svg": {
-          color: {
-            _light: "cornsilk",
-            _dark: "coffee",
-          },
-        },
+        backgroundColor: { _light: "coffee", _dark: "blonde" },
+        color: { _light: "cornsilk", _dark: "coffee" },
+        "& svg": { color: { _light: "cornsilk", _dark: "coffee" } },
       },
     },
     {
       colorPalette: "yellow",
       inverted: true,
       css: {
-        backgroundColor: {
-          _light: "bronze",
-          _dark: "banana",
-        },
-        color: {
-          _light: "cornsilk",
-          _dark: "coffee",
-        },
-        "& svg": {
-          color: {
-            _light: "cornsilk",
-            _dark: "coffee",
-          },
-        },
+        backgroundColor: { _light: "bronze", _dark: "banana" },
+        color: { _light: "cornsilk", _dark: "coffee" },
+        "& svg": { color: { _light: "cornsilk", _dark: "coffee" } },
       },
     },
     {
       colorPalette: "orange",
       inverted: true,
       css: {
-        backgroundColor: {
-          _light: "wood",
-          _dark: "champagne",
-        },
-        color: {
-          _light: "bisque",
-          _dark: "wood",
-        },
-        "& svg": {
-          color: {
-            _light: "bisque",
-            _dark: "wood",
-          },
-        },
+        backgroundColor: { _light: "wood", _dark: "champagne" },
+        color: { _light: "bisque", _dark: "wood" },
+        "& svg": { color: { _light: "bisque", _dark: "wood" } },
       },
     },
     {
       colorPalette: "red",
       inverted: true,
       css: {
-        backgroundColor: {
-          _light: "burgundy",
-          _dark: "lightRed",
-        },
-        color: {
-          _light: "pink",
-          _dark: "maroon",
-        },
-        "& svg": {
-          color: {
-            _light: "pink",
-            _dark: "maroon",
-          },
-        },
+        backgroundColor: { _light: "burgundy", _dark: "lightRed" },
+        color: { _light: "pink", _dark: "maroon" },
+        "& svg": { color: { _light: "pink", _dark: "maroon" } },
       },
     },
     {
@@ -266,20 +163,9 @@ export const badgeRecipie = defineRecipe({
       colorPalette: "neutral",
       inverted: true,
       css: {
-        backgroundColor: {
-          _light: "ink",
-          _dark: "white",
-        },
-        color: {
-          _light: "white",
-          _dark: "darkGrey",
-        },
-        "& svg": {
-          color: {
-            _light: "white",
-            _dark: "darkGrey",
-          },
-        },
+        backgroundColor: { _light: "ink", _dark: "white" },
+        color: { _light: "white", _dark: "darkGrey" },
+        "& svg": { color: { _light: "white", _dark: "darkGrey" } },
       },
     },
   ],

--- a/packages/spor-react/src/typography/Badge.tsx
+++ b/packages/spor-react/src/typography/Badge.tsx
@@ -6,18 +6,14 @@ import {
 } from "@chakra-ui/react";
 import { IconComponent } from "@vygruppen/spor-icon-react";
 
-export type BadgeProps = ChakraBadgeProps & {
-  icon?: IconComponent;
-};
+export type BadgeProps = ChakraBadgeProps & { icon?: IconComponent };
 
 export const Badge = function Badge({
   ref,
   icon,
   children,
   ...props
-}: BadgeProps & {
-  ref?: React.Ref<HTMLSpanElement>;
-}) {
+}: BadgeProps & { ref?: React.Ref<HTMLSpanElement> }) {
   return (
     <ChakraBadge ref={ref} {...props}>
       {children}

--- a/packages/spor-react/tsconfig.json
+++ b/packages/spor-react/tsconfig.json
@@ -6,9 +6,7 @@
     "lib": ["dom", "es2023"],
     "rootDir": ".",
 
-    "paths": {
-      "@/*": ["./src/*"]
-    },
+    "paths": { "@/*": ["./src/*"] },
     "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

We were missing colorPalette disabled for badges.

Figma link: https://www.figma.com/design/Tmr2URVX2vNkyRLqKhNRQA/Spor-komponentbibliotek?node-id=37593-27442&m=dev

---

## Solution
- Add disabled as a colorPalette to `packages/spor-react/src/theme/recipes/badge.ts`

---

## General Checklist

- [ ] I have updated documentation if necessary
- [x] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

---

## Screenshots

| Mode | Image |
| ------ | ----- |
|Dark mode|<img width="162" height="53" alt="image" src="https://github.com/user-attachments/assets/996fb847-efb8-4bad-ae38-e4de9e20f66b" />|
|Light mode| <img width="168" height="56" alt="image" src="https://github.com/user-attachments/assets/7cecc2aa-67c1-4064-8b79-4cf55abc1011" />|
