### PR TITLE
Solve WCAG violations

### DIFF
--- a/.changeset/evil-olives-arrive.md
+++ b/.changeset/evil-olives-arrive.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Solve accessibility problems: 1) adjust width of calendar-view in DatePicker to not overflow the screens view. 2) add asterisk to TimePicker when set to required. 3) Remove aria-assertive on errormessage in TimePicker.

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -115,7 +115,7 @@ export const DatePicker = ({
   const popoverContent = (
     <ChakraPopover.Positioner>
       <ChakraPopover.Content css={styles.calendarPopover}>
-        <ChakraPopover.Body minWidth="20rem">
+        <ChakraPopover.Body minWidth="18rem">
           <Calendar
             {...calendarProps}
             variant={variant}

--- a/packages/spor-react/src/datepicker/TimeField.tsx
+++ b/packages/spor-react/src/datepicker/TimeField.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box, Flex } from "@chakra-ui/react";
+import { Box, Field as ChakraField, Flex } from "@chakra-ui/react";
 import { CalendarDateTime, Time } from "@internationalized/date";
 import { useRef } from "react";
 import { AriaTimeFieldProps, useTimeField } from "react-aria";
@@ -45,6 +45,7 @@ export const TimeField = ({ state, ...props }: TimeFieldProps) => {
         maxWidth="80%"
       >
         {props.label}
+        <ChakraField.RequiredIndicator />
       </spor.label>
       <Flex {...fieldProps} ref={ref} paddingTop="3" paddingBottom="0.5">
         {state.segments.map((segment: DateSegment, index) => (

--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -144,7 +144,6 @@ export const TimePicker = ({
         opacity={isDisabled ? 0.5 : 1}
         pointerEvents={isDisabled ? "none" : "auto"}
         aria-disabled={isDisabled}
-        aria-live="assertive"
         aria-label={ariaLabel}
         position="relative"
         {...boxProps}

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -80,6 +80,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       boxShadow: "md",
       backgroundColor: "surface.floating",
       minHeight: "min-content",
+      maxWidth: "100vw",
     },
     rangeCalendarPopover: {
       width: "43rem",


### PR DESCRIPTION
## Background

Solves three wcag violations to improve the accessibility: 
1) adjust width of calendar-view in DatePicker to not overflow the screens view.
2) add asterisk to TimePicker when set to required
3) Remove `aria-live="assertive"` on errormessage in TimePicker, as it should be` aria-live="polite"` to not make too much noice. 
---
