### PR TITLE
Adjust darkmode-color on shadow

### DIFF
--- a/.changeset/poor-women-hammer.md
+++ b/.changeset/poor-women-hammer.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-design-tokens": patch
+---
+
+Adjust dark mode colors for shadow-token

--- a/packages/spor-design-tokens/tokens/depth/shadow.json
+++ b/packages/spor-design-tokens/tokens/depth/shadow.json
@@ -5,7 +5,7 @@
         "keepDetails": true,
         "value": {
           "_light": "0 1px 3px rgba(0, 0, 0, 0.1)",
-          "_dark": "0 1px 3px rgba(255, 255, 255, 0.5)"
+          "_dark": "0 1px 3px rgba(255, 255, 255, 0.2)"
         },
 
         "color": "{color.palette.black.value}",
@@ -22,7 +22,7 @@
         "keepDetails": true,
         "value": {
           "_light": "0 2px 6px rgba(0, 0, 0, 0.1)",
-          "_dark": "0 2px 6px rgba(255, 255, 255, 0.5)"
+          "_dark": "0 2px 6px rgba(255, 255, 255, 0.2)"
         },
         "color": "{color.palette.black.value}",
         "blur": 5,
@@ -38,7 +38,7 @@
         "keepDetails": true,
         "value": {
           "_light": "0 2px 8px 1px rgba(0, 0, 0, 0.1)",
-          "_dark": "0 2px 8px 1px rgba(255, 255, 255, 0.5)"
+          "_dark": "0 2px 8px 1px rgba(255, 255, 255, 0.2)"
         },
         "color": "{color.palette.black.value}",
         "blur": 5,

--- a/packages/spor-design-tokens/tokens/depth/shadow.json
+++ b/packages/spor-design-tokens/tokens/depth/shadow.json
@@ -5,7 +5,7 @@
         "keepDetails": true,
         "value": {
           "_light": "0 1px 3px rgba(0, 0, 0, 0.1)",
-          "_dark": "0 1px 3px rgba(255, 255, 255, 0.1)"
+          "_dark": "0 1px 3px rgba(255, 255, 255, 0.5)"
         },
 
         "color": "{color.palette.black.value}",
@@ -22,7 +22,7 @@
         "keepDetails": true,
         "value": {
           "_light": "0 2px 6px rgba(0, 0, 0, 0.1)",
-          "_dark": "0 2px 6px rgba(255, 255, 255, 0.1)"
+          "_dark": "0 2px 6px rgba(255, 255, 255, 0.5)"
         },
         "color": "{color.palette.black.value}",
         "blur": 5,
@@ -38,7 +38,7 @@
         "keepDetails": true,
         "value": {
           "_light": "0 2px 8px 1px rgba(0, 0, 0, 0.1)",
-          "_dark": "0 2px 8px 1px rgba(255, 255, 255, 0.1)"
+          "_dark": "0 2px 8px 1px rgba(255, 255, 255, 0.5)"
         },
         "color": "{color.palette.black.value}",
         "blur": 5,


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

The current darkmode color for shadow is very hard to see. This is quite problematic in components like Dialog.

## Solution

Change the opacity from 0.1 to 0.2


## General Checklist

- [x] I have updated documentation if necessary
- [x] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [ ] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|<img width="848" height="265" alt="Screenshot 2026-06-24 at 15 23 44" src="https://github.com/user-attachments/assets/f9c4eb9d-f4a3-45b2-a2db-33954238b900" />|<img width="848" height="265" alt="Screenshot 2026-06-24 at 15 23 35" src="https://github.com/user-attachments/assets/51755f6f-e41b-4d90-ad40-f6aaeeb17e81" />|
|<img width="848" height="410" alt="Screenshot 2026-06-24 at 15 22 58" src="https://github.com/user-attachments/assets/d4f23373-169e-459b-a104-e44824522851" />|<img width="848" height="410" alt="Screenshot 2026-06-24 at 15 23 01" src="https://github.com/user-attachments/assets/d38d4ca5-d4bb-4404-b743-57272ed3ed92" />|