### PR TITLE
Update hover-effect on links in breadcrumb

### DIFF
--- a/.changeset/free-words-enter.md
+++ b/.changeset/free-words-enter.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Breadcrumb: Links get an underline instead of outline on hover for the core-variant

--- a/packages/spor-react/src/theme/slot-recipes/breadcrumb.ts
+++ b/packages/spor-react/src/theme/slot-recipes/breadcrumb.ts
@@ -1,5 +1,4 @@
 import { defineSlotRecipe } from "@chakra-ui/react";
-import tokens from "@vygruppen/spor-design-tokens";
 
 import { breadcrumbAnatomy } from "./anatomy";
 
@@ -15,10 +14,12 @@ export const breadcrumbSlotRecipe = defineSlotRecipe({
     link: {
       cursor: "pointer",
       borderRadius: "xs",
+      paddingX: 0.5,
     },
     currentLink: {
       borderRadius: "xs",
       cursor: "default",
+      paddingX: 0.5,
     },
     separator: {
       "& svg": {
@@ -32,9 +33,7 @@ export const breadcrumbSlotRecipe = defineSlotRecipe({
       core: {
         link: {
           _hover: {
-            outlineColor: "outline.core.hover",
-            outlineWidth: tokens.size.stroke.md,
-            outlineStyle: "solid",
+            textDecoration: "underline",
             _active: {
               backgroundColor: "surface.core.active",
               outline: "none",


### PR DESCRIPTION
## Background
Links in the Breadcrumb gets an underline instead of outline when you hover them

Before: 
<img width="390" height="78" alt="Skjermbilde 2026-06-16 kl  14 19 14" src="https://github.com/user-attachments/assets/bcfd1ea1-b361-4dfb-90f7-7598c3eb643a" />


After:
<img width="387" height="78" alt="Skjermbilde 2026-06-16 kl  14 18 49" src="https://github.com/user-attachments/assets/eb27190e-1144-462d-913c-214465ef56f1" />
