### PR TITLE
Fix RadioCard layout to stack children in a column by default

### DIFF
--- a/.changeset/yummy-brooms-feel.md
+++ b/.changeset/yummy-brooms-feel.md
@@ -1,0 +1,8 @@
+---
+"@vygruppen/spor-react": patch
+"@vygruppen/spor-icon": patch
+"@vygruppen/spor-icon-react": patch
+"@vygruppen/spor-icon-react-native": patch
+---
+
+RadioCard bug: make the children of a RadioCard to by default be placed in a column instead of a row.

--- a/packages/spor-react/src/layout/RadioCard.tsx
+++ b/packages/spor-react/src/layout/RadioCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 import {
+  Box,
   RadioCard as ChakraRadioCard,
   RecipeVariantProps,
   useSlotRecipe,
@@ -64,7 +65,7 @@ export const RadioCard = ({
       />
       <ChakraRadioCard.ItemControl id={itemControlId} aria-hidden>
         {showIndicator && <ChakraRadioCard.ItemIndicator />}
-        {children}
+        <Box>{children}</Box>
       </ChakraRadioCard.ItemControl>
     </ChakraRadioCard.Item>
   );

--- a/packages/spor-react/src/layout/RadioCard.tsx
+++ b/packages/spor-react/src/layout/RadioCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 import {
-  Box,
+  Flex,
   RadioCard as ChakraRadioCard,
   RecipeVariantProps,
   useSlotRecipe,
@@ -65,7 +65,7 @@ export const RadioCard = ({
       />
       <ChakraRadioCard.ItemControl id={itemControlId} aria-hidden>
         {showIndicator && <ChakraRadioCard.ItemIndicator />}
-        <Box>{children}</Box>
+        <Flex direction="column">{children}</Flex>
       </ChakraRadioCard.ItemControl>
     </ChakraRadioCard.Item>
   );


### PR DESCRIPTION
## Background

Bug found in Spor release 13.5.0 that made the children of RadioCard be placed in a row instead of column. 
<img width="805" height="624" alt="image" src="https://github.com/user-attachments/assets/ad6eea07-3eb5-4662-924e-91452b71379b" />

<img width="807" height="567" alt="image" src="https://github.com/user-attachments/assets/2fca9425-dc35-4c23-bec5-8e5d82240f30" />


Read more about it here: 
https://nsb-utvikling.slack.com/archives/CM9H2N39U/p1786537635814149

---

## Solution

Wrap the children of the RadioCard with a Box. Please come with suggestions on a better solution 🙏 