### PR TITLE
Increase table of contents padding from 3 to 8

### DIFF
--- a/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
+++ b/apps/designmanual-frontend/app/routes/_base.$section.$category.$slug/route.tsx
@@ -251,7 +251,7 @@ export default function ArticlePage() {
             overflow="auto"
             right={0}
             paddingLeft={1}
-            paddingTop={3}
+            paddingTop={8}
             top={`${headerOffset}px`}
             transition="all .3s linear"
             height={`calc(100vh - ${headerOffset}px)`}


### PR DESCRIPTION
## Summary
Increases the top padding of the table of contents sidebar from spacing value 3 to 8, providing more visual breathing room below the header.

## Changes
- `paddingTop` prop on the table of contents container changed from `3` to `8`
- Affects the ArticlePage component's right-side navigation sidebar

This adjustment improves the visual spacing between the page header and the table of contents list.