### PR TITLE
Add size prop to Autocomplete component for customizable input size

### DIFF
--- a/.changeset/real-chefs-sit.md
+++ b/.changeset/real-chefs-sit.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": minor
+---
+
+Autocomplete: add a size-prop that can be set to either 'md' or 'sm'.

--- a/packages/spor-react/src/input/Autocomplete.tsx
+++ b/packages/spor-react/src/input/Autocomplete.tsx
@@ -50,6 +50,7 @@ export function Autocomplete({
   openOnClick = true,
   openOnFocus = true,
   ref,
+  size = "md",
   ...rest
 }: Props) {
   const { contains } = useFilter({ sensitivity: "base" });
@@ -114,6 +115,7 @@ export function Autocomplete({
               if (openOnFocus && filteredChildren.length > 0)
                 combobox.setOpen(true);
             }}
+            size={size}
           />
         </Combobox.Input>
         <Combobox.IndicatorGroup>


### PR DESCRIPTION
## Background

Adds support for a small-size of the Autocomplete component.

---

## Solution

Adds a "size" prop, and pass it down to the Input-component. 

