### PR TITLE
new design for articles

### DIFF
--- a/apps/design-studio/schemaTypes/documents/article.tsx
+++ b/apps/design-studio/schemaTypes/documents/article.tsx
@@ -84,6 +84,15 @@ export const article = defineType({
       type: "image",
     }),
     defineField({
+      name: "badges",
+      title: "Badges",
+      description:
+        "Used to display descriptive badges for the article, like 'New', 'Updated', 'Beta', or 'Deprecated'.",
+      type: "array",
+      of: [{ type: "badge" }],
+    }),
+
+    defineField({
       name: "resourceLinks",
       title: "Resource links",
       description:
@@ -202,6 +211,7 @@ export const article = defineType({
                   { value: "code", title: "Code" },
                   { value: "styling", title: "Styling" },
                   { value: "other", title: "Other" },
+                  { value: "codeExamples", title: "Code examples" },
                 ],
               },
             },
@@ -233,6 +243,15 @@ export const article = defineType({
               title: "Styling",
               type: "content",
               hidden: ({ parent }) => parent.title !== "code",
+            },
+            {
+              name: "codeExamples",
+              title: "Code examples",
+              type: "array",
+              of: [{ type: "codeExample" }],
+              hidden: ({ parent }) => {
+                return parent?.title !== "codeExamples";
+              },
             },
           ],
         },

--- a/apps/design-studio/schemaTypes/objects/badge.ts
+++ b/apps/design-studio/schemaTypes/objects/badge.ts
@@ -1,0 +1,52 @@
+import { CiShoppingTag } from "react-icons/ci";
+import { defineField, defineType } from "sanity";
+
+export const badge = defineType({
+  name: "badge",
+  title: "Badge",
+  type: "object",
+  icon: CiShoppingTag,
+  fields: [
+    defineField({
+      name: "badgeType",
+      title: "Type",
+      type: "string",
+      description: "The type of badge determines the color and style.",
+      initialValue: "updated",
+      options: {
+        list: [
+          { title: "New", value: "new" },
+          { title: "Updated", value: "updated" },
+          { title: "Beta", value: "beta" },
+          { title: "Deprecated", value: "deprecated" },
+        ],
+        layout: "radio",
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "description",
+      title: "Description",
+      type: "string",
+      description:
+        "Optional description to provide more context about why the badge is added to the article.",
+    }),
+  ],
+  preview: {
+    select: {
+      badgeType: "badgeType",
+    },
+    prepare(value) {
+      const badgeType = value.badgeType || "updated";
+      const titleMap: Record<string, string> = {
+        new: "New",
+        updated: "Updated",
+        beta: "Beta",
+        deprecated: "Deprecated",
+      };
+      return {
+        title: titleMap[badgeType] || badgeType,
+      };
+    },
+  },
+});

--- a/apps/design-studio/schemaTypes/objects/codeExample.tsx
+++ b/apps/design-studio/schemaTypes/objects/codeExample.tsx
@@ -9,6 +9,19 @@ export const codeExample = defineType({
   type: "object",
   fields: [
     defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      description: "Short title that is used to describe the code example.",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "description",
+      title: "Description",
+      type: "string",
+      description: "Description that is used to describe the code example.",
+    }),
+    defineField({
       name: "layout",
       title: "Layout",
       type: "string",
@@ -16,6 +29,7 @@ export const codeExample = defineType({
         list: ["simple", "preview-only", "code-only", "advanced"],
       },
       initialValue: "simple",
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       name: "reactCode",
@@ -25,6 +39,7 @@ export const codeExample = defineType({
         language: "react",
         languageAlternatives: [{ title: "React", value: "react" }],
       },
+      validation: (Rule) => Rule.required(),
     }),
   ],
   preview: {

--- a/apps/design-studio/schemaTypes/objects/index.tsx
+++ b/apps/design-studio/schemaTypes/objects/index.tsx
@@ -1,6 +1,7 @@
 export * from "./accordion";
 export * from "./accordionItem";
 export * from "./articleHeader";
+export * from "./badge";
 export * from "./bestPracticePanel";
 export * from "./buttonLink";
 export * from "./card";

--- a/apps/designmanual-frontend/app/features/portable-text/PortableText.tsx
+++ b/apps/designmanual-frontend/app/features/portable-text/PortableText.tsx
@@ -303,7 +303,7 @@ const components: Partial<PortableTextReactComponents> = {
           components={{
             block: {
               normal: ({ children }: any) => (
-                <Text variant="md">{children}</Text>
+                <Text variant="sm">{children}</Text>
               ),
             },
           }}

--- a/apps/designmanual-frontend/app/features/portable-text/code-block/CodeBlock.tsx
+++ b/apps/designmanual-frontend/app/features/portable-text/code-block/CodeBlock.tsx
@@ -7,7 +7,7 @@ import {
 import { Highlight } from "prism-react-renderer";
 import { Key, useRef } from "react";
 
-import { theme } from "./codeTheme";
+import { codeThemeCssVariables, theme } from "./codeTheme";
 import { sanitizeCode } from "./codeUtils";
 
 type CodeBlockProps = Omit<BoxProps, "children"> & {
@@ -23,12 +23,7 @@ export const CodeBlock = ({
   ...props
 }: CodeBlockProps) => {
   return (
-    <CodeBlockContainer
-      maxWidth="calc(100vw - var(--spor-space-6))"
-      {...props}
-      code={sanitizeCode(code)}
-      marginTop={2}
-    >
+    <CodeBlockContainer {...props} code={sanitizeCode(code)} marginTop={2}>
       <Highlight theme={theme} code={code} language={language}>
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <Box
@@ -83,23 +78,22 @@ export const CodeBlockContainer = ({
   };
   return (
     <Box
-      borderRadius="sm"
-      border="sm"
-      // eslint-disable-next-line spor/use-semantic-tokens
-      borderColor="osloGrey"
-      // eslint-disable-next-line spor/use-semantic-tokens
-      backgroundColor="darkGrey"
+      borderRadius="lg"
+      backgroundColor="surface.neutral"
       fontFamily="monospace"
-      fontSize={["mobile.sm", null, "desktop.sm"]}
+      fontSize={["mobile.sm", null, "desktop.xs"]}
       padding={2}
       position="relative"
       onKeyUp={handleKeyUp}
+      css={codeThemeCssVariables}
+      minHeight="12rem"
+      maxWidth="100%"
       {...props}
     >
       <Box position="absolute" top={2} right={2} ref={copyButtonRef}>
         <CopyCodeButton code={code} />
       </Box>
-      <Box>{children}</Box>
+      <Box overflowX="auto">{children}</Box>
     </Box>
   );
 };
@@ -122,7 +116,7 @@ type CopyCodeButtonProps = { code: string };
 export const CopyCodeButton = ({ code }: CopyCodeButtonProps) => {
   return (
     <Clipboard value={code}>
-      <ClipboardButton className="dark" variant="primary" />
+      <ClipboardButton variant="floating" />
     </Clipboard>
   );
 };

--- a/apps/designmanual-frontend/app/features/portable-text/code-block/codeTheme.ts
+++ b/apps/designmanual-frontend/app/features/portable-text/code-block/codeTheme.ts
@@ -1,28 +1,55 @@
 import { PrismTheme } from "prism-react-renderer";
 
-/** This is the shared theme used by all code highlighting */
+/**
+ * CSS variables used by the code theme.
+ * These are defined on the container element using Chakra's _light/_dark
+ * syntax, so switching is handled purely in CSS — no flash on refresh.
+ */
+export const codeThemeCssVariables = {
+  "--code-plain": { _light: "#2d2d2d", _dark: "#C5C8C6" },
+  "--code-comment": {
+    _light: "hsl(30, 10%, 40%)",
+    _dark: "hsl(30, 20%, 70%)",
+  },
+  "--code-property": {
+    _light: "hsl(350, 50%, 40%)",
+    _dark: "hsl(350, 40%, 70%)",
+  },
+  "--code-string": {
+    _light: "hsl(100, 50%, 30%)",
+    _dark: "hsl(75, 70%, 60%)",
+  },
+  "--code-operator": {
+    _light: "hsl(30, 80%, 35%)",
+    _dark: "hsl(40, 90%, 60%)",
+  },
+  "--code-deleted": { _light: "rgb(180, 40, 40)", _dark: "rgb(255, 85, 85)" },
+  "--code-regex": { _light: "#b85c00", _dark: "#e90" },
+  "--code-keyword": {
+    _light: "hsl(220, 50%, 40%)",
+    _dark: "hsl(350, 40%, 70%)",
+  },
+};
+
+/** Prism theme that references the CSS variables above */
 export const theme: PrismTheme = {
   plain: {
     // eslint-disable-next-line spor/use-semantic-tokens
-    color: "#C5C8C6",
+    color: "var(--code-plain)",
     backgroundColor: "transparent",
   },
   styles: [
     {
       types: ["prolog", "comment", "doctype", "cdata"],
-      style: {
-        color: "hsl(30, 20%, 70%)",
-      },
+      style: { color: "var(--code-comment)" },
     },
     {
       types: ["property", "tag", "boolean", "number", "constant", "symbol"],
-      style: { color: "hsl(350, 40%, 70%)" },
+      style: { color: "var(--code-property)" },
     },
     {
       types: ["attr-name", "string", "char", "builtin", "insterted"],
-      style: {
-        color: "hsl(75, 70%, 60%)",
-      },
+      style: { color: "var(--code-string)" },
     },
     {
       types: [
@@ -33,45 +60,31 @@ export const theme: PrismTheme = {
         "variable",
         "language-css",
       ],
-      style: {
-        color: "hsl(40, 90%, 60%)",
-      },
+      style: { color: "var(--code-operator)" },
     },
     {
       types: ["deleted"],
-      style: {
-        color: "rgb(255, 85, 85)",
-      },
+      style: { color: "var(--code-deleted)" },
     },
     {
       types: ["italic"],
-      style: {
-        fontStyle: "italic",
-      },
+      style: { fontStyle: "italic" },
     },
     {
       types: ["important", "bold"],
-      style: {
-        fontWeight: "bold",
-      },
+      style: { fontWeight: "bold" },
     },
     {
       types: ["regex", "important"],
-      style: {
-        color: "#e90",
-      },
+      style: { color: "var(--code-regex)" },
     },
     {
       types: ["atrule", "attr-value", "keyword"],
-      style: {
-        color: "hsl(350, 40%, 70%)",
-      },
+      style: { color: "var(--code-keyword)" },
     },
     {
       types: ["punctuation", "symbol"],
-      style: {
-        opacity: 0.7,
-      },
+      style: { opacity: 0.7 },
     },
   ],
 };

--- a/apps/designmanual-frontend/app/features/portable-text/components/ArticleAlert.tsx
+++ b/apps/designmanual-frontend/app/features/portable-text/components/ArticleAlert.tsx
@@ -1,0 +1,43 @@
+import {
+  IconComponent,
+  InformationOutline24Icon,
+  StarsOutline24Icon,
+  TokensFill24Icon,
+  WarningOutline24Icon,
+} from "@vygruppen/spor-icon-react";
+import { Alert, AlertProps } from "@vygruppen/spor-react";
+
+import { ArticleBadgeType } from "~/utils/initialSanityData.server";
+
+import { ArticleBadgeProps } from "./ArticleBadge";
+
+export const ArticleAlert = ({ badgeType, description }: ArticleBadgeType) => {
+  const articleBadgeAlertVariant: Record<
+    ArticleBadgeProps["badgeType"],
+    AlertProps["variant"]
+  > = {
+    new: "success",
+    updated: "info",
+    beta: "important",
+    deprecated: "error",
+  };
+  const articleBadgeAlertIcon: Record<
+    ArticleBadgeProps["badgeType"],
+    IconComponent
+  > = {
+    new: StarsOutline24Icon,
+    updated: InformationOutline24Icon,
+    beta: TokensFill24Icon,
+    deprecated: WarningOutline24Icon,
+  };
+  return (
+    <Alert
+      variant={articleBadgeAlertVariant[badgeType]}
+      icon={articleBadgeAlertIcon[badgeType]}
+      role="status"
+      aria-live="polite"
+    >
+      {description}
+    </Alert>
+  );
+};

--- a/apps/designmanual-frontend/app/features/portable-text/components/ArticleBadge.tsx
+++ b/apps/designmanual-frontend/app/features/portable-text/components/ArticleBadge.tsx
@@ -1,0 +1,58 @@
+import {
+  DeleteCircleOutline18Icon,
+  IconComponent,
+  NightOutline18Icon,
+  StarsOutline18Icon,
+  UpdateOutline18Icon,
+} from "@vygruppen/spor-icon-react";
+import { Badge, BadgeProps } from "@vygruppen/spor-react";
+
+import { ArticleBadgeType } from "~/utils/initialSanityData.server";
+
+type ArticleBadgeProps = Omit<ArticleBadgeType, "description">;
+
+export const ArticleBadge = ({
+  badgeType,
+  ...rest
+}: ArticleBadgeProps & BadgeProps) => {
+  const badgeColorMap: Record<
+    ArticleBadgeProps["badgeType"],
+    | "green"
+    | "blue"
+    | "yellow"
+    | "red"
+    | "neutral"
+    | "grey"
+    | "cream"
+    | "orange"
+    | "brightRed"
+    | undefined
+  > = {
+    new: "green",
+    updated: "blue",
+    beta: "yellow",
+    deprecated: "red",
+  };
+  const badgeTextMap = {
+    new: "New",
+    updated: "Updated",
+    beta: "Beta",
+    deprecated: "Deprecated",
+  };
+  const badgeIconMap: Record<ArticleBadgeProps["badgeType"], IconComponent> = {
+    new: StarsOutline18Icon,
+    updated: UpdateOutline18Icon,
+    beta: NightOutline18Icon,
+    deprecated: DeleteCircleOutline18Icon,
+  };
+
+  return (
+    <Badge
+      colorPalette={badgeColorMap[badgeType]}
+      {...rest}
+      icon={badgeIconMap[badgeType]}
+    >
+      {badgeTextMap[badgeType]}
+    </Badge>
+  );
+};

--- a/apps/designmanual-frontend/app/features/portable-text/components/ArticleBadge.tsx
+++ b/apps/designmanual-frontend/app/features/portable-text/components/ArticleBadge.tsx
@@ -1,15 +1,15 @@
 import {
-  DeleteCircleOutline18Icon,
   IconComponent,
-  NightOutline18Icon,
+  InformationOutline18Icon,
   StarsOutline18Icon,
-  UpdateOutline18Icon,
+  TokensOutline18Icon,
+  WarningOutline18Icon,
 } from "@vygruppen/spor-icon-react";
 import { Badge, BadgeProps } from "@vygruppen/spor-react";
 
 import { ArticleBadgeType } from "~/utils/initialSanityData.server";
 
-type ArticleBadgeProps = Omit<ArticleBadgeType, "description">;
+export type ArticleBadgeProps = Omit<ArticleBadgeType, "description">;
 
 export const ArticleBadge = ({
   badgeType,
@@ -41,9 +41,9 @@ export const ArticleBadge = ({
   };
   const badgeIconMap: Record<ArticleBadgeProps["badgeType"], IconComponent> = {
     new: StarsOutline18Icon,
-    updated: UpdateOutline18Icon,
-    beta: NightOutline18Icon,
-    deprecated: DeleteCircleOutline18Icon,
+    updated: InformationOutline18Icon,
+    beta: TokensOutline18Icon,
+    deprecated: WarningOutline18Icon,
   };
 
   return (

--- a/apps/designmanual-frontend/app/features/portable-text/interactive-code/LivePreview.tsx
+++ b/apps/designmanual-frontend/app/features/portable-text/interactive-code/LivePreview.tsx
@@ -10,12 +10,17 @@ export const LivePreview = (props: BoxProps) => {
       backgroundColor="bg"
       color="text"
       transition="all .1s ease-out"
-      padding={4}
-      paddingRight={8}
+      padding={9}
       position="relative"
       {...props}
     >
-      <ReactLivePreview Component={Box} />
+      <ReactLivePreview
+        Component={Box}
+        width="100%"
+        height="100%"
+        display="flex"
+        justifyContent="center"
+      />
     </Box>
   );
 };

--- a/apps/designmanual-frontend/app/root/layout/HeaderOffsetContext.tsx
+++ b/apps/designmanual-frontend/app/root/layout/HeaderOffsetContext.tsx
@@ -1,0 +1,5 @@
+import { createContext, useContext } from "react";
+
+export const HeaderOffsetContext = createContext(0);
+
+export const useHeaderOffset = () => useContext(HeaderOffsetContext);

--- a/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
+++ b/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
@@ -47,7 +47,7 @@ export const RootLayout = ({ children }: BaseLayoutProps) => {
             as="main"
             alignItems="stretch"
             marginLeft={[0, null, null, "21rem"]}
-            paddingTop={5}
+            paddingTop={8}
             flex={1}
             minWidth={0}
           >

--- a/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
+++ b/apps/designmanual-frontend/app/root/layout/RootLayout.tsx
@@ -6,6 +6,7 @@ import { LeftSidebar } from "~/routes/_base/left-sidebar/LeftSidebar";
 import { sendPageViewEvent } from "~/utils/analytics/metabaseCore";
 
 import { Footer } from "./Footer";
+import { HeaderOffsetContext } from "./HeaderOffsetContext";
 import { SiteHeader } from "./SiteHeader";
 
 type BaseLayoutProps = {
@@ -24,28 +25,37 @@ function usePageTracking() {
   }, [location.pathname]);
 }
 export const RootLayout = ({ children }: BaseLayoutProps) => {
-  const [headerOffset, setHeaderOffset] = useState(0);
+  const [headerOffset, setHeaderOffset] = useState(110);
 
   usePageTracking();
 
   return (
-    <Flex direction="column" minHeight="100vh" bg="bg" fontFamily="Vy Sans">
-      <SiteHeader onHeightChange={setHeaderOffset} />
+    <HeaderOffsetContext value={headerOffset}>
+      <Flex direction="column" minHeight="100vh" bg="bg" fontFamily="Vy Sans">
+        <SiteHeader onHeightChange={setHeaderOffset} />
 
-      <Flex marginX={[8, 8, 8, 0]} marginRight={8} flex={1} position="relative">
-        <LeftSidebar headerOffset={headerOffset} />
-        {/* Add left margin on large screens to account for the fixed sidebar width (20rem) */}
         <Flex
-          as="main"
-          flex="1"
-          alignItems="stretch"
-          marginLeft={[2, null, null, "20rem"]}
-          paddingTop={5}
+          marginX={[2, 6, 8, 0]}
+          marginRight={[2, 6, 6, 6]}
+          flex={1}
+          position="relative"
+          minWidth={0}
         >
-          {children}
+          <LeftSidebar headerOffset={headerOffset} />
+          {/* Add left margin on large screens to account for the fixed sidebar width (20rem) */}
+          <Flex
+            as="main"
+            alignItems="stretch"
+            marginLeft={[0, null, null, "21rem"]}
+            paddingTop={5}
+            flex={1}
+            minWidth={0}
+          >
+            {children}
+          </Flex>
         </Flex>
+        <Footer />
       </Flex>
-      <Footer />
-    </Flex>
+    </HeaderOffsetContext>
   );
 };

--- a/apps/designmanual-frontend/app/root/layout/SearchDocs/SearchDocsInput.tsx
+++ b/apps/designmanual-frontend/app/root/layout/SearchDocs/SearchDocsInput.tsx
@@ -12,18 +12,30 @@ import { useTopSearch } from "~/utils/useMenu";
 const useSearchableItems = () => {
   const menu = useTopSearch("side-menu-spor");
 
-  if (!menu?.menuItems) return [];
+  if (!menu) return [];
 
-  return menu.menuItems
-    .filter(({ _type, subItems }) => _type !== "divider" && subItems)
-    .flatMap(
-      ({ title, subItems }) =>
-        subItems?.map((subItem) => ({
-          ...subItem,
-          categoryTitle: title ?? "",
-          value: subItem.url,
-        })) ?? [],
-    );
+  const subItems = menu.menuItems
+    ? menu.menuItems
+        .filter(({ _type, subItems }) => _type !== "divider" && subItems)
+        .flatMap(
+          ({ title, subItems }) =>
+            subItems?.map((subItem) => ({
+              ...subItem,
+              categoryTitle: title ?? "",
+              value: subItem.url,
+            })) ?? [],
+        )
+    : [];
+
+  const components = (menu.components ?? []).map((component) => ({
+    title: component.title,
+    url: component.url,
+    categoryTitle: "Components",
+    value: component.url,
+    tags: [],
+  }));
+
+  return [...subItems, ...components];
 };
 
 const ComboboxItem = chakra(

--- a/apps/designmanual-frontend/app/root/layout/SiteHeader.tsx
+++ b/apps/designmanual-frontend/app/root/layout/SiteHeader.tsx
@@ -111,7 +111,7 @@ export const SiteHeader = ({
     }
     return true;
   });
-  const heightSpacer = ["72px", "90px", "120px", "138px"];
+  const heightSpacer = ["72px", "90px", "105px", "105px"];
 
   return (
     <Box minHeight={heightSpacer}>
@@ -131,7 +131,7 @@ export const SiteHeader = ({
       >
         <Flex
           as="header"
-          minHeight={["78px", "90px", "120px", "132px"]}
+          minHeight={["78px", "90px", "105px", "105px"]}
           position="relative"
           backgroundColor="bg"
           alignItems="center"

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ComponentDocs.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ComponentDocs.tsx
@@ -16,19 +16,21 @@ import { PortableText } from "~/features/portable-text/PortableText";
 import { CodeBlock } from "../../../features/portable-text/code-block/CodeBlock";
 import { LinkableHeading } from "../../../features/portable-text/LinkableHeading";
 
-type ComponentDocsProps = {
-  component: {
+export type Component = {
+  name: string;
+  content: unknown[];
+  props: {
+    platform: "react" | "react-native" | "react, react-native";
+    type: "other" | string;
+    typeOther?: string;
     name: string;
-    content: unknown[];
-    props: {
-      platform: "react" | "react-native" | "react, react-native";
-      type: "other" | string;
-      typeOther?: string;
-      name: string;
-      description?: string;
-      isRequired: boolean;
-    }[];
-  };
+    description?: string;
+    isRequired: boolean;
+  }[];
+};
+
+type ComponentDocsProps = {
+  component: Component;
 };
 export const ComponentDocs = ({ component }: ComponentDocsProps) => {
   const visibleProps = component.props?.filter((property) => {

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ComponentDocs.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ComponentDocs.tsx
@@ -37,57 +37,58 @@ export const ComponentDocs = ({ component }: ComponentDocsProps) => {
   });
   return (
     <Box key={component.name} as="section" marginBottom={9}>
-      <LinkableHeading as="h3" variant="md" fontWeight="bold" marginBottom={1}>
-        <Code fontSize="md">{`<${component.name} />`}</Code>
+      <LinkableHeading as="h3" variant="sm" marginBottom={1}>
+        <Code fontSize="sm" height="auto">{`<${component.name} />`}</Code>
       </LinkableHeading>
       <CodeBlock
         code={`import { ${component.name} } from "@vygruppen/spor-react";`}
+        minHeight="auto"
       />
       <Box marginTop={1}>
         <PortableText value={component.content} />
       </Box>
       {visibleProps && (
         <>
-          <Heading as="h4" variant="md" marginTop={3}>
+          <Heading as="h4" variant="sm" marginTop={3}>
             Props
           </Heading>
-          <Table
-            variant="core"
-            marginTop={3}
-            colorPalette="grey"
-            maxWidth="calc(100vw - var(--spor-space-6))"
-          >
-            <TableHeader>
-              <TableRow>
-                <TableColumnHeader>Name</TableColumnHeader>
-                <TableColumnHeader>Type</TableColumnHeader>
-                <TableColumnHeader>Required?</TableColumnHeader>
-                <TableColumnHeader>Description</TableColumnHeader>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {visibleProps.map((property) => (
-                <TableRow key={property.name}>
-                  <TableCell>
-                    <Code>{property.name}</Code>
-                  </TableCell>
-                  <TableCell>
-                    <Code>
-                      {property.type === "other"
-                        ? property.typeOther
-                        : property.type}
-                    </Code>
-                  </TableCell>
-                  <TableCell>
-                    {property.isRequired && (
-                      <SuccessFill24Icon aria-label="Required" marginX="auto" />
-                    )}
-                  </TableCell>
-                  <TableCell>{property.description}</TableCell>
+          <Box overflowX="auto" marginTop={3}>
+            <Table variant="core" colorPalette="grey" maxWidth="100%">
+              <TableHeader>
+                <TableRow>
+                  <TableColumnHeader>Name</TableColumnHeader>
+                  <TableColumnHeader>Type</TableColumnHeader>
+                  <TableColumnHeader>Required?</TableColumnHeader>
+                  <TableColumnHeader>Description</TableColumnHeader>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {visibleProps.map((property) => (
+                  <TableRow key={property.name}>
+                    <TableCell>
+                      <Code>{property.name}</Code>
+                    </TableCell>
+                    <TableCell>
+                      <Code>
+                        {property.type === "other"
+                          ? property.typeOther
+                          : property.type}
+                      </Code>
+                    </TableCell>
+                    <TableCell>
+                      {property.isRequired && (
+                        <SuccessFill24Icon
+                          aria-label="Required"
+                          marginX="auto"
+                        />
+                      )}
+                    </TableCell>
+                    <TableCell>{property.description}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Box>
         </>
       )}
     </Box>

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ExampleSection.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ExampleSection.tsx
@@ -1,0 +1,58 @@
+import { CheckboxGroup, Flex, Text } from "@chakra-ui/react";
+import { FilterChip } from "@vygruppen/spor-react";
+import { useState } from "react";
+
+import { InteractiveCode } from "~/features/portable-text/interactive-code/InteractiveCode";
+
+import { CodeExample } from "../route";
+
+export const ExamplesSection = ({
+  codeExamples,
+}: {
+  codeExamples: CodeExample[];
+}) => {
+  const [currentExampleIndex, setCurrentExampleIndex] = useState(
+    codeExamples.length > 0 ? codeExamples[0].title : "",
+  );
+  return (
+    <Flex direction="column" gap={3} as="section">
+      {codeExamples.length === 0 ? (
+        <Text>No examples exist (yet!)</Text>
+      ) : (
+        <CheckboxGroup defaultValue={[currentExampleIndex]}>
+          <Flex flexWrap="wrap" gap={1}>
+            {codeExamples.map((example, index) => (
+              <FilterChip
+                key={index}
+                variant="accent"
+                value={example.title}
+                checked={currentExampleIndex === example.title}
+                onCheckedChange={() => {
+                  setCurrentExampleIndex(example.title);
+                }}
+                size="xs"
+              >
+                {example.title}
+              </FilterChip>
+            ))}
+          </Flex>
+        </CheckboxGroup>
+      )}
+      <Text>
+        {
+          codeExamples.find((example) => example.title === currentExampleIndex)
+            ?.description
+        }
+      </Text>
+
+      <InteractiveCode
+        layout="simple"
+        maxWidth="100%"
+        code={
+          codeExamples.find((example) => example.title === currentExampleIndex)
+            ?.reactCode?.code ?? ""
+        }
+      />
+    </Flex>
+  );
+};

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ExampleSection.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ExampleSection.tsx
@@ -38,7 +38,7 @@ export const ExamplesSection = ({
           </Flex>
         </CheckboxGroup>
       )}
-      <Text>
+      <Text fontSize="sm">
         {
           codeExamples.find((example) => example.title === currentExampleIndex)
             ?.description

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ExampleSection.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ExampleSection.tsx
@@ -23,7 +23,7 @@ export const ExamplesSection = ({
           <Flex flexWrap="wrap" gap={1}>
             {codeExamples.map((example, index) => (
               <FilterChip
-                key={index}
+                key={index + example.title}
                 variant="accent"
                 value={example.title}
                 checked={currentExampleIndex === example.title}

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
@@ -242,6 +242,26 @@ export default function ArticlePage() {
             </Stack>
           </Flex>
 
+          <Box
+            width="20%"
+            display="none"
+            position="fixed"
+            overflow="auto"
+            right={0}
+            paddingLeft={1}
+            paddingTop={3}
+            top={`${headerOffset}px`}
+            transition="all .3s linear"
+            height={`calc(100vh - ${headerOffset}px)`}
+            css={{
+              [`@media screen and (min-width: 1110px)`]: {
+                display: "block",
+              },
+            }}
+          >
+            <RightSidebar />
+          </Box>
+
           {article.componentSections ? (
             <ComponentSections
               id={article._id}
@@ -268,24 +288,6 @@ export default function ArticlePage() {
           },
         }}
       />
-      <Box
-        width="20%"
-        display="none"
-        position="fixed"
-        overflow="auto"
-        right={0}
-        paddingTop={3}
-        top={`${headerOffset}px`}
-        transition="all .3s linear"
-        height={`calc(100vh - ${headerOffset}px)`}
-        css={{
-          [`@media screen and (min-width: 1110px)`]: {
-            display: "block",
-          },
-        }}
-      >
-        <RightSidebar />
-      </Box>
     </Flex>
   );
 }

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
@@ -10,13 +10,12 @@ import {
   createSystem,
   Flex,
   Heading,
-  slugify,
   SporProvider,
   Stack,
   Text,
   themes,
 } from "@vygruppen/spor-react";
-import { PropsWithChildren } from "react";
+import { type ComponentProps, PropsWithChildren } from "react";
 import {
   Link,
   type LoaderFunctionArgs,
@@ -37,8 +36,8 @@ import {
   urlBuilder,
 } from "~/utils/sanity/utils";
 import { toTitleCase } from "~/utils/stringUtils";
-import { useHeadingsMenu } from "~/utils/useHeadingsMenu";
 
+import { RightSidebar } from "../_base/right-sidebar/RightSidebar";
 import { ExamplesSection } from "./component-docs/ExampleSection";
 
 type ResourceLink = {
@@ -54,6 +53,9 @@ export type CodeExample = {
     code: string;
   };
 };
+
+type ComponentDocsComponent = ComponentProps<typeof ComponentDocs>["component"];
+
 type ComponentSection = {
   _id: string;
   title: "guidelines" | "examples" | "code" | "other" | "codeExamples";
@@ -63,13 +65,7 @@ type ComponentSection = {
     badgeType: "new" | "updated" | "beta" | "deprecated";
     description?: string;
   }[];
-  components?: {
-    _id: string;
-    name: string;
-    slug: string;
-    props: unknown[];
-    content: unknown[];
-  }[];
+  components?: ComponentDocsComponent[];
   styling: unknown[];
   codeExamples: CodeExample[];
 };
@@ -188,12 +184,10 @@ export default function ArticlePage() {
   const { initialData, isPreview } = useLoaderData<typeof loader>();
   const article = initialData[0];
   const headerOffset = useHeaderOffset();
-  const rawHeadingsMenu = useHeadingsMenu();
 
   if (!article) {
     return null;
   }
-  const onThisPageLinks = article.componentSections ?? rawHeadingsMenu;
 
   return (
     <Flex gap={8} justifyContent="space-between">
@@ -290,21 +284,7 @@ export default function ArticlePage() {
           },
         }}
       >
-        <Stack gap={1}>
-          <Text fontWeight="bold" marginLeft={2}>
-            On this page
-          </Text>
-          {onThisPageLinks?.map((section) => (
-            <Button key={section.title} variant="ghost" size="sm" asChild>
-              <Link to={`#${slugify(section.title)}`}>
-                {getCorrectTitle({
-                  title: section.title,
-                  customTitle: section.customTitle,
-                })}
-              </Link>
-            </Button>
-          ))}
-        </Stack>
+        <RightSidebar />
       </Box>
     </Flex>
   );
@@ -357,7 +337,7 @@ const ComponentSections = ({ sections }: ComponentSectionsProps) => {
               />
             )}
             {section.components?.map((component) => (
-              <ComponentDocs key={component._id} component={component as any} />
+              <ComponentDocs key={component.name} component={component} />
             ))}
             {section.content && <PortableText value={section.content} />}
           </Stack>

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
@@ -1,41 +1,35 @@
 import { PortableTextBlock } from "@portabletext/react";
 import { groq } from "@sanity/groq-store";
 import { sidesporConfig } from "@vygruppen/sidespor-config";
+import { LinkOutOutline18Icon } from "@vygruppen/spor-icon-react";
 import {
-  FigmaOutline24Icon,
-  GithubOutline24Icon,
-} from "@vygruppen/spor-icon-react";
-import {
+  Alert,
   Badge,
   Box,
-  Brand,
   Button,
   createSystem,
   Flex,
   Heading,
-  HStack,
-  Separator,
+  slugify,
   SporProvider,
   Stack,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
   Text,
   themes,
 } from "@vygruppen/spor-react";
 import { PropsWithChildren } from "react";
 import {
+  Link,
   type LoaderFunctionArgs,
   type MetaFunction,
   useLoaderData,
 } from "react-router";
 import invariant from "tiny-invariant";
 
+import { ArticleBadge } from "~/features/portable-text/components/ArticleBadge";
 import { PortableText } from "~/features/portable-text/PortableText";
+import { useHeaderOffset } from "~/root/layout/HeaderOffsetContext";
 import { ComponentDocs } from "~/routes/_base.$section.$category.$slug/component-docs/ComponentDocs";
-import { sendCustomEvent } from "~/utils/analytics/metabase";
-import { useBrand } from "~/utils/brand";
+import { ArticleBadgeType } from "~/utils/initialSanityData.server";
 import { getClient } from "~/utils/sanity/client";
 import {
   blockContentToPlainText,
@@ -43,16 +37,32 @@ import {
   urlBuilder,
 } from "~/utils/sanity/utils";
 import { toTitleCase } from "~/utils/stringUtils";
+import { useHeadingsMenu } from "~/utils/useHeadingsMenu";
+
+import { ExamplesSection } from "./component-docs/ExampleSection";
 
 type ResourceLink = {
   linkType: "figma" | "react" | "react-native";
   url: string;
 };
+
+export type CodeExample = {
+  title: string;
+  description?: string;
+  layout: "simple" | "preview-only" | "code-only" | "advanced";
+  reactCode: {
+    code: string;
+  };
+};
 type ComponentSection = {
   _id: string;
-  title: "guidelines" | "examples" | "code" | "other";
+  title: "guidelines" | "examples" | "code" | "other" | "codeExamples";
   customTitle?: string;
   content: unknown[];
+  badges?: {
+    badgeType: "new" | "updated" | "beta" | "deprecated";
+    description?: string;
+  }[];
   components?: {
     _id: string;
     name: string;
@@ -61,6 +71,7 @@ type ComponentSection = {
     content: unknown[];
   }[];
   styling: unknown[];
+  codeExamples: CodeExample[];
 };
 
 export const extendedSystemConfigWithSidespor = createSystem(
@@ -86,6 +97,10 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
       title,
       "slug": slug.current
     },
+    badges[] {
+      badgeType, 
+      description
+    },
     resourceLinks[linkType == "react" || linkType == "react-native" || linkType == "figma"],
     content[]{
       _type == 'reference' => @->,
@@ -100,6 +115,12 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
       components[] {
         _type == 'reference' => @->,
         _type != 'reference' => @,
+      },
+      codeExamples[]{
+        title,
+        description,
+        layout,
+        reactCode,
       }
     }
   }`;
@@ -165,81 +186,127 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
 export default function ArticlePage() {
   const { initialData, isPreview } = useLoaderData<typeof loader>();
-  const brand = useBrand();
-
   const article = initialData[0];
+  const headerOffset = useHeaderOffset();
+  const rawHeadingsMenu = useHeadingsMenu();
 
   if (!article) {
     return null;
   }
+  const onThisPageLinks = article.componentSections ?? rawHeadingsMenu;
 
   return (
-    <>
-      <Flex
-        marginBottom={1}
-        gap={6}
-        justifyContent="space-between"
-        alignContent="stretch"
-      >
-        <HStack>
+    <Flex gap={8} justifyContent="space-between">
+      <Box flex={1} minWidth={0}>
+        <Flex marginBottom={1.5} gap={1}>
           {article?.category?.title && (
-            <Badge colorPalette={brand === Brand.CargoNet ? "orange" : "green"}>
-              {article?.category?.title}
-            </Badge>
+            <Badge>{article?.category?.title}</Badge>
           )}
+          {article.badges?.map((badge: ArticleBadgeType) => (
+            <ArticleBadge key={badge.badgeType} badgeType={badge.badgeType} />
+          ))}
           {isPreview && <Badge colorPalette="yellow">Preview</Badge>}
-        </HStack>
-        <Flex wrap="wrap" gap={2} marginLeft="auto" justifyContent="end">
-          {article.resourceLinks?.map((link: ResourceLink) => (
-            <Button
-              key={link.url}
-              variant="tertiary"
-              size="sm"
-              leftIcon={mapLinkToIcon(link.linkType)}
-              onClick={() => window.open(link.url, "_blank")}
-            >
-              {mapLinkToLabel(link.linkType)}
+        </Flex>
+        <Flex direction="column" gap={8}>
+          <Flex gap={3} direction="column">
+            <Heading as="h1" variant="xl-display" autoId>
+              {article.title}
+            </Heading>
+            {article.introduction && (
+              <PortableText
+                value={article.introduction}
+                components={{
+                  block: {
+                    normal: ({ children }: PropsWithChildren) => (
+                      <Text variant="md">{children}</Text>
+                    ),
+                  },
+                }}
+              />
+            )}
+            <Flex gap={1}>
+              {article.resourceLinks?.map((link: ResourceLink) => (
+                <Button
+                  asChild
+                  key={link.url}
+                  variant="tertiary"
+                  size="sm"
+                  rightIcon={<LinkOutOutline18Icon />}
+                >
+                  <Link to={link.url} target="_blank">
+                    {mapLinkToLabel(link.linkType)}
+                  </Link>
+                </Button>
+              ))}
+            </Flex>
+            <Stack direction="column" gap={2}>
+              {article.badges?.map((badge: ArticleBadgeType, index: number) => (
+                <Alert key={index} variant="info">
+                  {badge.description}
+                </Alert>
+              ))}
+            </Stack>
+          </Flex>
+
+          {article.componentSections ? (
+            <ComponentSections
+              id={article._id}
+              sections={article.componentSections}
+              component={article.title}
+            />
+          ) : article.title.includes("Sidespor") ? (
+            <SporProvider theme={extendedSystemConfigWithSidespor}>
+              <PortableText value={article.content} />
+            </SporProvider>
+          ) : (
+            <Box>
+              <PortableText value={article.content} />
+            </Box>
+          )}
+        </Flex>
+      </Box>
+      <Box
+        width="20%"
+        display="none"
+        css={{
+          [`@media screen and (min-width: 1110px)`]: {
+            display: "block",
+          },
+        }}
+      />
+      <Box
+        width="20%"
+        display="none"
+        position="fixed"
+        overflow="auto"
+        right={0}
+        paddingTop={3}
+        top={`${headerOffset}px`}
+        transition="all .3s linear"
+        height={`calc(100vh - ${headerOffset}px)`}
+        css={{
+          [`@media screen and (min-width: 1110px)`]: {
+            display: "block",
+          },
+        }}
+      >
+        <Stack gap={1}>
+          <Text fontWeight="bold" marginLeft={2}>
+            On this page
+          </Text>
+          {onThisPageLinks?.map((section) => (
+            <Button key={section.title} variant="ghost" size="sm" asChild>
+              <Link to={`#${slugify(section.title)}`}>
+                {getCorrectTitle({
+                  title: section.title,
+                  customTitle: section.customTitle,
+                })}
+              </Link>
             </Button>
           ))}
-        </Flex>
-      </Flex>
-      <Flex direction="column">
-        <Heading as="h1" variant="xl-display" marginBottom={2}>
-          {article.title}
-        </Heading>
-        {article.introduction && (
-          <Box marginBottom={3}>
-            <PortableText
-              value={article.introduction}
-              components={{
-                block: {
-                  normal: ({ children }: PropsWithChildren) => (
-                    <Text variant="md">{children}</Text>
-                  ),
-                },
-              }}
-            />
-          </Box>
-        )}
-        {article.componentSections ? (
-          <ComponentSections
-            id={article._id}
-            sections={article.componentSections}
-            component={article.title}
-          />
-        ) : (
-          <Box>
-            {article.title.includes("Sidespor") ? (
-              <SporProvider theme={extendedSystemConfigWithSidespor}>
-                <PortableText value={article.content} />
-              </SporProvider>
-            ) : (
-              <PortableText value={article.content} />
-            )}
-          </Box>
-        )}
-      </Flex>
-    </>
+        </Stack>
+      </Box>
+    </Flex>
   );
 }
 
@@ -249,7 +316,7 @@ const mapLinkToLabel = (linkType: ResourceLink["linkType"]) => {
       return "Figma";
     }
     case "react": {
-      return "React";
+      return "GitHub";
     }
     case "react-native": {
       return "React Native";
@@ -260,93 +327,43 @@ const mapLinkToLabel = (linkType: ResourceLink["linkType"]) => {
   }
 };
 
-const mapLinkToIcon = (linkType: ResourceLink["linkType"]) => {
-  switch (linkType) {
-    case "figma": {
-      return <FigmaOutline24Icon />;
-    }
-    default: {
-      return <GithubOutline24Icon />;
-    }
-  }
-};
-
 type ComponentSectionsProps = {
   component: string;
   sections: ComponentSection[];
   id: string;
 };
-const ComponentSections = ({
-  component,
-  sections,
-  id,
-}: ComponentSectionsProps) => {
+const ComponentSections = ({ sections }: ComponentSectionsProps) => {
   return (
-    <Tabs
-      variant="accent"
-      size="md"
-      marginTop={4}
-      fitted={true}
-      lazyMount
-      key={id}
-      defaultValue={sections[0].customTitle || sections[0].title}
-    >
-      <TabsList>
-        {sections.map((section) => (
-          <TabsTrigger
-            key={section.title}
-            value={section.title}
-            onClick={() =>
-              sendCustomEvent({
-                event: "component_tab_visited",
-                properties: {
-                  tab: section.title,
-                  component: component,
-                },
-              })
-            }
-          >
-            {`${section.title.charAt(0).toUpperCase()}${section.title.slice(1)}`}
-          </TabsTrigger>
-        ))}
-      </TabsList>
-      <Separator marginY={4} />
+    <>
       {sections.map((section) => (
-        <TabsContent
-          key={section.customTitle || section.title}
-          value={section.customTitle || section.title}
-        >
-          <Heading as="h2" variant="lg" marginBottom={1}>
+        <Box key={section._id}>
+          <Heading
+            as="h2"
+            variant="lg"
+            fontWeight="bold"
+            marginBottom={1}
+            autoId
+          >
             {getCorrectTitle({
               title: section.title,
               customTitle: section.customTitle,
             })}
           </Heading>
           <Stack>
-            {section.content && <PortableText value={section.content} />}
+            {section.title === "codeExamples" && (
+              <ExamplesSection
+                key={section._id}
+                codeExamples={section.codeExamples ?? []}
+              />
+            )}
             {section.components?.map((component) => (
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               <ComponentDocs key={component._id} component={component as any} />
             ))}
-            {section.styling && (
-              <Box as="section">
-                <Heading
-                  as="h3"
-                  variant="md"
-                  fontWeight="bold"
-                  marginBottom={1}
-                >
-                  Styling
-                </Heading>
-                <Box marginTop={1}>
-                  <PortableText value={section.styling} />
-                </Box>
-              </Box>
-            )}
+            {section.content && <PortableText value={section.content} />}
           </Stack>
-        </TabsContent>
+        </Box>
       ))}
-    </Tabs>
+    </>
   );
 };
 
@@ -356,6 +373,9 @@ const getCorrectTitle = ({ title, customTitle }: GetCorrectTitleArguments) => {
     case "examples": {
       return "Examples";
     }
+    case "codeExamples": {
+      return "Code examples";
+    }
     case "guidelines": {
       return "Guidelines";
     }
@@ -364,6 +384,9 @@ const getCorrectTitle = ({ title, customTitle }: GetCorrectTitleArguments) => {
     }
     case "other": {
       return toTitleCase(customTitle ?? "");
+    }
+    default: {
+      return title;
     }
   }
 };

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
@@ -3,7 +3,6 @@ import { groq } from "@sanity/groq-store";
 import { sidesporConfig } from "@vygruppen/sidespor-config";
 import { LinkOutOutline18Icon } from "@vygruppen/spor-icon-react";
 import {
-  Alert,
   Badge,
   Box,
   Button,
@@ -24,6 +23,7 @@ import {
 } from "react-router";
 import invariant from "tiny-invariant";
 
+import { ArticleAlert } from "~/features/portable-text/components/ArticleAlert";
 import { ArticleBadge } from "~/features/portable-text/components/ArticleBadge";
 import { PortableText } from "~/features/portable-text/PortableText";
 import { useHeaderOffset } from "~/root/layout/HeaderOffsetContext";
@@ -190,7 +190,7 @@ export default function ArticlePage() {
   }
 
   return (
-    <Flex gap={8} justifyContent="space-between">
+    <Flex gap={5} justifyContent="space-between">
       <Box flex={1} minWidth={0}>
         <Flex marginBottom={1.5} gap={1}>
           {article?.category?.title && (
@@ -201,7 +201,7 @@ export default function ArticlePage() {
           ))}
           {isPreview && <Badge colorPalette="yellow">Preview</Badge>}
         </Flex>
-        <Flex direction="column" gap={8}>
+        <Flex direction="column" gap={5}>
           <Flex gap={3} direction="column">
             <Heading as="h1" variant="xl-display" autoId>
               {article.title}
@@ -233,14 +233,16 @@ export default function ArticlePage() {
                 </Button>
               ))}
             </Flex>
-            <Stack direction="column" gap={2}>
-              {article.badges?.map((badge: ArticleBadgeType, index: number) => (
-                <Alert key={index} variant="info">
-                  {badge.description}
-                </Alert>
-              ))}
-            </Stack>
           </Flex>
+          <Stack direction="column" gap={2}>
+            {article.badges?.map((badge: ArticleBadgeType, index: number) => (
+              <ArticleAlert
+                key={index}
+                badgeType={badge.badgeType}
+                description={badge.description}
+              />
+            ))}
+          </Stack>
 
           <Box
             width="20%"

--- a/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
@@ -312,7 +312,7 @@ const MobileMenu = ({ sections, mobileMenus, isPreview }: MobileMenuProps) => {
                   )
                   ?.components?.map((component: Component, index: number) => (
                     <MenuItem
-                      key={index}
+                      key={index + component.url}
                       url={component.url}
                       title={component.title}
                       badges={component.badges}

--- a/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
@@ -15,7 +15,7 @@ import { useLocation, useNavigate, useRouteLoaderData } from "react-router";
 
 import { loader } from "~/root";
 import { getIcon } from "~/utils/getIcon";
-import type { Section } from "~/utils/initialSanityData.server";
+import type { Component, Section } from "~/utils/initialSanityData.server";
 import { useHeadingsMenu } from "~/utils/useHeadingsMenu";
 import { useMenu } from "~/utils/useMenu";
 
@@ -80,9 +80,8 @@ export const ContentMenu = ({ refreshKey, ref }: Props) => {
             <MenuItem
               key={`${section.slug.current}_m`}
               url={`/${section.slug.current}${isPreview ? "?sanity-preview-perspective=drafts" : ""}`}
-            >
-              {section.title}
-            </MenuItem>
+              title={section.title}
+            />
           ))}
         <MobileMenu
           sections={sections}
@@ -98,7 +97,7 @@ export const ContentMenu = ({ refreshKey, ref }: Props) => {
         onValueChange={(details) => setExpanded(details.value)}
         key={refreshKey}
         display={["none", null, null, "block"]}
-        paddingLeft={7}
+        paddingLeft={2}
         paddingRight={1}
         paddingTop={3}
         gap={1}
@@ -144,6 +143,7 @@ export const ContentMenu = ({ refreshKey, ref }: Props) => {
                   }
                 }}
                 fontSize="xs"
+                fontWeight="normal"
               >
                 {item.title}
               </AccordionItemTrigger>
@@ -173,9 +173,9 @@ export const ContentMenu = ({ refreshKey, ref }: Props) => {
                   <Stack as="ul">
                     {headingsMenu.map((subItem) => (
                       <MenuItem
-                        key={subItem.text}
+                        key={subItem.title}
                         url={`${location.pathname}#${subItem.id}`}
-                        title={subItem.text}
+                        title={subItem.title}
                       />
                     ))}
                   </Stack>
@@ -185,6 +185,22 @@ export const ContentMenu = ({ refreshKey, ref }: Props) => {
           );
         })}
       </Accordion>
+      {isSpor && (
+        <Stack
+          paddingLeft={3}
+          gap={0.5}
+          display={["none", null, null, "block"]}
+        >
+          {menu?.components?.map((component: Component, index: number) => (
+            <MenuItem
+              key={index}
+              url={component.url}
+              title={component.title}
+              badges={component.badges}
+            />
+          ))}
+        </Stack>
+      )}
     </Box>
   );
 };
@@ -215,6 +231,7 @@ export type MenuType = {
   slug?: string;
   url?: string;
   link?: string;
+  components?: Component[];
 };
 
 type MobileMenuProps = {
@@ -225,6 +242,9 @@ type MobileMenuProps = {
 };
 
 const MobileMenu = ({ sections, mobileMenus, isPreview }: MobileMenuProps) => {
+  const hasComponents = mobileMenus?.some(
+    (menu) => menu.components && menu.components.length > 0,
+  );
   return (
     <Stack gap="2" direction="column">
       {sections &&
@@ -247,18 +267,7 @@ const MobileMenu = ({ sections, mobileMenus, isPreview }: MobileMenuProps) => {
                 if (item._type === "divider") {
                   return null;
                 } else if (item._type === "heading") {
-                  return (
-                    <Text
-                      key={item.title}
-                      fontSize="xs"
-                      fontWeight="bold"
-                      color="text.subtle"
-                      paddingX={3}
-                      marginTop={2}
-                    >
-                      {item.title}
-                    </Text>
-                  );
+                  return null;
                 } else if (item.subItems && item.subItems.length > 0) {
                   return (
                     <Expandable
@@ -267,8 +276,9 @@ const MobileMenu = ({ sections, mobileMenus, isPreview }: MobileMenuProps) => {
                       title={item.title}
                       variant="ghost"
                       marginBottom={2}
-                      paddingLeft={6}
+                      marginLeft={2}
                       as="ul"
+                      fontWeight="normal"
                     >
                       {item.subItems.map((subItem) => (
                         <MenuItem
@@ -291,6 +301,28 @@ const MobileMenu = ({ sections, mobileMenus, isPreview }: MobileMenuProps) => {
                   />
                 );
               })}
+            {hasComponents && section.slug?.current === "spor" && (
+              <Expandable
+                marginLeft={2}
+                title="Components"
+                variant="ghost"
+                collapsible
+                as="ul"
+              >
+                {mobileMenus
+                  ?.find(
+                    (menu) => section.slug.current === menu.relatedTo?.slug,
+                  )
+                  ?.components?.map((component: Component, index: number) => (
+                    <MenuItem
+                      key={index}
+                      url={component.url}
+                      title={component.title}
+                      badges={component.badges}
+                    />
+                  ))}
+              </Expandable>
+            )}
           </Expandable>
         ))}
     </Stack>

--- a/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
@@ -190,7 +190,7 @@ export const ContentMenu = ({ refreshKey, ref }: Props) => {
         >
           {menu?.components?.map((component: Component, index: number) => (
             <MenuItem
-              key={index}
+              key={index + component.url}
               url={component.url}
               title={component.title}
               badges={component.badges}

--- a/apps/designmanual-frontend/app/routes/_base/content-menu/MenuItem.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/MenuItem.tsx
@@ -41,12 +41,7 @@ export const MenuItem = ({ url, title, badges }: MenuItemProps) => {
           target={isExternal ? "_blank" : undefined}
           rel={isExternal ? "noopener noreferrer" : undefined}
         >
-          <Stack
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-            width="100%"
-          >
+          <Stack direction="row" alignItems="center" width="100%">
             {title}
             {badges && (
               <Stack direction="row">

--- a/apps/designmanual-frontend/app/routes/_base/content-menu/MenuItem.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/MenuItem.tsx
@@ -1,17 +1,20 @@
-import { Box, Button, FlexProps } from "@vygruppen/spor-react";
+import { Box, Button, FlexProps, Stack } from "@vygruppen/spor-react";
 import { Link } from "react-router";
 
+import { ArticleBadge } from "~/features/portable-text/components/ArticleBadge";
 import { sendCustomEvent } from "~/utils/analytics/metabase";
+import { ArticleBadgeType } from "~/utils/initialSanityData.server";
 
 type MenuItemProps = FlexProps & {
   url: string;
   title?: string;
+  badges?: ArticleBadgeType[];
 };
 /**
  * Menu item in the `ContentMenu`, and search result in the `SearchResults`.
  */
 
-export const MenuItem = ({ url, title }: MenuItemProps) => {
+export const MenuItem = ({ url, title, badges }: MenuItemProps) => {
   const isExternal = url.includes("http");
   return (
     <Box as="li" listStyle="none">
@@ -38,7 +41,21 @@ export const MenuItem = ({ url, title }: MenuItemProps) => {
           target={isExternal ? "_blank" : undefined}
           rel={isExternal ? "noopener noreferrer" : undefined}
         >
-          {title}
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            width="100%"
+          >
+            {title}
+            {badges && (
+              <Stack direction="row">
+                {badges.map((badge) => (
+                  <ArticleBadge key={badge.badgeType} {...badge} size="sm" />
+                ))}
+              </Stack>
+            )}
+          </Stack>
         </Link>
       </Button>
     </Box>

--- a/apps/designmanual-frontend/app/routes/_base/left-sidebar/LeftSidebar.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/left-sidebar/LeftSidebar.tsx
@@ -12,7 +12,7 @@ export const LeftSidebar = ({ headerOffset }: { headerOffset: number }) => {
   };
   return (
     <Box
-      width={[null, null, null, "20rem"]}
+      width={[null, null, null, "18rem"]}
       height={["100vh", null, null, `calc(100vh - ${headerOffset}px)`]}
       display={["none", null, null, "block"]}
       top={`${headerOffset}px`}

--- a/apps/designmanual-frontend/app/routes/_base/right-sidebar/RightSidebar.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/right-sidebar/RightSidebar.tsx
@@ -1,0 +1,22 @@
+import { Button, slugify, Stack, Text } from "@vygruppen/spor-react";
+import { Link } from "react-router";
+
+import { useHeadingsMenu } from "~/utils/useHeadingsMenu";
+
+export const RightSidebar = () => {
+  const rawHeadingsMenu = useHeadingsMenu();
+  const onThisPageLinks = rawHeadingsMenu;
+
+  return (
+    <Stack gap={1}>
+      <Text fontWeight="bold" marginLeft={2}>
+        On this page
+      </Text>
+      {onThisPageLinks?.map((section) => (
+        <Button key={section.title} variant="ghost" size="sm" asChild>
+          <Link to={`#${slugify(section.title)}`}>{section.title}</Link>
+        </Button>
+      ))}
+    </Stack>
+  );
+};

--- a/apps/designmanual-frontend/app/routes/_base/right-sidebar/RightSidebar.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/right-sidebar/RightSidebar.tsx
@@ -1,4 +1,4 @@
-import { Button, slugify, Stack, Text } from "@vygruppen/spor-react";
+import { Box, Button, slugify, Stack, Text } from "@vygruppen/spor-react";
 import { Link } from "react-router";
 
 import { useHeadingsMenu } from "~/utils/useHeadingsMenu";
@@ -8,15 +8,19 @@ export const RightSidebar = () => {
   const onThisPageLinks = rawHeadingsMenu;
 
   return (
-    <Stack gap={1}>
+    <Stack gap={1} as="nav">
       <Text fontWeight="bold" marginLeft={2}>
         On this page
       </Text>
-      {onThisPageLinks?.map((section) => (
-        <Button key={section.title} variant="ghost" size="sm" asChild>
-          <Link to={`#${slugify(section.title)}`}>{section.title}</Link>
-        </Button>
-      ))}
+      <Stack gap={1} as="ol">
+        {onThisPageLinks?.map((section) => (
+          <Box as="li" key={section.title}>
+            <Button variant="ghost" size="sm" asChild>
+              <Link to={`#${slugify(section.title)}`}>{section.title}</Link>
+            </Button>
+          </Box>
+        ))}
+      </Stack>
     </Stack>
   );
 };

--- a/apps/designmanual-frontend/app/routes/_base/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/route.tsx
@@ -39,6 +39,7 @@ export default function BaseLayout() {
     <Box
       width={[null, "container.sm", "container.md", "container.lg"]}
       marginX="auto"
+      maxWidth="100%"
     >
       <Outlet />
     </Box>

--- a/apps/designmanual-frontend/app/routes/_base/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/route.tsx
@@ -37,7 +37,7 @@ export default function BaseLayout() {
 
   return (
     <Box
-      width={[null, null, null, "container.md", "container.lg"]}
+      width={[null, "container.sm", "container.md", "container.lg"]}
       marginX="auto"
     >
       <Outlet />

--- a/apps/designmanual-frontend/app/utils/initialSanityData.server.ts
+++ b/apps/designmanual-frontend/app/utils/initialSanityData.server.ts
@@ -37,9 +37,19 @@ export type MenuItem = {
     slug: { current: string };
   };
 };
+export type Component = {
+  title: string;
+  url: string;
+  badges: ArticleBadgeType[];
+};
+export type ArticleBadgeType = {
+  badgeType: "new" | "updated" | "beta" | "deprecated";
+  description?: string;
+};
 export type Menu = {
   slug: string;
   menuItems: MenuItem[];
+  components: Component[];
   relatedTo: {
     _type: string;
     title: string;
@@ -93,7 +103,13 @@ export const getInitialSanityData = async (stega = false) => {
               defined(externalLink) => externalLink
             ),
           }
-        } 
+        },
+        "components": *[_type == "article" && !(_id in path("drafts.**")) && category->slug.current == "components"] | order(title asc) {
+          title,
+          slug,
+          badges,
+          "url": "/" + section->slug.current + "/" + category->slug.current + "/" + slug.current
+         },
       },
       "siteSettings": *[_type == "siteSettings"][0] {
         title,

--- a/apps/designmanual-frontend/app/utils/useHeadingsMenu.ts
+++ b/apps/designmanual-frontend/app/utils/useHeadingsMenu.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
 
 export type HeadingsMenu = {
-  text: string;
+  title: string;
   id?: string;
 };
 
@@ -14,7 +14,7 @@ export const useHeadingsMenu = (): Array<HeadingsMenu> | [] => {
   );
 
   useEffect(() => {
-    const headings: Array<{ text: string; id?: string }> = [];
+    const headings: Array<{ title: string; id?: string }> = [];
     const h2Elements =
       typeof document === "undefined"
         ? []
@@ -24,16 +24,16 @@ export const useHeadingsMenu = (): Array<HeadingsMenu> | [] => {
 
     if (h2Elements.length > 0) {
       for (const element of h2Elements) {
-        const text = element.textContent?.trim() || "";
+        const title = element.textContent?.trim() || "";
 
         const id =
           element.id ||
-          text
+          title
             .toLowerCase()
             .replaceAll(/\s+/g, "-")
             .replaceAll(/[^a-z0-9-]/g, "");
 
-        headings.push({ text, id });
+        headings.push({ title, id });
       }
     }
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/apps/designmanual-frontend/app/utils/useMenu.ts
+++ b/apps/designmanual-frontend/app/utils/useMenu.ts
@@ -1,10 +1,11 @@
-import type { InitialSanityData } from "./initialSanityData.server";
+import type { Component, InitialSanityData } from "./initialSanityData.server";
 import { MenuItem } from "./initialSanityData.server";
 import { useMatchesData } from "./useMatchesData";
 
 type Menu = {
   slug: string;
   menuItems: MenuItem[];
+  components?: Component[];
   relatedTo: {
     _type: string;
     title: string;

--- a/packages/spor-mcp-server/index.ts
+++ b/packages/spor-mcp-server/index.ts
@@ -70,6 +70,8 @@ interface SanityCodeExample {
   _type: "codeExample";
   reactCode?: { code?: string; language?: string };
   layout?: string;
+  title: string;
+  description?: string;
 }
 
 interface SanityStaticCodeBlock {


### PR DESCRIPTION
## Background

New design for articles, and a few changes to the contentmenu. 

**Changes to articles:** 
- Articles in Sanity can now get badges attached to them that indicates if an article is either new, updated, deprecated or in "beta". This is supposed to be used to alert the users of Spor if changes to a component has been made. 
- A new componentSection called "Code examples" has been added to Articles, and will eventually replace the componentSection called "Examples". 
- The new "Code examples" section in articles will be the new way we present examples for the components that Spor provides. Instead of having all the examples listed vertically on the page, the different examples will be listed as FilterChips that the user can select between, and the one selected will be shown in a single InteractiveCode-block. 
- The tabs that the user have used to navigate between the different sections (examples, guidelines, and code) have been removed. Everything is now on one page. 


**Changes to ConentMenu:** 
- Instead of manually adding new components to the sidebar-menu in Spor, we retrieve all components through the initial groq-query made to Sanity. These components is then used to create the list of components in the sidebarmenu. 

---


### Testing
I recommend testing on the` /spor/components/switch` page. This is the only page where I have added code-examples in Sanity that work with the new design: https://pr-2251.test.design.vy.no/spor/components/switch 

## General Checklist

- [ ] I have updated documentation if necessary
- [ ] I have verified the design aligns with the latest Figma sketches.
- [ ] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [x] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots
Old layout
<img width="1591" height="1324" alt="Skjermbilde 2026-06-03 kl  09 07 18" src="https://github.com/user-attachments/assets/4b9965cc-bc81-4096-a04f-161ea7e2ab35" />


New layout
<img width="1590" height="1323" alt="Skjermbilde 2026-06-03 kl  08 58 56" src="https://github.com/user-attachments/assets/6aed9872-c44d-4f30-914e-09c15e31dd26" />
