### PR TITLE
Fix Duotone Fill status icons to use real colors

### DIFF
--- a/.changeset/fix-rn-icon-duotone-css-vars.md
+++ b/.changeset/fix-rn-icon-duotone-css-vars.md
@@ -1,0 +1,15 @@
+---
+"@vygruppen/spor-icon-react-native": patch
+---
+
+Fix duotone status icons rendering with the wrong color in React Native
+
+The duotone "Fill" status icons (`InformationFill*`, `ErrorFill*`, `SuccessFill*`)
+shipped with web CSS variables (e.g. `var(--spor-colors-icon-info)`) as their SVG
+`fill` values. `react-native-svg` cannot parse these, which produced warnings like
+`"var(--spor-colors-icon-info)" is not a valid color or brush` and caused the icons
+to fall back to a default color, losing their two-tone appearance.
+
+The icon generator now maps these CSS variables to the corresponding theme colors
+(e.g. `theme.colors["icon.info"]`), so the icons resolve their colors from the
+active Spor theme instead.

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -159,6 +159,13 @@ async function generateComponent(iconData: IconData) {
   // It looks hacky, it is hacky, but it works.
   jsCode = "import { Box, useTheme } from 'app/spor';\n" + jsCode;
   jsCode = jsCode
+    // Duotone status icons ship with web CSS variables (`var(--spor-colors-*)`)
+    // as fills, which react-native-svg can't parse. Map them to theme colors.
+    .replace(
+      /fill="var\(--spor-colors-([a-z-]+)\)"/g,
+      (_match, token: string) =>
+        `fill={theme.colors["${token.replace(/-/g, ".")}"]}`,
+    )
     .replace("{...props}", "")
     .replace("props", '{ color = "icon.default", width, height, ...props }')
     // Weird regex alert!

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -164,7 +164,7 @@ async function generateComponent(iconData: IconData) {
     .replaceAll(
       /fill="var\(--spor-colors-([a-z-]+)\)"/g,
       (_match, token: string) =>
-        `fill={theme.colors["${token.replaceAll(/-/g, ".")}"]}`,
+        `fill={theme.colors["${token.replaceAll("-", ".")}"]}`,
     )
     .replace("{...props}", "")
     .replace("props", '{ color = "icon.default", width, height, ...props }')

--- a/packages/spor-icon-react-native/bin/generate.ts
+++ b/packages/spor-icon-react-native/bin/generate.ts
@@ -161,10 +161,10 @@ async function generateComponent(iconData: IconData) {
   jsCode = jsCode
     // Duotone status icons ship with web CSS variables (`var(--spor-colors-*)`)
     // as fills, which react-native-svg can't parse. Map them to theme colors.
-    .replace(
+    .replaceAll(
       /fill="var\(--spor-colors-([a-z-]+)\)"/g,
       (_match, token: string) =>
-        `fill={theme.colors["${token.replace(/-/g, ".")}"]}`,
+        `fill={theme.colors["${token.replaceAll(/-/g, ".")}"]}`,
     )
     .replace("{...props}", "")
     .replace("props", '{ color = "icon.default", width, height, ...props }')


### PR DESCRIPTION
## Background

Duotone Fill status icons (Information/Error/Success) shipped web CSS variables (var(--spor-colors-*)) as SVG fills, which react-native-svg cannot parse. The generator now maps these to theme colors (e.g. theme.colors["icon.info"]) so the icons render their intended two-tone colors from the active Spor theme.

Sample log from salgsapp:

```
var(--spor-colors-icon-info)" is not a valid color or brush
 WARN  "var(--spor-colors-surface-info)" is not a valid color or brush
 WARN  "var(--spor-colors-surface-info)" is not a valid color or brush
```


---

## Solution

The icon generator now maps web CSS variables (e.g., `var(--spor-colors-icon-info)`) to their corresponding theme colors (e.g., `theme.colors["icon.info"]`) for duotone "Fill" status icons (`InformationFill*`, `ErrorFill*`, `SuccessFill*`), resolving color parsing issues in React Native and restoring proper two-tone rendering.

---

## General Checklist

- [x] I have updated documentation if necessary
- [x] I have created a changeset if publishing is required
 