### PR TITLE
Image and text designmanual

### DIFF
--- a/apps/designmanual-frontend/app/features/portable-text/components/ImageAndTextList.tsx
+++ b/apps/designmanual-frontend/app/features/portable-text/components/ImageAndTextList.tsx
@@ -31,7 +31,7 @@ const ImageAndText = ({
   const { t } = useTranslation();
 
   const imageConst = (
-    <Box as="figure" flex={12} overflow="hidden">
+    <Box as="figure" flex={6 / 12} overflow="hidden">
       {image && (
         <ResponsiveImage
           image={image}
@@ -41,7 +41,6 @@ const ImageAndText = ({
           borderRadius="md"
           size="md"
           quality={60}
-          width="100%"
         />
       )}
       {(image.caption || image.credits) && (

--- a/packages/spor-react/__tests__/accordion.test.tsx
+++ b/packages/spor-react/__tests__/accordion.test.tsx
@@ -1,0 +1,110 @@
+import { ConditionalValue } from "@chakra-ui/react";
+import { AccordionRootProps as ChakraAccordionProps } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionItemContent,
+  AccordionItemTrigger,
+  SporProvider,
+} from "@vygruppen/spor-react";
+import { Ref } from "react";
+import { JSX } from "react/jsx-runtime";
+import { describe, expect, test, vi } from "vitest";
+
+const AccordionTest = (
+  props: JSX.IntrinsicAttributes &
+    ChakraAccordionProps & {
+      variant?: ConditionalValue<
+        "core" | "ghost" | "underlined" | "floating" | undefined
+      >;
+    } & {
+      children?: React.ReactNode | undefined;
+    } & {
+      variant?: "ghost" | "core" | "floating" | "underlined";
+      gap?: string | number;
+      href?: string;
+    } & {
+      ref?: Ref<HTMLDivElement>;
+    },
+) => {
+  return (
+    <SporProvider>
+      <Accordion
+        collapsible
+        width="100%"
+        {...props}
+        data-testid="accordion-root"
+      >
+        <AccordionItem value="accordion-item-1">
+          <AccordionItemTrigger data-testid="accordion-item-1">
+            Item 1 trigger
+          </AccordionItemTrigger>
+          <AccordionItemContent>Item 1 content</AccordionItemContent>
+        </AccordionItem>
+        <AccordionItem value="accordion-item-2">
+          <AccordionItemTrigger data-testid="accordion-item-2">
+            Item 1 trigger
+          </AccordionItemTrigger>
+          <AccordionItemContent>Item 1 content</AccordionItemContent>
+        </AccordionItem>
+      </Accordion>
+    </SporProvider>
+  );
+};
+
+describe("Uncontrolled accordion", () => {
+  test("handles expandable-state correctly", async () => {
+    const user = userEvent.setup();
+
+    render(<AccordionTest />);
+
+    const item1 = screen.getByTestId("accordion-item-1") as HTMLInputElement;
+    const item2 = screen.getByTestId("accordion-item-2") as HTMLInputElement;
+
+    await user.click(item2);
+
+    expect(item1.ariaExpanded).toBe("false");
+    expect(item2.ariaExpanded).toBe("true");
+  });
+});
+
+describe("Controlled accordion", () => {
+  test("handles expandable-state correctly", async () => {
+    const expandedItems = ["accordion-item-1"];
+    render(<AccordionTest value={expandedItems} />);
+
+    const item1 = screen.getByTestId("accordion-item-1") as HTMLInputElement;
+    const item2 = screen.getByTestId("accordion-item-2") as HTMLInputElement;
+
+    expect(item1.ariaExpanded).toBe("true");
+    expect(item2.ariaExpanded).toBe("false");
+  });
+});
+
+describe("Default open accordion", () => {
+  test("handles expandable-state correctly", async () => {
+    render(<AccordionTest defaultValue={["accordion-item-1"]} />);
+
+    const item1 = screen.getByTestId("accordion-item-1") as HTMLInputElement;
+    const item2 = screen.getByTestId("accordion-item-2") as HTMLInputElement;
+
+    expect(item1.ariaExpanded).toBe("true");
+    expect(item2.ariaExpanded).toBe("false");
+  });
+});
+
+describe("OnValuechange accordion", () => {
+  test("handles onValueChange correctly", async () => {
+    const onValueChange = vi.fn();
+
+    const user = userEvent.setup();
+    render(<AccordionTest onValueChange={onValueChange} />);
+
+    const item1 = screen.getByTestId("accordion-item-1") as HTMLInputElement;
+    await user.click(item1);
+
+    expect(onValueChange).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Background

In the ImageAndText-component the image took all of the space in desktop-view, but it should take 50% of it. 

---
Før: 
<img width="861" height="742" alt="Skjermbilde 2026-06-18 kl  09 48 35" src="https://github.com/user-attachments/assets/de228993-2a7f-4017-829a-fbf0664f955d" />

Etter: 
<img width="886" height="475" alt="Skjermbilde 2026-06-18 kl  09 48 12" src="https://github.com/user-attachments/assets/4c976920-26cb-4d1b-8d6f-22d88db0f51b" />

