### PR TITLE
Optional radiobutton on Radiocards

### DIFF
--- a/.changeset/quick-ears-cut.md
+++ b/.changeset/quick-ears-cut.md
@@ -1,5 +1,5 @@
 ---
-"@vygruppen/spor-react": patch
+"@vygruppen/spor-react": minor
 ---
 
 RadioCards: Add "showIndicator" as an optional prop. If true, show a radiobutton-indicator on the left side of the content.

--- a/.changeset/quick-ears-cut.md
+++ b/.changeset/quick-ears-cut.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+RadioCards: Add "showIndicator" as an optional prop. If true, show a radiobutton-indicator on the left side of the content.

--- a/packages/spor-react/src/layout/RadioCard.tsx
+++ b/packages/spor-react/src/layout/RadioCard.tsx
@@ -36,10 +36,12 @@ type RadioCardItemProps = Exclude<
   RadioCardVariantProps & {
     inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
     ariaLabel?: string;
+    showIndicator?: boolean;
   };
 
 export const RadioCard = ({
   ref,
+  showIndicator = false,
   ...props
 }: RadioCardItemProps & {
   ref?: React.Ref<HTMLInputElement>;
@@ -61,6 +63,7 @@ export const RadioCard = ({
         {...inputProps}
       />
       <ChakraRadioCard.ItemControl id={itemControlId} aria-hidden>
+        {showIndicator && <ChakraRadioCard.ItemIndicator />}
         {children}
       </ChakraRadioCard.ItemControl>
     </ChakraRadioCard.Item>

--- a/packages/spor-react/src/theme/slot-recipes/anatomy.ts
+++ b/packages/spor-react/src/theme/slot-recipes/anatomy.ts
@@ -159,6 +159,7 @@ export const radioCardAnatomy = createAnatomy("radio-card").parts(
   "itemDescription",
   "itemContent",
   "itemControl",
+  "itemIndicator",
 );
 
 export const radioAnatomy = createAnatomy("radio").parts(

--- a/packages/spor-react/src/theme/slot-recipes/radio-card.ts
+++ b/packages/spor-react/src/theme/slot-recipes/radio-card.ts
@@ -37,6 +37,99 @@ export const radioCardSlotRecipe = defineSlotRecipe({
       fontWeight: "bold",
       fontSize: "inherit",
     },
+    itemControl: {
+      display: "flex",
+      alignItems: "flex-start",
+      justifyContent: "flex-start",
+    },
+
+    itemIndicator: {
+      display: "inline-flex",
+      flexShrink: 0,
+      alignItems: "center",
+      justifyContent: "center",
+      borderWidth: "2px",
+      borderColor: "outline.core",
+      borderRadius: "xl",
+      width: 3,
+      height: 3,
+      marginRight: 2,
+      marginTop: 0.5,
+
+      _checked: {
+        borderColor: "surface.brand",
+      },
+      _hover: {
+        borderColor: "surface.brand.hover",
+        "& .dot": {
+          backgroundColor: "surface.brand.hover",
+        },
+      },
+
+      _disabled: {
+        pointerEvents: "none",
+        backgroundColor: "surface.disabled",
+        borderColor: "outline.disabled",
+        "& .dot": {
+          backgroundColor: "outline.disabled",
+        },
+      },
+      _focusVisible: {
+        outlineWidth: "2px",
+        outlineColor: "outline.focus",
+        outlineStyle: "solid",
+        outlineOffset: "1px",
+      },
+
+      "& .dot": {
+        height: "full",
+        width: "full",
+        borderRadius: "xl",
+        backgroundColor: "surface.brand",
+        scale: "0.5",
+      },
+    },
+    /*itemIndicator: {
+      display: "inline-flex",
+      position: "relative",
+      borderWidth: "2px",
+      borderColor: "outline.core",
+      borderRadius: "xl",
+      width: 3,
+      height: 3,
+      _before: {
+        content: '""',
+        position: "absolute",
+        inset: 0,
+        margin: "auto",
+        width: "50%",
+        height: "50%",
+        borderRadius: "full",
+        backgroundColor: "surface.brand",
+        transform: "scale(0)",
+        transition: "transform 0.1s ease",
+      },
+      _checked: {
+        borderColor: "surface.brand",
+        _before: {
+          transform: "scale(1)",
+        },
+      },
+      _hover: {
+        borderColor: "surface.brand.hover",
+        _before: {
+          backgroundColor: "surface.brand.hover",
+        },
+      },
+      _disabled: {
+        pointerEvents: "none",
+        backgroundColor: "surface.disabled",
+        borderColor: "outline.disabled",
+        _before: {
+          backgroundColor: "outline.disabled",
+        },
+      },
+    },*/
   },
   variants: {
     variant: {

--- a/packages/spor-react/src/theme/slot-recipes/radio-card.ts
+++ b/packages/spor-react/src/theme/slot-recipes/radio-card.ts
@@ -89,47 +89,6 @@ export const radioCardSlotRecipe = defineSlotRecipe({
         scale: "0.5",
       },
     },
-    /*itemIndicator: {
-      display: "inline-flex",
-      position: "relative",
-      borderWidth: "2px",
-      borderColor: "outline.core",
-      borderRadius: "xl",
-      width: 3,
-      height: 3,
-      _before: {
-        content: '""',
-        position: "absolute",
-        inset: 0,
-        margin: "auto",
-        width: "50%",
-        height: "50%",
-        borderRadius: "full",
-        backgroundColor: "surface.brand",
-        transform: "scale(0)",
-        transition: "transform 0.1s ease",
-      },
-      _checked: {
-        borderColor: "surface.brand",
-        _before: {
-          transform: "scale(1)",
-        },
-      },
-      _hover: {
-        borderColor: "surface.brand.hover",
-        _before: {
-          backgroundColor: "surface.brand.hover",
-        },
-      },
-      _disabled: {
-        pointerEvents: "none",
-        backgroundColor: "surface.disabled",
-        borderColor: "outline.disabled",
-        _before: {
-          backgroundColor: "outline.disabled",
-        },
-      },
-    },*/
   },
   variants: {
     variant: {


### PR DESCRIPTION
## Background

It has been requested that it should be possible to show a radiobutton-indicator on RadioCards to make it even more clear  for the user that the cards together make a RadioGroup with singleselect. 

---

## Solution

Add an optional `showIndicator` prop that by default is false, but when set to true it shows a radiobutton-indicator on the left side of the content. 

## How to test
Take a look at the last example here: https://pr-2327.test.design.vy.no/spor/components/radiocard

<img width="887" height="564" alt="Skjermbilde 2026-07-16 kl  11 04 12" src="https://github.com/user-attachments/assets/88ba15ca-d749-4b72-93a1-632c42886e4a" />
