### PR TITLE
Sort props in code-documentation by name

### DIFF
--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ComponentDocs.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ComponentDocs.tsx
@@ -33,10 +33,12 @@ type ComponentDocsProps = {
   component: Component;
 };
 export const ComponentDocs = ({ component }: ComponentDocsProps) => {
-  const visibleProps = component.props?.filter((property) => {
-    const platform = property.platform ?? "react, react-native";
-    return platform.split(", ").includes("react");
-  });
+  const visibleProps = component.props
+    ?.filter((property) => {
+      const platform = property.platform ?? "react, react-native";
+      return platform.split(", ").includes("react");
+    })
+    ?.toSorted((a, b) => a.name.localeCompare(b.name));
   return (
     <Box key={component.name} as="section" marginBottom={9}>
       <LinkableHeading as="h3" variant="sm" marginBottom={1}>


### PR DESCRIPTION
## Background

Sort the table of props in the component-docs alphabetically by name. This will make it easier to read for the users. 

Before
<img width="862" height="579" alt="Skjermbilde 2026-07-09 kl  09 54 36" src="https://github.com/user-attachments/assets/845bda47-3553-477c-8d7b-d52b9a376d33" />


After
<img width="881" height="546" alt="Skjermbilde 2026-07-09 kl  09 54 21" src="https://github.com/user-attachments/assets/3a714d6c-ce9e-46df-84f1-81bb22a84a4d" />

