### PR TITLE
Add aria-labels to TimeField

### DIFF
--- a/.changeset/fifty-news-arrive.md
+++ b/.changeset/fifty-news-arrive.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Add aria-labels to dateTime segments in TimePicker

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -72,7 +72,7 @@ export const DateField = ({
           <DateTimeSegment
             key={index}
             segment={segment}
-            ariaDescription={t(getAriaLabel(segment.type))}
+            ariaLabel={t(getAriaLabel(segment.type))}
             state={state}
           />
         ))}

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -10,7 +10,7 @@ type DateTimeSegmentProps = PropsWithChildren<DatePickerVariantProps> & {
   segment: DateSegment;
   state: DateFieldState;
   ariaLabel?: string;
-  ariaDescription?: string;
+  ariaLabelledby?: string;
 };
 /**
  * A date time segment is a part of a date or a time stamp.
@@ -24,7 +24,7 @@ export const DateTimeSegment = ({
   segment,
   state,
   ariaLabel,
-  ariaDescription,
+  ariaLabelledby,
   variant,
 }: DateTimeSegmentProps & {
   ref?: React.Ref<HTMLDivElement>;
@@ -59,8 +59,8 @@ export const DateTimeSegment = ({
       borderRadius="xs"
       fontSize={["mobile.sm", "desktop.sm"]}
       css={styles.dateTimeSegment}
-      aria-label={ariaDescription}
-      aria-labelledby={ariaLabel}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
     >
       {isPaddable(segment.type) ? segment.text.padStart(2, "0") : segment.text}
     </Box>

--- a/packages/spor-react/src/datepicker/TimeField.tsx
+++ b/packages/spor-react/src/datepicker/TimeField.tsx
@@ -7,6 +7,7 @@ import { DateSegment, TimeFieldState } from "react-stately";
 
 import { spor } from "@/util";
 
+import { createTexts, useTranslation } from "../i18n";
 import { DateTimeSegment } from "./DateTimeSegment";
 import { getTimestampFromTime } from "./utils";
 
@@ -23,6 +24,7 @@ type TimeFieldProps = AriaTimeFieldProps<Time> & {
 export const TimeField = ({ state, ...props }: TimeFieldProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const { labelProps, fieldProps } = useTimeField(props, state, ref);
+  const { t } = useTranslation();
 
   return (
     <Box>
@@ -46,7 +48,12 @@ export const TimeField = ({ state, ...props }: TimeFieldProps) => {
       </spor.label>
       <Flex {...fieldProps} ref={ref} paddingTop="3" paddingBottom="0.5">
         {state.segments.map((segment: DateSegment, index) => (
-          <DateTimeSegment key={index} segment={segment} state={state} />
+          <DateTimeSegment
+            key={index}
+            segment={segment}
+            state={state}
+            ariaLabel={t(getAriaLabel(segment.type))}
+          />
         ))}
       </Flex>
       <input
@@ -57,3 +64,47 @@ export const TimeField = ({ state, ...props }: TimeFieldProps) => {
     </Box>
   );
 };
+
+const getAriaLabel = (segmentType: DateSegment["type"]) => {
+  switch (segmentType) {
+    case "hour": {
+      return texts.hour;
+    }
+    case "minute": {
+      return texts.minute;
+    }
+    case "second": {
+      return texts.second;
+    }
+    default: {
+      return texts.default;
+    }
+  }
+};
+
+const texts = createTexts({
+  hour: {
+    nb: "Velg time",
+    nn: "Vel time",
+    sv: "Välj timme",
+    en: "Choose hour",
+  },
+  minute: {
+    nb: "Velg minutt",
+    nn: "Vel minutt",
+    sv: "Välj minut",
+    en: "Choose minute",
+  },
+  second: {
+    nb: "Velg sekund",
+    nn: "Vel sekund",
+    sv: "Välj sekund",
+    en: "Choose second",
+  },
+  default: {
+    nb: "Velg tid",
+    nn: "Vel tid",
+    sv: "Välj tid",
+    en: "Choose time",
+  },
+});


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

We have a WCAG issue in `TimePicker`: "4.1.2 Form field missing a label". This can be fixed by setting aria-labels on the dateTime segments in `TimeField` in the same way that we already do for `DateField`.

## Solution

Add aria-labels to the dateTime segments in `TimeField`. Also update the props name in `DateTimeSegment` so that the prop `ariaLabel` sets the `aria-label` and `ariaLabelledby` sets `aria-labelledby` (instead of `ariaLabel` setting `aria-labelledby` and `ariaDescription` setting `aria-label`).

## General Checklist

- [x] I have updated documentation if necessary
- [x] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave


## Screenshots

| Before | After |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/fbb43dff-10cb-43ba-93e4-818467846648" />|<video src="https://github.com/user-attachments/assets/596cdfbb-5708-4d58-acae-90a45495b9d0" />|


