### PR TITLE
Styling in SwitchButton for AttachedInputs

### DIFF
--- a/.changeset/quick-ravens-wonder.md
+++ b/.changeset/quick-ravens-wonder.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+AttachedInputs: removed "!important"-tag on styling, and added "flipButtonProps" as a prop to the AttahcedInput component to make it possible to override the styling of the button.

--- a/packages/spor-react/src/input/AttachedInputs.tsx
+++ b/packages/spor-react/src/input/AttachedInputs.tsx
@@ -6,6 +6,7 @@ import {
   defineRecipe,
   Group,
   GroupProps,
+  IconButtonProps,
   RecipeVariantProps,
   useRecipe,
 } from "@chakra-ui/react";
@@ -40,10 +41,22 @@ export type AttachedInputsProps = RecipeVariantProps<
         onFlip: () => void;
         flipAriaLabel: string;
       }
-  );
+  ) & {
+    flipButtonProps?: Omit<
+      IconButtonProps,
+      | "icon"
+      | "aria-label"
+      | "onClick"
+      | "variant"
+      | "size"
+      | "orientation"
+      | "spinner"
+    >;
+  };
 
 export const AttachedInputs = ({
   ref,
+  flipButtonProps,
   ...props
 }: AttachedInputsProps & {
   ref?: React.Ref<HTMLDivElement>;
@@ -76,6 +89,10 @@ export const AttachedInputs = ({
         size={["xs", null, "sm"]}
         aria-label={flipAriaLabel}
         onClick={onFlip}
+        position="absolute"
+        bg="bg"
+        outlineWidth="1px"
+        {...flipButtonProps}
       />
     </Box>
   );
@@ -85,24 +102,20 @@ const SwitchButton = chakra(
   IconButton,
   defineRecipe({
     base: {
-      position: "absolute !important",
-      zIndex: "101 !important",
-      // eslint-disable-next-line spor/use-semantic-tokens
-      bg: "bg !important",
-      outlineWidth: "1px !important",
-
+      zIndex: "101",
       _focus: {
-        outlineOffset: "0px !important",
+        outlineOffset: "0px",
+        alignItems: "center",
       },
     },
     variants: {
       orientation: {
         horizontal: {
-          top: "calc(50% - 18px)",
-          right: "calc(50% - 18px)",
+          top: "calc(50% - 1.1rem)",
+          right: "calc(50% - 1.1rem)",
         },
         vertical: {
-          top: "calc(50% - 15px)",
+          top: "calc(50% - 1.1rem)",
           right: "3rem",
           transform: "rotate(90deg)",
         },


### PR DESCRIPTION
## Background

The styling in the SwitchButton on AttachedInputs had !important on them, making them impossible to override. 

## Solution
Removed the !important, and moved the styling to the SwitchButton-component. 
Have also added a flipButtonProps to the AttachedInput-component to make it easier to override the styling. 
