### PR TITLE
Add support for brightRed badge

### DIFF
--- a/.changeset/loose-otters-stand.md
+++ b/.changeset/loose-otters-stand.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add brightRed colorPalette to Badge

--- a/packages/spor-react/src/typography/Badge.tsx
+++ b/packages/spor-react/src/typography/Badge.tsx
@@ -3,10 +3,18 @@ import {
   Badge as ChakraBadge,
   BadgeProps as ChakraBadgeProps,
   Box,
+  RecipeVariantProps,
 } from "@chakra-ui/react";
 import { IconComponent } from "@vygruppen/spor-icon-react";
 
-export type BadgeProps = ChakraBadgeProps & { icon?: IconComponent };
+import { badgeRecipie } from "../theme/recipes/badge";
+
+type BadgeVariantProps = RecipeVariantProps<typeof badgeRecipie>;
+
+export type BadgeProps = Omit<ChakraBadgeProps, "colorPalette"> &
+  BadgeVariantProps & {
+    icon?: IconComponent;
+  };
 
 export const Badge = function Badge({
   ref,

--- a/packages/spor-react/src/typography/Badge.tsx
+++ b/packages/spor-react/src/typography/Badge.tsx
@@ -11,10 +11,10 @@ import { badgeRecipie } from "../theme/recipes/badge";
 
 type BadgeVariantProps = RecipeVariantProps<typeof badgeRecipie>;
 
-export type BadgeProps = Omit<ChakraBadgeProps, "colorPalette"> &
-  BadgeVariantProps & {
-    icon?: IconComponent;
-  };
+export type BadgeProps = ChakraBadgeProps & {
+  colorPalette?: BadgeVariantProps["colorPalette"];
+  icon?: IconComponent;
+};
 
 export const Badge = function Badge({
   ref,


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

We are having issues with colorPalette brigthRed being missing from Badge

<!-- Why this task is needed, context, and problem it solves -->

---

## Solution

<!-- What has been done and why this approach was chosen -->
Add support for brightRed by setting colorPalette prop from recipe.

---

## General Checklist

- [x] I have updated documentation if necessary
- [x] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|        |<img width="876" height="366" alt="Skjermbilde 2026-06-18 kl  16 57 23" src="https://github.com/user-attachments/assets/21ced2f6-8b12-47d3-b5b1-5d3cd0b2cce3" />|