### PR TITLE
"Component overview" in sidebarmenu

### DIFF
--- a/apps/designmanual-frontend/app/root/layout/Footer.tsx
+++ b/apps/designmanual-frontend/app/root/layout/Footer.tsx
@@ -56,7 +56,7 @@ export const Footer = () => {
             icon={<GithubOutline18Icon />}
           />
           <FooterLink
-            url="https://www.figma.com/design/Tmr2URVX2vNkyRLqKhNRQA/Spor-komponentbibliotek?node-id=0-1&p=f&m=dev"
+            url="https://www.figma.com/@vy_spor"
             label="Figma"
             icon={<FigmaOutline18Icon />}
           />
@@ -79,7 +79,12 @@ const FooterLink = ({
   label: string;
   icon?: React.ReactNode;
 }) => (
-  <Button variant="tertiary" size={{ base: "xs", md: "sm" }} leftIcon={icon}>
+  <Button
+    variant="tertiary"
+    size={{ base: "xs", md: "sm" }}
+    leftIcon={icon}
+    asChild
+  >
     <Link to={url} target="_blank" rel="noopener noreferrer">
       {label}
     </Link>

--- a/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/ContentMenu.tsx
@@ -1,3 +1,4 @@
+import { GridOutline18Icon } from "@vygruppen/spor-icon-react";
 import {
   Accordion,
   AccordionItem,
@@ -174,6 +175,11 @@ export const ContentMenu = ({ refreshKey, ref }: Props) => {
           gap={0.5}
           display={["none", null, null, "block"]}
         >
+          <MenuItem
+            url="/spor/components/overview"
+            title="Overview"
+            icon={<GridOutline18Icon />}
+          />
           {menu?.components?.map((component: Component, index: number) => (
             <MenuItem
               key={index + component.url}

--- a/apps/designmanual-frontend/app/routes/_base/content-menu/MenuItem.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/MenuItem.tsx
@@ -44,8 +44,8 @@ export const MenuItem = ({ url, title, badges, icon }: MenuItemProps) => {
           rel={isExternal ? "noopener noreferrer" : undefined}
         >
           <Stack direction="row" alignItems="center" width="100%">
-            {icon && icon}
             {title}
+            {icon && icon}
             {badges && (
               <Stack direction="row">
                 {badges.map((badge) => (

--- a/apps/designmanual-frontend/app/routes/_base/content-menu/MenuItem.tsx
+++ b/apps/designmanual-frontend/app/routes/_base/content-menu/MenuItem.tsx
@@ -10,12 +10,13 @@ type MenuItemProps = FlexProps & {
   url: string;
   title?: string;
   badges?: ArticleBadgeType[];
+  icon?: React.ReactNode;
 };
 /**
  * Menu item in the `ContentMenu`, and search result in the `SearchResults`.
  */
 
-export const MenuItem = ({ url, title, badges }: MenuItemProps) => {
+export const MenuItem = ({ url, title, badges, icon }: MenuItemProps) => {
   const isExternal = url.includes("http");
   return (
     <Box as="li" listStyle="none">
@@ -43,6 +44,7 @@ export const MenuItem = ({ url, title, badges }: MenuItemProps) => {
           rel={isExternal ? "noopener noreferrer" : undefined}
         >
           <Stack direction="row" alignItems="center" width="100%">
+            {icon && icon}
             {title}
             {badges && (
               <Stack direction="row">


### PR DESCRIPTION
## Background

Added an item in the sidebarmenu that points to the "Component overview"-page. 

<img width="654" height="550" alt="Skjermbilde 2026-06-22 kl  13 03 00" src="https://github.com/user-attachments/assets/f4bfe33c-16bc-4f9c-8f6a-7b202a8467f4" />
