### PR TITLE
expand the colorPalette in Badge

### DIFF
--- a/.changeset/cold-comics-remain.md
+++ b/.changeset/cold-comics-remain.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Badge: expand the colorPalette to include the colors that does not exist in Chakra's base colorPalette to resolve typeerrors.

--- a/packages/spor-react/src/theme/recipes/badge.ts
+++ b/packages/spor-react/src/theme/recipes/badge.ts
@@ -168,5 +168,14 @@ export const badgeRecipie = defineRecipe({
         "& svg": { color: { _light: "white", _dark: "darkGrey" } },
       },
     },
+    {
+      colorPalette: "brightRed",
+      inverted: true,
+      css: {
+        backgroundColor: { _light: "brightRed", _dark: "brightRed" },
+        color: { _light: "pink", _dark: "pink" },
+        "& svg": { color: { _light: "pink", _dark: "pink" } },
+      },
+    },
   ],
 });

--- a/packages/spor-react/src/theme/recipes/badge.ts
+++ b/packages/spor-react/src/theme/recipes/badge.ts
@@ -177,5 +177,23 @@ export const badgeRecipie = defineRecipe({
         "& svg": { color: { _light: "pink", _dark: "pink" } },
       },
     },
+    {
+      // @ts-expect-error Chakra gir feilmelding fordi "disabled" ikke eksisterer i built-in typen
+      colorPalette: "disabled",
+      inverted: true,
+      css: {
+        backgroundColor: {
+          _light: "blackAlpha.50",
+          _dark: "whiteAlpha.100",
+        },
+        color: { _light: "whiteAlpha.300", _dark: "blackAlpha.300" },
+        "& svg": {
+          color: {
+            _light: "whiteAlpha.300",
+            _dark: "blackAlpha.300",
+          },
+        },
+      },
+    },
   ],
 });

--- a/packages/spor-react/src/typography/Badge.tsx
+++ b/packages/spor-react/src/typography/Badge.tsx
@@ -6,7 +6,10 @@ import {
 } from "@chakra-ui/react";
 import { IconComponent } from "@vygruppen/spor-icon-react";
 
-export type BadgeProps = ChakraBadgeProps & { icon?: IconComponent };
+export type BadgeProps = Omit<ChakraBadgeProps, "colorPalette"> & {
+  icon?: IconComponent;
+  colorPalette?: ChakraBadgeProps["colorPalette"] | "brightRed" | "disabled";
+};
 
 export const Badge = function Badge({
   ref,


### PR DESCRIPTION
## Background

Expands the colorPalette in Badge to include the colors that does not exist in the default colorPalette from Chakra. 
This should resolve the typeerror that is shown when using either "disabled" or "brightRed" as value for the colorPalette-prop in Badges.
