### PR TITLE
Line tags: adjust dark mode colours

### DIFF
--- a/.changeset/yellow-needles-start.md
+++ b/.changeset/yellow-needles-start.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Update dark mode colours for line tags

--- a/packages/spor-react/src/linjetag/LineIcon.tsx
+++ b/packages/spor-react/src/linjetag/LineIcon.tsx
@@ -111,7 +111,7 @@ export const LineIcon = function LineIcon({
       borderColor={variant === "walk" ? "outline.core" : "transparent"}
       aria-label={label}
       ref={ref}
-      className={clsx("light", rest.className)}
+      className={variant === "walk" ? undefined : clsx("light", rest.className)}
     >
       <LinjeTagIcon size={size} css={styles.icon} variant={getIconVariant()} />
     </Box>

--- a/packages/spor-react/src/linjetag/TravelTag.tsx
+++ b/packages/spor-react/src/linjetag/TravelTag.tsx
@@ -14,7 +14,6 @@ import {
   WarningFill18Icon,
   WarningFill24Icon,
 } from "@vygruppen/spor-icon-react";
-import clsx from "clsx";
 import { PropsWithChildren } from "react";
 
 import { travelTagSlotRecipe } from "../theme/slot-recipes/travel-tag";
@@ -155,7 +154,6 @@ export const TravelTag = function TravelTag({
       css={styles.container}
       aria-disabled={disabled}
       ref={ref}
-      className={clsx("light", rest.className)}
       backgroundColor={backgroundColor}
       {...rest}
     >

--- a/packages/spor-react/src/theme/slot-recipes/travel-tag.ts
+++ b/packages/spor-react/src/theme/slot-recipes/travel-tag.ts
@@ -162,7 +162,10 @@ export const travelTagSlotRecipe = defineSlotRecipe({
       },
       "alt-transport": {
         container: {
-          backgroundColor: "linjetag.altTransportLight",
+          backgroundColor: {
+            _light: "linjetag.altTransportLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       walk: {

--- a/packages/spor-react/src/theme/slot-recipes/travel-tag.ts
+++ b/packages/spor-react/src/theme/slot-recipes/travel-tag.ts
@@ -81,90 +81,57 @@ export const travelTagSlotRecipe = defineSlotRecipe({
     variant: {
       "local-train": {
         container: {
-          backgroundColor: {
-            _light: "linjetag.lokaltogLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       "region-train": {
         container: {
-          backgroundColor: {
-            _light: "linjetag.regiontogLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       "region-express-train": {
         container: {
-          backgroundColor: {
-            _light: "linjetag.regionEkspressLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       "long-distance-train": {
         container: {
-          backgroundColor: {
-            _light: "linjetag.fjerntogLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       "airport-express-train": {
         container: {
-          backgroundColor: {
-            _light: "linjetag.flytogLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       "vy-bus": {
         container: {
-          backgroundColor: {
-            _light: "linjetag.vyBussLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       "local-bus": {
         container: {
-          backgroundColor: {
-            _light: "linjetag.lokalbussLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       ferry: {
         container: {
-          backgroundColor: {
-            _light: "linjetag.fergeLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       subway: {
         container: {
-          backgroundColor: {
-            _light: "linjetag.tbaneLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       tram: {
         container: {
-          backgroundColor: {
-            _light: "linjetag.trikkLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       "alt-transport": {
         container: {
-          backgroundColor: {
-            _light: "linjetag.altTransportLight",
-            _dark: "surface.disabled",
-          },
+          backgroundColor: "surface.disabled",
         },
       },
       walk: {

--- a/packages/spor-react/src/theme/slot-recipes/travel-tag.ts
+++ b/packages/spor-react/src/theme/slot-recipes/travel-tag.ts
@@ -2,7 +2,6 @@ import { defineSlotRecipe } from "@chakra-ui/react";
 
 import { travelTagAnatomy } from "./anatomy";
 
-//Todo: here
 export const travelTagSlotRecipe = defineSlotRecipe({
   slots: travelTagAnatomy.keys(),
   className: "spor-travel-tag",

--- a/packages/spor-react/src/theme/slot-recipes/travel-tag.ts
+++ b/packages/spor-react/src/theme/slot-recipes/travel-tag.ts
@@ -2,6 +2,7 @@ import { defineSlotRecipe } from "@chakra-ui/react";
 
 import { travelTagAnatomy } from "./anatomy";
 
+//Todo: here
 export const travelTagSlotRecipe = defineSlotRecipe({
   slots: travelTagAnatomy.keys(),
   className: "spor-travel-tag",

--- a/packages/spor-react/src/theme/slot-recipes/travel-tag.ts
+++ b/packages/spor-react/src/theme/slot-recipes/travel-tag.ts
@@ -82,52 +82,82 @@ export const travelTagSlotRecipe = defineSlotRecipe({
     variant: {
       "local-train": {
         container: {
-          backgroundColor: "linjetag.lokaltogLight",
+          backgroundColor: {
+            _light: "linjetag.lokaltogLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       "region-train": {
         container: {
-          backgroundColor: "linjetag.regiontogLight",
+          backgroundColor: {
+            _light: "linjetag.regiontogLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       "region-express-train": {
         container: {
-          backgroundColor: "linjetag.regionEkspressLight",
+          backgroundColor: {
+            _light: "linjetag.regionEkspressLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       "long-distance-train": {
         container: {
-          backgroundColor: "linjetag.fjerntogLight",
+          backgroundColor: {
+            _light: "linjetag.fjerntogLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       "airport-express-train": {
         container: {
-          backgroundColor: "linjetag.flytogLight",
+          backgroundColor: {
+            _light: "linjetag.flytogLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       "vy-bus": {
         container: {
-          backgroundColor: "linjetag.vyBussLight",
+          backgroundColor: {
+            _light: "linjetag.vyBussLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       "local-bus": {
         container: {
-          backgroundColor: "linjetag.lokalbussLight",
+          backgroundColor: {
+            _light: "linjetag.lokalbussLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       ferry: {
         container: {
-          backgroundColor: "linjetag.fergeLight",
+          backgroundColor: {
+            _light: "linjetag.fergeLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       subway: {
         container: {
-          backgroundColor: "linjetag.tbaneLight",
+          backgroundColor: {
+            _light: "linjetag.tbaneLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       tram: {
         container: {
-          backgroundColor: "linjetag.trikkLight",
+          backgroundColor: {
+            _light: "linjetag.trikkLight",
+            _dark: "surface.disabled",
+          },
         },
       },
       "alt-transport": {


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

<!-- Why this task is needed, context, and problem it solves -->

We want to update the background colours for `TravelTag` so that every variant of travel tag has the background colour "surface.disabled"

We also want to fix the dark mode colour for `LineIcon`, when the variant is "walk", as it also doesn't differ from light mode mode, which can make it really difficult to see. 

## Solution

Update the colours for `TravelTag` and enable dark mode for `LineIcon` when the variant is "walk".

## General Checklist

- [x] I have updated documentation if necessary
- [ ] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|<img width="652" height="176" alt="Screenshot 2026-06-08 at 09 33 28" src="https://github.com/user-attachments/assets/9e6da288-e579-4e9e-8acc-ac547fb43656" />|<img width="652" height="176" alt="Screenshot 2026-06-08 at 09 33 33" src="https://github.com/user-attachments/assets/b5ef6a0c-d69b-40ae-a511-2c26cceb66dd" />|
|<img width="714" height="210" alt="Screenshot 2026-06-05 at 14 23 57" src="https://github.com/user-attachments/assets/da378d76-6c72-4769-a3be-7d995876a2aa" />|<img width="714" height="210" alt="Screenshot 2026-06-05 at 14 23 29" src="https://github.com/user-attachments/assets/d0690a15-3c7c-419a-9863-7533ad3a418c" />|
|<img width="359" height="103" alt="Screenshot 2026-06-05 at 14 24 32" src="https://github.com/user-attachments/assets/52073c70-3472-44ab-ba6f-98d97597e5d5" />|<img width="359" height="103" alt="Screenshot 2026-06-05 at 14 24 55" src="https://github.com/user-attachments/assets/d467728e-0398-4f6f-8dbd-b5520b6fbea1" />|
