### PR TITLE
Action and closable prop for Toast

### DIFF
--- a/.changeset/tangy-rules-fix.md
+++ b/.changeset/tangy-rules-fix.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Toast: Add action and closable props to Toast component for enhanced functionality

--- a/.changeset/tangy-rules-fix.md
+++ b/.changeset/tangy-rules-fix.md
@@ -1,5 +1,5 @@
 ---
-"@vygruppen/spor-react": patch
+"@vygruppen/spor-react": minor
 ---
 
 Toast: Add action and closable props to Toast component for enhanced functionality

--- a/packages/spor-react/src/toast/toast.tsx
+++ b/packages/spor-react/src/toast/toast.tsx
@@ -10,6 +10,7 @@ import {
 } from "@chakra-ui/react";
 
 import { AlertIcon } from "@/alert/AlertIcon";
+import { Button, CloseButton } from "@/button";
 
 const toaster = createToaster({
   placement: "bottom",
@@ -18,11 +19,18 @@ const toaster = createToaster({
 
 type Variant = "info" | "success" | "error";
 
+type ToastAction = {
+  label: string;
+  onClick: () => void;
+};
+
 type ToastProps = {
   duration?: number;
   text: string;
   variant: Variant;
   id?: string;
+  action?: ToastAction;
+  closable?: boolean;
 } & Pick<BoxProps, "width">;
 
 export const createToast = ({
@@ -31,13 +39,17 @@ export const createToast = ({
   id,
   duration = 6000,
   width = "sm",
+  action,
+  closable = false,
 }: ToastProps) =>
   toaster.create({
     description: text,
     type: variant,
     id: id ?? crypto.randomUUID(),
     duration,
+    action,
     meta: { width },
+    closable: closable,
   });
 
 export const Toaster = () => {
@@ -56,6 +68,18 @@ export const Toaster = () => {
             <Stack gap="1" flex="1" maxWidth="100%">
               <Toast.Description>{toast.description}</Toast.Description>
             </Stack>
+            {toast.action && (
+              <Toast.ActionTrigger onClick={toast.action.onClick}>
+                <Button variant="ghost" size="xs">
+                  {toast.action.label}
+                </Button>
+              </Toast.ActionTrigger>
+            )}
+            {toast.closable && (
+              <Toast.CloseTrigger>
+                <CloseButton size="xs" />
+              </Toast.CloseTrigger>
+            )}
           </Toast.Root>
         )}
       </ChakraToaster>


### PR DESCRIPTION
## Background

Adds possibility to add an action to a Toast, and also a close-button. 

---

## Solution

Uses Chakra's built-in functionality for action and closable. 

## How to test? 
Take a look at the "Closable" and "With action" examples here: https://pr-2328.test.design.vy.no/spor/components/toast


## Screenshots

<img width="898" height="725" alt="Skjermbilde 2026-07-16 kl  11 29 08" src="https://github.com/user-attachments/assets/e72482de-fc67-416c-b9e1-8dc86a6584cb" />
