### PR TITLE
Avoid wrong cutting of icons

### DIFF
--- a/.changeset/wet-comics-sniff.md
+++ b/.changeset/wet-comics-sniff.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-icon-react": patch
+---
+
+Prevent id minification to avoid clip path collisions when multiple icons are on the same page

--- a/packages/spor-icon-react/bin/generate.ts
+++ b/packages/spor-icon-react/bin/generate.ts
@@ -138,6 +138,9 @@ async function generateComponent(iconData: IconData) {
               overrides: {
                 removeViewBox: false,
                 convertColors: false,
+                cleanupIds: {
+                  minify: false,
+                },
               },
             },
           },


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

Closes #2160

<!-- Why this task is needed, context, and problem it solves -->
The "preset-default" enabled minification of ids. The clipPathId became `a` for the 18px icon and for the 24px icon. 18px icon came first, and then the 24px icon got clipped like the first icon (to 18x18)

---

## Solution

<!-- What has been done and why this approach was chosen -->
Set cleanupIds minify to false to avoid duplicate clipPath ids. Read more about cleanupIds [here](https://svgo.dev/docs/plugins/cleanupIds/). Assumes all svg's have unqiue ids to be a proper fix. Instead of both icons having id `a` they keep the original id from the svg code (`clip0_6837_347` for add-outline-18x18 for example)

---

## General Checklist

- [ ] I have updated documentation if necessary
- [ ] I have verified the design aligns with the latest Figma sketches.
- [ ] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [ ] It is possible to use the keyboard to reach your changes
- [ ] It is possible to enlarge the text 400% without losing functionality
- [ ] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [ ] It works with VoiceOver
- [ ] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
|  <img width="2138" height="916" alt="image" src="https://github.com/user-attachments/assets/94cfbb8f-5e07-4ec2-8715-56b0d9af7699" /> |    <img width="823" height="518" alt="Fix" src="https://github.com/user-attachments/assets/dab674eb-abc5-4a7b-b022-bddcbecd1b18" /> |
| <img width="1169" height="857" alt="Problem" src="https://github.com/user-attachments/assets/59acfa6f-49df-4593-933f-f53ad4638511" /> |   <img width="1126" height="612" alt="Skjermbilde 2026-07-09 kl  14 54 38" src="https://github.com/user-attachments/assets/ef49af49-2c21-4a6a-8997-c4fda3113d42" /> |
