### PR TITLE
Dialog: add possibility to send positioner-props to Chakra's positioner

### DIFF
--- a/.changeset/angry-lamps-care.md
+++ b/.changeset/angry-lamps-care.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Dialog: add possibility to send positioner-props to Chakra's positioner

--- a/packages/spor-react/src/dialog/Dialog.tsx
+++ b/packages/spor-react/src/dialog/Dialog.tsx
@@ -9,6 +9,7 @@ interface DialogContentProps extends ChakraDialog.ContentProps {
   portalRef?: React.RefObject<HTMLElement>;
   backdrop?: boolean;
   children?: React.ReactNode;
+  positionerProps: ChakraDialog.PositionerProps;
 }
 
 export const DialogContent = ({
@@ -22,13 +23,14 @@ export const DialogContent = ({
     portalled = true,
     portalRef,
     backdrop = true,
+    positionerProps,
     ...rest
   } = props;
 
   return (
     <Portal disabled={!portalled} container={portalRef}>
       {backdrop && <ChakraDialog.Backdrop />}
-      <ChakraDialog.Positioner>
+      <ChakraDialog.Positioner {...positionerProps}>
         <ChakraDialog.Content ref={ref} {...rest} asChild={false}>
           {children}
         </ChakraDialog.Content>

--- a/packages/spor-react/src/dialog/Dialog.tsx
+++ b/packages/spor-react/src/dialog/Dialog.tsx
@@ -9,7 +9,7 @@ interface DialogContentProps extends ChakraDialog.ContentProps {
   portalRef?: React.RefObject<HTMLElement>;
   backdrop?: boolean;
   children?: React.ReactNode;
-  positionerProps: ChakraDialog.PositionerProps;
+  positionerProp?: ChakraDialog.PositionerProps;
 }
 
 export const DialogContent = ({
@@ -23,14 +23,14 @@ export const DialogContent = ({
     portalled = true,
     portalRef,
     backdrop = true,
-    positionerProps,
+    positionerProp,
     ...rest
   } = props;
 
   return (
     <Portal disabled={!portalled} container={portalRef}>
       {backdrop && <ChakraDialog.Backdrop />}
-      <ChakraDialog.Positioner {...positionerProps}>
+      <ChakraDialog.Positioner {...positionerProp}>
         <ChakraDialog.Content ref={ref} {...rest} asChild={false}>
           {children}
         </ChakraDialog.Content>

--- a/packages/spor-react/src/dialog/Dialog.tsx
+++ b/packages/spor-react/src/dialog/Dialog.tsx
@@ -9,7 +9,7 @@ interface DialogContentProps extends ChakraDialog.ContentProps {
   portalRef?: React.RefObject<HTMLElement>;
   backdrop?: boolean;
   children?: React.ReactNode;
-  positionerProp?: ChakraDialog.PositionerProps;
+  positionerProps?: ChakraDialog.PositionerProps;
 }
 
 export const DialogContent = ({
@@ -23,14 +23,14 @@ export const DialogContent = ({
     portalled = true,
     portalRef,
     backdrop = true,
-    positionerProp,
+    positionerProps,
     ...rest
   } = props;
 
   return (
     <Portal disabled={!portalled} container={portalRef}>
       {backdrop && <ChakraDialog.Backdrop />}
-      <ChakraDialog.Positioner {...positionerProp}>
+      <ChakraDialog.Positioner {...positionerProps}>
         <ChakraDialog.Content ref={ref} {...rest} asChild={false}>
           {children}
         </ChakraDialog.Content>


### PR DESCRIPTION
## Background

Someone has a need to send props to the Positioner component in the DialogContent. 

---

## Solution

Added `positionerProps` to the DialogContent component so that props to the Positioner can be sent. 

