### PR TITLE
Add truncate to Select ValueText

### DIFF
--- a/.changeset/tricky-cycles-grow.md
+++ b/.changeset/tricky-cycles-grow.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+truncate long select labels when selected

--- a/packages/spor-react/src/input/Select.tsx
+++ b/packages/spor-react/src/input/Select.tsx
@@ -276,7 +276,6 @@ export const SelectValueText = function SelectValueText({
       ref={ref}
       placeholder={placeholder}
       data-with-placeholder={withPlaceholder || undefined}
-      truncate
     >
       <ChakraSelect.Context>
         {(select: {

--- a/packages/spor-react/src/input/Select.tsx
+++ b/packages/spor-react/src/input/Select.tsx
@@ -276,6 +276,7 @@ export const SelectValueText = function SelectValueText({
       ref={ref}
       placeholder={placeholder}
       data-with-placeholder={withPlaceholder || undefined}
+      truncate
     >
       <ChakraSelect.Context>
         {(select: {

--- a/packages/spor-react/src/theme/slot-recipes/select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/select.ts
@@ -166,6 +166,11 @@ export const selectSlotRecipe = defineSlotRecipe({
         outlineColor: "outline.error",
       },
     },
+    valueText: {
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+    },
     itemText: {
       flex: "1",
       alignItems: "center",


### PR DESCRIPTION
## Background

When working on a seperate PR i noticed this issue for the `Select` component

<img width="426" height="89" alt="Screenshot 2026-08-12 at 08 50 17" src="https://github.com/user-attachments/assets/d6b71795-f1c3-46dd-8657-6fbfcb27988d" />

## Solution

- add `truncate` to ValueText for `Select` component

## General Checklist

- [x] I have updated documentation if necessary
- [x] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

## Accessibility checklist

For changes impacting the user interface or functionality, ensure the following:

- [x] It is possible to use the keyboard to reach your changes
- [x] It is possible to enlarge the text 400% without losing functionality
- [x] It works on both mobile and desktop
- [x] It works in both Chrome, Safari and Firefox
- [x] It works with VoiceOver
- [x] There are no errors in aXe / SiteImprove-plugins / Wave

---

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="541" height="95" alt="Screenshot 2026-08-12 at 08 48 54" src="https://github.com/user-attachments/assets/979a5d12-d3c1-468b-823f-70f5e41f1b06" /> | <img width="533" height="84" alt="Screenshot 2026-08-12 at 08 48 37" src="https://github.com/user-attachments/assets/3a1004f2-72a0-4fb5-a1c2-8c93aed98aac" /> |