### PR TITLE
change the fontsize and color of the label in date/time picker

### DIFF
--- a/.changeset/eleven-beds-push.md
+++ b/.changeset/eleven-beds-push.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Time/Date-picker: Make the fontsize of the label smaller

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -62,7 +62,12 @@ export const DateField = ({
     <Box minWidth="6rem" width="100%">
       {props.label && (
         <Box css={styles.inputLabel} position="absolute" paddingTop="2px">
-          <Label padding="0" {...props.labelProps}>
+          <Label
+            padding="0"
+            fontSize={["mobile.2xs", "desktop.2xs"]}
+            color="text.subtle"
+            {...props.labelProps}
+          >
             {props.label} <Field.RequiredIndicator />
           </Label>
         </Box>

--- a/packages/spor-react/src/datepicker/TimeField.tsx
+++ b/packages/spor-react/src/datepicker/TimeField.tsx
@@ -32,7 +32,8 @@ export const TimeField = ({ state, ...props }: TimeFieldProps) => {
         {...labelProps}
         htmlFor={fieldProps.id}
         marginBottom={0}
-        fontSize={["mobile.xs", "desktop.xs"]}
+        fontSize={["mobile.2xs", "desktop.2xs"]}
+        color="text.subtle"
         top={0}
         cursor="text"
         left="50%"


### PR DESCRIPTION
Change the label in the Date and Time-picker to have fontsize `2xs` and the color `text.subtle`. 