### PR TITLE
Style Select based on position of SelectContent

### DIFF
--- a/.changeset/tidy-lizards-carry.md
+++ b/.changeset/tidy-lizards-carry.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Select: Fix border radius and spacing when dropdown opens above the trigger

--- a/packages/spor-react/src/theme/slot-recipes/select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/select.ts
@@ -82,6 +82,13 @@ export const selectSlotRecipe = defineSlotRecipe({
       borderBottomRadius: "sm",
       marginTop: -1,
 
+      "&[data-placement^='top']": {
+        borderTopRadius: "sm",
+        borderBottomRadius: 0,
+        marginTop: 0,
+        marginBottom: -1,
+      },
+
       _open: {
         animationStyle: "slide-fade-in",
         animationDuration: "fast",
@@ -149,6 +156,10 @@ export const selectSlotRecipe = defineSlotRecipe({
       },
       _open: {
         borderBottomRadius: 0,
+      },
+      "&:has([data-placement^='top'][data-state='open'])": {
+        borderTopRadius: 0,
+        borderBottomRadius: "sm",
       },
       _invalid: {
         outline: "2px solid",


### PR DESCRIPTION
## Background

When the SelectContent moves on top of the SelectTrigger because there are not enough space under the trigger to show the content, the styling of the trigger and content no longer matches the layout. 

---

## Solution

Based on the position of the SelectContent add styling such as borderRadius and margin to match where the content is. 

---

Before 
<img width="681" height="364" alt="Skjermbilde 2026-07-10 kl  08 24 36" src="https://github.com/user-attachments/assets/12093fd4-ab80-4ca1-881c-422fad54a5e6" />


After
<img width="592" height="376" alt="Skjermbilde 2026-07-10 kl  08 25 33" src="https://github.com/user-attachments/assets/f511c7c9-c7e8-4523-8954-0c278c7b17a9" />
