### PR TITLE
Update bg.accent token

### DIFF
--- a/.changeset/early-moles-bow.md
+++ b/.changeset/early-moles-bow.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-design-tokens": patch
+---
+
+Update bg.accent token to be darkTeal in darkmode for vy-digital theme

--- a/packages/spor-design-tokens/tokens/color/vy-digital.json
+++ b/packages/spor-design-tokens/tokens/color/vy-digital.json
@@ -295,7 +295,7 @@
         "accent": {
           "value": {
             "_light": "colors.mint",
-            "_dark": "colors.jungle"
+            "_dark": "colors.darkTeal"
           }
         }
       },


### PR DESCRIPTION
Update bg.accent token to be darkTeal in darkmode for the vy-digital theme. 
