### PR TITLE
support custom resource-links on pages

### DIFF
--- a/apps/design-studio/schemaTypes/documents/article.tsx
+++ b/apps/design-studio/schemaTypes/documents/article.tsx
@@ -114,9 +114,18 @@ export const article = defineType({
                   { title: "Figma", value: "figma" },
                   { title: "React", value: "react" },
                   { title: "React Native", value: "react-native" },
+                  { title: "Custom", value: "custom" },
                 ],
               },
               validation: (Rule) => Rule.required(),
+            },
+            {
+              name: "buttonText",
+              type: "string",
+              title: "Button text",
+              hidden: ({ parent }) => {
+                return parent?.linkType !== "custom";
+              },
             },
             {
               name: "url",

--- a/apps/design-studio/schemaTypes/documents/article.tsx
+++ b/apps/design-studio/schemaTypes/documents/article.tsx
@@ -126,6 +126,16 @@ export const article = defineType({
               hidden: ({ parent }) => {
                 return parent?.linkType !== "custom";
               },
+              validation: (Rule) =>
+                Rule.custom((value, context) => {
+                  if (
+                    (context.parent as any)?.linkType === "custom" &&
+                    !value
+                  ) {
+                    return "Required";
+                  }
+                  return true;
+                }),
             },
             {
               name: "icon",

--- a/apps/design-studio/schemaTypes/documents/article.tsx
+++ b/apps/design-studio/schemaTypes/documents/article.tsx
@@ -128,6 +128,14 @@ export const article = defineType({
               },
             },
             {
+              name: "icon",
+              type: "icon",
+              title: "Icon",
+              hidden: ({ parent }) => {
+                return parent?.linkType !== "custom";
+              },
+            },
+            {
               name: "url",
               type: "url",
               title: "URL",

--- a/apps/designmanual-frontend/app/root/layout/Footer.tsx
+++ b/apps/designmanual-frontend/app/root/layout/Footer.tsx
@@ -13,7 +13,7 @@ export const Footer = () => {
       backgroundColor="surface.subtle"
       className="dark"
       alignItems="center"
-      marginTop={4}
+      marginTop={10}
       padding={{ base: 4, md: 7 }}
       width="100%"
       zIndex="banner"

--- a/apps/designmanual-frontend/app/routes/$section._index/route.tsx
+++ b/apps/designmanual-frontend/app/routes/$section._index/route.tsx
@@ -174,7 +174,7 @@ export default function Index() {
         </Stack>
       </Flex>
       <Box
-        paddingX={10}
+        paddingX={[2, 4, 4, 8]}
         position="relative"
         top="-5rem"
         justifyContent="center"
@@ -217,7 +217,7 @@ const ImageCard = ({ title, textContent, image, href, anchor }: ImageCard) => {
 
   return (
     <PressableCard
-      maxWidth={["100%", "270px"]}
+      maxWidth={["100%", "100%", "100%", "270px"]}
       backgroundColor="surface"
       padding="3"
       variant="floating"

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
@@ -41,7 +41,8 @@ import { RightSidebar } from "../_base/right-sidebar/RightSidebar";
 import { ExamplesSection } from "./component-docs/ExampleSection";
 
 type ResourceLink = {
-  linkType: "figma" | "react" | "react-native";
+  linkType: "figma" | "react" | "react-native" | "custom";
+  buttonText?: string;
   url: string;
 };
 
@@ -97,7 +98,11 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
       badgeType, 
       description
     },
-    resourceLinks[linkType == "react" || linkType == "react-native" || linkType == "figma"],
+    resourceLinks[linkType == "react" || linkType == "react-native" || linkType == "figma" || linkType == "custom"] {
+      linkType,
+      buttonText,
+      url
+    },
     content[]{
       _type == 'reference' => @->,
       _type != 'reference' => @,
@@ -228,7 +233,9 @@ export default function ArticlePage() {
                   rightIcon={<LinkOutOutline18Icon />}
                 >
                   <Link to={link.url} target="_blank">
-                    {mapLinkToLabel(link.linkType)}
+                    {link.linkType === "custom"
+                      ? link.buttonText
+                      : mapLinkToLabel(link.linkType)}
                   </Link>
                 </Button>
               ))}

--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
@@ -28,6 +28,7 @@ import { ArticleBadge } from "~/features/portable-text/components/ArticleBadge";
 import { PortableText } from "~/features/portable-text/PortableText";
 import { useHeaderOffset } from "~/root/layout/HeaderOffsetContext";
 import { ComponentDocs } from "~/routes/_base.$section.$category.$slug/component-docs/ComponentDocs";
+import { getIcon } from "~/utils/getIcon";
 import { ArticleBadgeType } from "~/utils/initialSanityData.server";
 import { getClient } from "~/utils/sanity/client";
 import {
@@ -43,6 +44,7 @@ import { ExamplesSection } from "./component-docs/ExampleSection";
 type ResourceLink = {
   linkType: "figma" | "react" | "react-native" | "custom";
   buttonText?: string;
+  icon?: string;
   url: string;
 };
 
@@ -101,6 +103,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     resourceLinks[linkType == "react" || linkType == "react-native" || linkType == "figma" || linkType == "custom"] {
       linkType,
       buttonText,
+      icon,
       url
     },
     content[]{
@@ -223,60 +226,51 @@ export default function ArticlePage() {
                 }}
               />
             )}
-            <Flex gap={1}>
-              {article.resourceLinks?.map((link: ResourceLink) => (
-                <Button
-                  asChild
-                  key={link.url}
-                  variant="tertiary"
-                  size="sm"
-                  rightIcon={<LinkOutOutline18Icon />}
-                >
-                  <Link to={link.url} target="_blank">
-                    {link.linkType === "custom"
-                      ? link.buttonText
-                      : mapLinkToLabel(link.linkType)}
-                  </Link>
-                </Button>
-              ))}
-            </Flex>
+            {article.resourceLinks && article.resourceLinks.length > 0 && (
+              <Flex gap={1}>
+                {article.resourceLinks?.map((link: ResourceLink) => (
+                  <Button
+                    asChild
+                    key={link.url}
+                    variant="tertiary"
+                    size="sm"
+                    rightIcon={<LinkOutOutline18Icon />}
+                    leftIcon={
+                      link.linkType === "custom" && link.icon
+                        ? getIcon({ iconName: link.icon, size: 24 })
+                        : undefined
+                    }
+                  >
+                    <Link to={link.url} target="_blank">
+                      {link.linkType === "custom"
+                        ? link.buttonText
+                        : mapLinkToLabel(link.linkType)}
+                    </Link>
+                  </Button>
+                ))}
+              </Flex>
+            )}
           </Flex>
-          <Stack direction="column" gap={2}>
-            {article.badges?.map((badge: ArticleBadgeType, index: number) => (
-              <ArticleAlert
-                key={index}
-                badgeType={badge.badgeType}
-                description={badge.description}
-              />
-            ))}
-          </Stack>
-
-          <Box
-            width="20%"
-            display="none"
-            position="fixed"
-            overflow="auto"
-            right={0}
-            paddingLeft={1}
-            paddingTop={3}
-            top={`${headerOffset}px`}
-            transition="all .3s linear"
-            height={`calc(100vh - ${headerOffset}px)`}
-            css={{
-              [`@media screen and (min-width: 1110px)`]: {
-                display: "block",
-              },
-            }}
-          >
-            <RightSidebar />
-          </Box>
+          {article.badges && article.badges.length > 0 && (
+            <Stack direction="column" gap={2}>
+              {article.badges?.map((badge: ArticleBadgeType, index: number) => (
+                <ArticleAlert
+                  key={index}
+                  badgeType={badge.badgeType}
+                  description={badge.description}
+                />
+              ))}
+            </Stack>
+          )}
 
           {article.componentSections ? (
-            <ComponentSections
-              id={article._id}
-              sections={article.componentSections}
-              component={article.title}
-            />
+            <Flex gap="5" marginTop={6} direction="column">
+              <ComponentSections
+                id={article._id}
+                sections={article.componentSections}
+                component={article.title}
+              />
+            </Flex>
           ) : article.title.includes("Sidespor") ? (
             <SporProvider theme={extendedSystemConfigWithSidespor}>
               <PortableText value={article.content} />
@@ -297,6 +291,25 @@ export default function ArticlePage() {
           },
         }}
       />
+      <Box
+        width="20%"
+        display="none"
+        position="fixed"
+        overflow="auto"
+        right={0}
+        paddingLeft={1}
+        paddingTop={3}
+        top={`${headerOffset}px`}
+        transition="all .3s linear"
+        height={`calc(100vh - ${headerOffset}px)`}
+        css={{
+          [`@media screen and (min-width: 1110px)`]: {
+            display: "block",
+          },
+        }}
+      >
+        <RightSidebar />
+      </Box>
     </Flex>
   );
 }


### PR DESCRIPTION
## Background

There is a need to add custom resource-links to pages, where the editor can choose what the button text should be. 

+a couple of UI fixes in designmanual including: 
- Adjustments to the widths of the imageCards in the index pages for the different sections (spor and resources)
- Adjustments to the gaps between the ingress and content in the different guides

---

## Solution

Added an option "custom" in the ResourceLink object in the article document in Sanity. 


Frontend
<img width="858" height="306" alt="Skjermbilde 2026-08-18 kl  13 31 33" src="https://github.com/user-attachments/assets/c3193f65-7096-4ec6-970d-4d793220d653" />

Sanity
<img width="662" height="617" alt="Skjermbilde 2026-08-18 kl  13 31 59" src="https://github.com/user-attachments/assets/1994ee8a-8150-4ab3-a8d2-3ac931b94aa8" />
