### PR TITLE
Remove red border around countrycode on invalid phonenumber

### DIFF
--- a/.changeset/plain-llamas-make.md
+++ b/.changeset/plain-llamas-make.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Phonenumber input: remove red border from countrycode select when invalid

--- a/packages/spor-react/src/input/PhoneNumberInput.tsx
+++ b/packages/spor-react/src/input/PhoneNumberInput.tsx
@@ -92,7 +92,6 @@ export const PhoneNumberInput = ({
         variant={variant}
         allowedCountryCodes={allowedCountryCodes}
         data-state="on"
-        invalid={invalid}
         size={size}
       />
       <Input


### PR DESCRIPTION
## Background

Removes the red border around the countrycode selector if the phonenumber input is invalid. This is design-choice has been made on the basis that the countrycode is never "wrong" or "invalid", and should therefore not get a red line around it when the number is invalid. 


## Screenshots

Before: 
<img width="684" height="133" alt="Skjermbilde 2026-06-12 kl  14 42 48" src="https://github.com/user-attachments/assets/de82ad29-41b1-490f-8f3e-f0bd8609d076" />


After:
<img width="706" height="132" alt="Skjermbilde 2026-06-12 kl  14 42 23" src="https://github.com/user-attachments/assets/6441ab62-d7e4-477b-8e34-25e6aa5e1ecc" />
