### PR TITLE
Use iconsize 30x30 when TextLink is of size "lg".

### DIFF
--- a/.changeset/angry-dots-push.md
+++ b/.changeset/angry-dots-push.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+TextLink: Change the ExternalLink-Icon to be of size 30x30 when TextLink is of size "lg"

--- a/packages/spor-react/src/link/TextLink.tsx
+++ b/packages/spor-react/src/link/TextLink.tsx
@@ -7,6 +7,7 @@ import {
 import {
   LinkOutOutline18Icon,
   LinkOutOutline24Icon,
+  LinkOutOutline30Icon,
 } from "@vygruppen/spor-icon-react";
 import React, {
   cloneElement,
@@ -39,17 +40,31 @@ const ExternalIcon = ({
 }: {
   label: string;
   size: LinkProps["size"];
-}) => (
-  <>
-    {size === "lg" || size === "md" ? (
-      <LinkOutOutline24Icon aria-hidden display="inline" />
-    ) : (
-      <LinkOutOutline18Icon aria-hidden display="inline" />
-    )}
-    {/* Visually hidden text for screen readers */}
-    <VisuallyHidden>{label}</VisuallyHidden>
-  </>
-);
+}) => {
+  const getIcon = () => {
+    switch (size) {
+      case "lg": {
+        return <LinkOutOutline30Icon aria-hidden display="inline" />;
+      }
+      case "md": {
+        return <LinkOutOutline24Icon aria-hidden display="inline" />;
+      }
+      case "sm": {
+        return <LinkOutOutline18Icon aria-hidden display="inline" />;
+      }
+      default: {
+        return <LinkOutOutline24Icon aria-hidden display="inline" />;
+      }
+    }
+  };
+  return (
+    <>
+      {getIcon()}
+      {/* Visually hidden text for screen readers */}
+      <VisuallyHidden>{label}</VisuallyHidden>
+    </>
+  );
+};
 
 export const TextLink = ({
   ref,


### PR DESCRIPTION
## Background

When the TextLink was of size "lg" is used a 24x24 icon which was a little too small. 
Changed to using a 30x30 icon. 
