### PR TITLE
Padding in textarea and color token

### DIFF
--- a/.changeset/spicy-dots-thank.md
+++ b/.changeset/spicy-dots-thank.md
@@ -1,0 +1,6 @@
+---
+"@vygruppen/spor-design-tokens": patch
+"@vygruppen/spor-react": patch
+---
+
+Add paddingleft to textarea and change the color of surface.ghost.hover in Vy-Digital theme

--- a/packages/spor-design-tokens/tokens/color/vy-digital.json
+++ b/packages/spor-design-tokens/tokens/color/vy-digital.json
@@ -541,7 +541,7 @@
         "ghost": {
           "hover": {
             "value": {
-              "_light": "colors.seaMist",
+              "_light": "colors.coralGreen",
               "_dark": "colors.whiteAlpha.100"
             }
           },

--- a/packages/spor-react/src/theme/recipes/textarea.ts
+++ b/packages/spor-react/src/theme/recipes/textarea.ts
@@ -14,6 +14,8 @@ export const textareaRecipe = defineRecipe({
     "&:focus-visible, &:not(:placeholder-shown)": {
       borderTop: "var(--label-height) solid transparent",
     },
+    fontSize: "mobile.md",
+    paddingLeft: 3,
   },
   variants: {
     variant: {


### PR DESCRIPTION
## Background

Added paddingLeft to the input in the TextArea so the user-input is aligned with the label. 
+changed the color-value of the surface.ghost.hover token. 
