### PR TITLE
Padding in breadcrumb

### DIFF
--- a/.changeset/salty-hotels-call.md
+++ b/.changeset/salty-hotels-call.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Remove padding around link in breadcrumb to prevent text from moving 3px when navigating between elements

--- a/packages/spor-react/src/theme/slot-recipes/breadcrumb.ts
+++ b/packages/spor-react/src/theme/slot-recipes/breadcrumb.ts
@@ -14,7 +14,6 @@ export const breadcrumbSlotRecipe = defineSlotRecipe({
     },
     link: {
       cursor: "pointer",
-      padding: 0.5,
       borderRadius: "xs",
     },
     currentLink: {


### PR DESCRIPTION
## Background

Removes the padding from the links in the breadcrumb to prevent the text from moving 3px to the left when a link becomes the current link. 

https://github.com/user-attachments/assets/d262aaeb-627b-40ec-95dd-4b6071d518d7

