### PR TITLE
Add size prop to date and time picker components

### DIFF
--- a/.changeset/better-dots-dress.md
+++ b/.changeset/better-dots-dress.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Date and time picker: Add `size` prop with `"sm"` and `"md"` variants (defaults to `"md"`)

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -56,6 +56,7 @@ type DatePickerProps = Omit<AriaDatePickerProps<DateValue>, "onChange"> &
  * A date picker component.
  *
  * There are three different variants –`core`, `floating` and `ghost`.
+ * There are two different sizes - `sm` and `md`
  *
  * ```tsx
  * <DatePicker label="Dato" variant="core" />
@@ -65,6 +66,7 @@ type DatePickerProps = Omit<AriaDatePickerProps<DateValue>, "onChange"> &
 export const DatePicker = ({
   ref: externalRef,
   variant,
+  size,
   errorText,
   minHeight,
   showYearNavigation,
@@ -144,12 +146,13 @@ export const DatePicker = ({
             invalid={invalid}
             helperText={helperText}
             required={props.required}
+            size={size}
           >
             <PopoverAnchor>
               <StyledField
                 variant={variant}
+                size={size}
                 onClick={onFieldClick}
-                paddingX={3}
                 minHeight={minHeight}
                 isDisabled={props.isDisabled}
                 isActive={props.isActive}
@@ -162,8 +165,7 @@ export const DatePicker = ({
                 ) : (
                   <ChakraPopover.Trigger asChild>
                     <CalendarTriggerButton
-                      paddingLeft={1}
-                      paddingRight={1}
+                      marginLeft={1}
                       variant={variant}
                       ref={ref}
                       {...buttonProps}

--- a/packages/spor-react/src/datepicker/DateRangePicker.tsx
+++ b/packages/spor-react/src/datepicker/DateRangePicker.tsx
@@ -52,12 +52,14 @@ type DateRangePickerProps = Omit<
  * A date range picker component.
  *
  * There are three variants to choose from – `core`, `floating` and `ghost`.
+ * There are two different sizes - `sm` and `md`
  *
  * ```tsx
  * <DateRangePicker startLabel="From" startName="from" endLabel="To" endName="to" variant="core" />
  * ```
  */ export function DateRangePicker({
   variant = "core",
+  size,
   minHeight,
   startName,
   endName,
@@ -135,6 +137,7 @@ type DateRangePickerProps = Omit<
                 alignItems="center"
                 paddingX={3}
                 variant={variant}
+                size={size}
                 onClick={onFieldClick}
                 minHeight={minHeight}
               >

--- a/packages/spor-react/src/datepicker/DateTimeSegment.tsx
+++ b/packages/spor-react/src/datepicker/DateTimeSegment.tsx
@@ -57,7 +57,6 @@ export const DateTimeSegment = ({
       textAlign="center"
       outline="none"
       borderRadius="xs"
-      fontSize={["mobile.sm", "desktop.sm"]}
       css={styles.dateTimeSegment}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}

--- a/packages/spor-react/src/datepicker/StyledField.tsx
+++ b/packages/spor-react/src/datepicker/StyledField.tsx
@@ -29,6 +29,7 @@ export const StyledField = function StyledField({
     isDisabled,
     isActive,
     overrideBorderColor,
+    size,
     ...otherProps
   } = props;
   const { invalid } = useFieldContext() ?? {
@@ -38,7 +39,7 @@ export const StyledField = function StyledField({
   const recipe = useSlotRecipe({
     key: "datePicker",
   });
-  const styles = recipe({ variant });
+  const styles = recipe({ variant, size });
 
   return (
     <Box
@@ -51,7 +52,6 @@ export const StyledField = function StyledField({
       ref={ref}
       aria-invalid={invalid}
       aria-disabled={isDisabled}
-      fontSize={["mobile.md", "desktop.md"]}
     >
       {children}
     </Box>

--- a/packages/spor-react/src/datepicker/TimeField.tsx
+++ b/packages/spor-react/src/datepicker/TimeField.tsx
@@ -36,8 +36,6 @@ export const TimeField = ({ state, ...props }: TimeFieldProps) => {
         color="text.subtle"
         top={0}
         cursor="text"
-        left="50%"
-        transform="translateX(-50%)"
         position="absolute"
         paddingTop="2px"
         whiteSpace="nowrap"

--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -50,6 +50,11 @@ type TimePickerProps = Omit<BoxProps, "defaultValue" | "onChange"> &
      * Defaults to "core".
      */
     variant?: "core" | "floating" | "ghost";
+    /**
+     * The size of the time picker.
+     * Defaults to "md".
+     */
+    size?: "sm" | "md";
   };
 /** A time picker component.
  *
@@ -137,10 +142,8 @@ export const TimePicker = ({
     <Field as="time" {...boxProps}>
       <StyledField
         width="fit-content"
-        paddingX={2}
         alignItems="center"
         justifyContent="space-between"
-        gap={2}
         opacity={isDisabled ? 0.5 : 1}
         pointerEvents={isDisabled ? "none" : "auto"}
         aria-disabled={isDisabled}

--- a/packages/spor-react/src/datepicker/types.ts
+++ b/packages/spor-react/src/datepicker/types.ts
@@ -2,4 +2,5 @@ import { ConditionalValue } from "@chakra-ui/react";
 
 export type CalendarVariants = {
   variant?: ConditionalValue<"core" | "floating" | "ghost">;
+  size?: ConditionalValue<"sm" | "md">;
 };

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -13,6 +13,8 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       display: "flex",
       flex: 1,
       paddingY: 0.5,
+      paddingX: 2,
+      gap: 1.5,
       alignItems: "center",
       _hover: {
         zIndex: "docked",
@@ -237,8 +239,23 @@ export const datePickerSlotRecipe = defineSlotRecipe({
         },
       },
     },
+    size: {
+      sm: {
+        wrapper: {
+          fontSize: ["mobile.xs", "desktop.xs"],
+          paddingX: 1,
+          gap: 1,
+        },
+      },
+      md: {
+        wrapper: {
+          fontSize: ["mobile.sm", "desktop.sm"],
+        },
+      },
+    },
   },
   defaultVariants: {
     variant: "core",
+    size: "md",
   },
 });


### PR DESCRIPTION
## Background

Adds possibility to choose between two different sizes for the date and time picker.

---

## Solution

Adds size variant to the `StyledField` component that both the TimePicker and DatePicker uses. Since the `StyledField`-component uses the `datepicker`-recipe for styling, the variants have been added to this recipe and will therefore both affect the TimePicker and DatePicker. 

### How to test
Take a look at the Size examples: 
DatePicker: https://pr-2331.test.design.vy.no/spor/components/datepicker 
TimePicker: https://pr-2331.test.design.vy.no/spor/components/timepicker

---

## General Checklist

- [ ] I have updated documentation if necessary
- [ ] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

TimePicker
<img width="951" height="557" alt="Skjermbilde 2026-07-20 kl  10 42 36" src="https://github.com/user-attachments/assets/226dbd0f-4d94-4e98-8ef4-bdccd3b66408" />


DatePicker
<img width="894" height="544" alt="Skjermbilde 2026-07-20 kl  10 43 07" src="https://github.com/user-attachments/assets/458b6d7d-ebe0-46fa-87ed-4c5e405db97b" />
