### PR TITLE
fix bug: component-example failes on navigation

### DIFF
--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ExampleSection.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ExampleSection.tsx
@@ -11,24 +11,28 @@ export const ExamplesSection = ({
 }: {
   codeExamples: CodeExample[];
 }) => {
-  const [currentExampleIndex, setCurrentExampleIndex] = useState(
+  const [currentExampleTitle, setCurrentExampleTitle] = useState(
     codeExamples.length > 0 ? codeExamples[0].title : "",
   );
+
+  const activeTitle = codeExamples.some((e) => e.title === currentExampleTitle)
+    ? currentExampleTitle
+    : (codeExamples[0]?.title ?? "");
   return (
     <Flex direction="column" gap={3} as="section">
       {codeExamples.length === 0 ? (
         <Text>No examples exist (yet!)</Text>
       ) : (
-        <CheckboxGroup defaultValue={[currentExampleIndex]}>
+        <CheckboxGroup defaultValue={[activeTitle]}>
           <Flex flexWrap="wrap" gap={1}>
             {codeExamples.map((example, index) => (
               <FilterChip
                 key={index + example.title}
                 variant="accent"
                 value={example.title}
-                checked={currentExampleIndex === example.title}
+                checked={activeTitle === example.title}
                 onCheckedChange={() => {
-                  setCurrentExampleIndex(example.title);
+                  setCurrentExampleTitle(example.title);
                 }}
                 size="xs"
               >
@@ -40,7 +44,7 @@ export const ExamplesSection = ({
       )}
       <Text fontSize="sm">
         {
-          codeExamples.find((example) => example.title === currentExampleIndex)
+          codeExamples.find((example) => example.title === activeTitle)
             ?.description
         }
       </Text>
@@ -49,7 +53,7 @@ export const ExamplesSection = ({
         layout="simple"
         maxWidth="100%"
         code={
-          codeExamples.find((example) => example.title === currentExampleIndex)
+          codeExamples.find((example) => example.title === activeTitle)
             ?.reactCode?.code ?? ""
         }
       />

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ExampleSection.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/component-docs/ExampleSection.tsx
@@ -15,7 +15,9 @@ export const ExamplesSection = ({
     codeExamples.length > 0 ? codeExamples[0].title : "",
   );
 
-  const activeTitle = codeExamples.some((e) => e.title === currentExampleTitle)
+  const activeTitle = codeExamples.some(
+    (example) => example.title === currentExampleTitle,
+  )
     ? currentExampleTitle
     : (codeExamples[0]?.title ?? "");
   return (


### PR DESCRIPTION
## Background

When navigating between component docs the examples sometimes failed. This was because React Router reuses the same component instance without remounting, and thereby keep the value of the useState. If the title of an example was set in the useState, but did not exist among the examples of the component the user navigated to, the example-section failed adn the user needed to refresh the page to get the useState re-initialised. 

---

## Solution

If the title-value that is set in the useState does not exist among the examples of the current component-doc, default back to showing the first example in the list. 

## Screenshots

Before: 
https://github.com/user-attachments/assets/af5ff07d-4dd1-4285-9e1f-30954000058c


After: 
https://github.com/user-attachments/assets/6b6e12f8-349e-44ab-ab87-1fad2f7a1906


