### PR TITLE
Add outline on badges

### DIFF
--- a/.changeset/heavy-ears-buy.md
+++ b/.changeset/heavy-ears-buy.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Badge: Added outline on badges

--- a/packages/spor-react/src/theme/recipes/badge.ts
+++ b/packages/spor-react/src/theme/recipes/badge.ts
@@ -7,57 +7,69 @@ export const badgeRecipie = defineRecipe({
     justifyContent: "center",
     height: "fit-content",
     gap: "0.5",
+    outline: "1px solid",
+    outlineOffset: "-1px",
   },
   variants: {
     colorPalette: {
       neutral: {
         backgroundColor: "surface",
         color: "text",
+        outlineColor: "outline",
         "& svg": { color: "icon" },
       },
       grey: {
         backgroundColor: "surface.neutral",
         color: "text.neutral",
+        outlineColor: "outline.neutral",
         "& svg": { color: "icon.neutral" },
       },
       green: {
         backgroundColor: "surface.success",
         color: "text.success",
+        outlineColor: "outline.success",
         "& svg": { color: "icon.success" },
       },
       blue: {
         backgroundColor: "surface.info",
         color: "text.info",
+        outlineColor: "outline.info",
         "& svg": { color: "icon.info" },
       },
       cream: {
         backgroundColor: "surface.warning",
         color: "text.warning",
+        outlineColor: "outline.warning",
         "& svg": { color: "icon.warning" },
       },
       yellow: {
         backgroundColor: "surface.notice",
         color: "text.notice",
+        outlineColor: "outline.notice",
         "& svg": { color: "icon.notice" },
       },
       orange: {
         backgroundColor: "surface.caution",
         color: "text.caution",
+        outlineColor: "outline.caution",
         "& svg": { color: "icon.caution" },
       },
       red: {
         backgroundColor: "surface.critical",
         color: "text.critical",
+        outlineColor: "outline.critical",
         "& svg": { color: "icon.critical" },
       },
       brightRed: {
         backgroundColor: { _light: "brightRed", _dark: "brightRed" },
         color: { _light: "pink", _dark: "pink" },
+        outlineColor: "outline.error",
         "& svg": { color: { _light: "pink", _dark: "pink" } },
       },
       disabled: {
         backgroundColor: "surface.disabled",
         color: "text.disabled",
+        outlineColor: "outline.disabled",
         "& svg": { color: "icon.disabled" },
       },
     },
@@ -100,6 +112,7 @@ export const badgeRecipie = defineRecipe({
       css: {
         backgroundColor: { _light: "darkBlue", _dark: "lightBlue" },
         color: { _light: "icyBlue", _dark: "royal" },
+        outlineColor: { _light: "ocean", _dark: "cloudy" },
         "& svg": { color: { _light: "royal", _dark: "icyBlue" } },
       },
     },
@@ -109,6 +122,7 @@ export const badgeRecipie = defineRecipe({
       css: {
         backgroundColor: { _light: "darkTeal", _dark: "seaMist" },
         color: { _light: "mint", _dark: "jungle" },
+        outlineColor: { _light: "greenHaze", _dark: "coralGreen" },
         "& svg": { color: { _light: "mint", _dark: "jungle" } },
       },
     },
@@ -118,6 +132,7 @@ export const badgeRecipie = defineRecipe({
       css: {
         backgroundColor: { _light: "carbon", _dark: "platinum" },
         color: { _light: "white", _dark: "darkGrey" },
+        outlineColor: { _light: "iron", _dark: "silver" },
         "& svg": { color: { _light: "white", _dark: "darkGrey" } },
       },
     },
@@ -128,6 +143,7 @@ export const badgeRecipie = defineRecipe({
       css: {
         backgroundColor: { _light: "coffee", _dark: "blonde" },
         color: { _light: "cornsilk", _dark: "coffee" },
+        outlineColor: { _light: "bronze", _dark: "banana" },
         "& svg": { color: { _light: "cornsilk", _dark: "coffee" } },
       },
     },
@@ -137,6 +153,7 @@ export const badgeRecipie = defineRecipe({
       css: {
         backgroundColor: { _light: "bronze", _dark: "banana" },
         color: { _light: "cornsilk", _dark: "coffee" },
+        outlineColor: { _light: "golden", _dark: "banana" },
         "& svg": { color: { _light: "cornsilk", _dark: "coffee" } },
       },
     },
@@ -146,6 +163,7 @@ export const badgeRecipie = defineRecipe({
       css: {
         backgroundColor: { _light: "wood", _dark: "champagne" },
         color: { _light: "bisque", _dark: "wood" },
+        outlineColor: { _light: "russet", _dark: "saffron" },
         "& svg": { color: { _light: "bisque", _dark: "wood" } },
       },
     },
@@ -155,6 +173,7 @@ export const badgeRecipie = defineRecipe({
       css: {
         backgroundColor: { _light: "burgundy", _dark: "lightRed" },
         color: { _light: "pink", _dark: "maroon" },
+        outlineColor: { _light: "crimson", _dark: "salmon" },
         "& svg": { color: { _light: "pink", _dark: "maroon" } },
       },
     },
@@ -164,6 +183,7 @@ export const badgeRecipie = defineRecipe({
       inverted: true,
       css: {
         backgroundColor: { _light: "ink", _dark: "white" },
+        outlineColor: { _light: "whiteAlpha.400", _dark: "blackAlpha.400" },
         color: { _light: "white", _dark: "darkGrey" },
         "& svg": { color: { _light: "white", _dark: "darkGrey" } },
       },


### PR DESCRIPTION
## Background

It has been a request that badges get an outline to make them more visible. 

---

## Solution

Added a thin outline to the badges. The outlineOffset is necessary because it was a hairline gap between the element's painted background and the outline itself, that did not look good. The offset is added to prevent this small gap. Here is a screenshot of the small gap when offset is not added: 
<img width="219" height="86" alt="Skjermbilde 2026-08-20 kl  08 18 11" src="https://github.com/user-attachments/assets/c68d3255-7dda-412a-9a3d-17201eee5fb3" />


## Screenshots
Before
<img width="607" height="44" alt="Skjermbilde 2026-08-20 kl  08 20 56" src="https://github.com/user-attachments/assets/9a3ae919-d5b2-41fd-8272-84b2c8766fab" />

After
<img width="601" height="48" alt="Skjermbilde 2026-08-20 kl  08 18 45" src="https://github.com/user-attachments/assets/a4571ab8-333d-488a-9fe1-5ca88777f2eb" />
