### PR TITLE
Input - Override safari banana-yellow autofill color

### DIFF
--- a/.changeset/chilly-pears-doubt.md
+++ b/.changeset/chilly-pears-doubt.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+override safari autofill for input fields with spor colors

--- a/packages/spor-react/src/theme/recipes/input.ts
+++ b/packages/spor-react/src/theme/recipes/input.ts
@@ -56,6 +56,10 @@ export const inputRecipe = defineRecipe({
           outline: "2px solid",
           outlineColor: "outline.focus",
         },
+        "&:-webkit-autofill, &:-webkit-autofill:focus": {
+          boxShadow: "0 0 0 1000px var(--spor-colors-surface-info-hover) inset",
+          WebkitTextFillColor: "var(--spor-colors-text)",
+        },
       },
       floating: {
         boxShadow: "sm",
@@ -72,10 +76,13 @@ export const inputRecipe = defineRecipe({
           outlineColor: "outline.neutral",
           backgroundColor: "surface.floating.active",
         },
-
         focus: {
           outline: "1px solid",
           outlineColor: "outline.focus",
+        },
+        "&:-webkit-autofill, &:-webkit-autofill:focus": {
+          boxShadow: "0 0 0 1000px var(--spor-colors-surface-info-hover) inset",
+          WebkitTextFillColor: "var(--spor-colors-text)",
         },
       },
     },


### PR DESCRIPTION
## Background

[TRELLO](https://trello.com/c/GPDBp66I/3845-autofill-gj%C3%B8r-tekstfelt-gult-og-tekst-sort-darkmode-men-label-beholder-hvitfargen-sin)

We currently use the default autofill colors that webkit provides which are:

light: #E8F0FE
dark: #1D3041

iOS however using the Safari browser overrides this with a banana yellow color which looks like this:

<img width="300" alt="Screenshot 2026-08-03 at 13 17 13" src="https://github.com/user-attachments/assets/6f644c96-9fb5-4998-b31c-7c54e0c5a366" />

This requires some changes.

## Solution

We can override the default webkit colors. The closest equivalent that the spor library offers is the `surface.info.hover`. I am open for suggestions for other color values.

Code implementation is based on this [stackOverflow](https://stackoverflow.com/questions/41871618/how-to-change-safari-autofill-yellow-background-color) solution
[More info about the banana yellow issue on Safari can be found here](https://mariusschulz.com/blog/how-to-remove-webkits-banana-yellow-autofill-background)


Below are the before and after of light and dark mode (top is before)

| Light mode | Dark mode |
|------------|-----------|
| <img width="298" height="77" alt="Before light mode" src="https://github.com/user-attachments/assets/9c90f121-715a-4e32-8a97-9a2d9818b32f" /> | <img width="295" height="74" alt="Before dark mode" src="https://github.com/user-attachments/assets/a51c2cee-cbcc-4d46-ac8a-3f4e2a7fe998" /> |
| <img width="356" height="104" alt="After light mode" src="https://github.com/user-attachments/assets/93e422d7-ae80-4b45-8a98-e04bf9f8da3a" /> | <img width="366" height="96" alt="After dark mode" src="https://github.com/user-attachments/assets/cc529d9e-432f-45cd-995e-701b34d6490e" /> |

---

## General Checklist

- [x] I have updated documentation if necessary
- [ ] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [ ] There are no errors in aXe / SiteImprove-plugins / Wave

