### PR TITLE
indicator with animation on Tabs

### DIFF
--- a/.changeset/wide-grapes-happen.md
+++ b/.changeset/wide-grapes-happen.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Tabs: Added indicator with animation when navigating between tabtriggers.

--- a/packages/spor-react/src/tab/Tabs.tsx
+++ b/packages/spor-react/src/tab/Tabs.tsx
@@ -4,7 +4,7 @@ import {
   Tabs as ChakraTabs,
   TabsRootProps as ChakraTabsRootProps,
 } from "@chakra-ui/react";
-import { PropsWithChildren } from "react";
+import { ComponentProps, PropsWithChildren } from "react";
 
 import { tabsSlotRecipe } from "../theme/slot-recipes/tabs";
 
@@ -68,7 +68,16 @@ export const Tabs = ({
   return <ChakraTabs.Root {...props} ref={ref} variant={variant} size={size} />;
 };
 
-export const TabsList = ChakraTabs.List;
+export const TabsList = ({
+  children,
+  ...props
+}: ComponentProps<typeof ChakraTabs.List>) => (
+  <ChakraTabs.List {...props}>
+    <ChakraTabs.Indicator />
+
+    {children}
+  </ChakraTabs.List>
+);
 export const TabsTrigger = ChakraTabs.Trigger;
 export const TabsIndicator = ChakraTabs.Indicator;
 export const TabsContent = ChakraTabs.Content;

--- a/packages/spor-react/src/tab/Tabs.tsx
+++ b/packages/spor-react/src/tab/Tabs.tsx
@@ -4,7 +4,7 @@ import {
   Tabs as ChakraTabs,
   TabsRootProps as ChakraTabsRootProps,
 } from "@chakra-ui/react";
-import { ComponentProps, PropsWithChildren } from "react";
+import { PropsWithChildren } from "react";
 
 import { tabsSlotRecipe } from "../theme/slot-recipes/tabs";
 
@@ -68,16 +68,7 @@ export const Tabs = ({
   return <ChakraTabs.Root {...props} ref={ref} variant={variant} size={size} />;
 };
 
-export const TabsList = ({
-  children,
-  ...props
-}: ComponentProps<typeof ChakraTabs.List>) => (
-  <ChakraTabs.List {...props}>
-    <ChakraTabs.Indicator />
-
-    {children}
-  </ChakraTabs.List>
-);
+export const TabsList = ChakraTabs.List;
 export const TabsTrigger = ChakraTabs.Trigger;
 export const TabsIndicator = ChakraTabs.Indicator;
 export const TabsContent = ChakraTabs.Content;

--- a/packages/spor-react/src/theme/slot-recipes/tabs.ts
+++ b/packages/spor-react/src/theme/slot-recipes/tabs.ts
@@ -31,8 +31,8 @@ export const tabsSlotRecipe = defineSlotRecipe({
       borderRadius: "xl",
       position: "relative",
       _selected: {
+        backgroundColor: "surface.brand",
         color: "text.brand",
-        transition: "transform  0.2s ease",
         _hover: {
           backgroundColor: "surface.brand",
         },

--- a/packages/spor-react/src/theme/slot-recipes/tabs.ts
+++ b/packages/spor-react/src/theme/slot-recipes/tabs.ts
@@ -30,17 +30,23 @@ export const tabsSlotRecipe = defineSlotRecipe({
       whiteSpace: "nowrap",
       borderRadius: "xl",
       position: "relative",
+      ".spor-tabs__list:has(.spor-tabs__indicator) &": {
+        transition: "color 0.2s ease",
+      },
       _selected: {
-        backgroundColor: "surface.brand",
         color: "text.brand",
-        _hover: {
+        // @ts-expect-error — valid CSS selector, not recognized by Chakra's types
+        ".spor-tabs__list:not(:has(.spor-tabs__indicator)) &[data-selected]": {
           backgroundColor: "surface.brand",
+          _hover: {
+            backgroundColor: "surface.brand",
+          },
         },
       },
     },
     indicator: {
       position: "absolute",
-      top: "3px",
+      top: "2.5px",
       left: 0,
       width: "var(--width)",
       height: "var(--height)",
@@ -48,10 +54,6 @@ export const tabsSlotRecipe = defineSlotRecipe({
       transition: "transform 0.2s ease, width 0.2s ease",
       borderRadius: "xl",
       backgroundColor: "surface.brand",
-      _hover: {
-        backgroundColor: "surface.brand.hover",
-        outline: "none",
-      },
     },
   },
   variants: {
@@ -90,26 +92,26 @@ export const tabsSlotRecipe = defineSlotRecipe({
         list: {
           color: "text.core",
           border: "sm",
+          borderColor: "outline",
         },
         trigger: {
           color: "text.core",
           border: "md",
           borderColor: "transparent",
-          _hover: {
-            outline: "2px solid",
-            outlineColor: "outline.core.hover",
-            outlineOffset: "-2px",
-            _active: {
-              backgroundColor: "surface.core.active",
-              outline: "none",
-              outlineColor: "transparent",
+          "&:not([data-selected])": {
+            _hover: {
+              backgroundColor: "surface.ghost.hover",
+              _active: {
+                backgroundColor: "surface.ghost.active",
+                outline: "none",
+                outlineColor: "transparent",
+              },
             },
           },
-
-          _disabled: {
-            backgroundColor: "surface.disabled",
-            color: "surface.disabled",
-          },
+        },
+        _disabled: {
+          backgroundColor: "surface.disabled",
+          color: "surface.disabled",
         },
       },
       accent: {
@@ -124,19 +126,17 @@ export const tabsSlotRecipe = defineSlotRecipe({
             backgroundColor: "surface.disabled",
             color: "icon.disabled",
           },
-          _hover: {
-            backgroundColor: "surface.accent.hover",
-            _active: {
-              backgroundColor: "surface.accent.active",
+          "&:not([data-selected])": {
+            _hover: {
+              backgroundColor: "surface.accent.hover",
+              _active: {
+                backgroundColor: "surface.accent.active",
+              },
             },
           },
         },
         indicator: {
           backgroundColor: "surface.brand",
-          _hover: {
-            backgroundColor: "surface.brand.hover",
-            outline: "none",
-          },
         },
       },
     },
@@ -151,7 +151,7 @@ export const tabsSlotRecipe = defineSlotRecipe({
           paddingY: 0,
         },
         indicator: {
-          top: "2px",
+          top: "1px",
         },
       },
       sm: {

--- a/packages/spor-react/src/theme/slot-recipes/tabs.ts
+++ b/packages/spor-react/src/theme/slot-recipes/tabs.ts
@@ -16,6 +16,8 @@ export const tabsSlotRecipe = defineSlotRecipe({
       gap: 0.5,
       borderRadius: "xl",
       width: "fit-content",
+      position: "relative",
+      overflow: "hidden",
     },
     trigger: {
       display: "flex",
@@ -27,6 +29,29 @@ export const tabsSlotRecipe = defineSlotRecipe({
       height: "100%",
       whiteSpace: "nowrap",
       borderRadius: "xl",
+      position: "relative",
+      _selected: {
+        color: "text.brand",
+        transition: "transform  0.2s ease",
+        _hover: {
+          backgroundColor: "surface.brand",
+        },
+      },
+    },
+    indicator: {
+      position: "absolute",
+      top: "3px",
+      left: 0,
+      width: "var(--width)",
+      height: "var(--height)",
+      transform: "translate(var(--x), var(--y))",
+      transition: "transform 0.2s ease, width 0.2s ease",
+      borderRadius: "xl",
+      backgroundColor: "surface.brand",
+      _hover: {
+        backgroundColor: "surface.brand.hover",
+        outline: "none",
+      },
     },
   },
   variants: {
@@ -74,19 +99,13 @@ export const tabsSlotRecipe = defineSlotRecipe({
             outline: "2px solid",
             outlineColor: "outline.core.hover",
             outlineOffset: "-2px",
-          },
-          _active: {
-            backgroundColor: "surface.brand.active",
-            color: "text.brand",
-            outline: "none",
-          },
-          _selected: {
-            backgroundColor: "surface.brand",
-            color: "text.brand",
-            _hover: {
+            _active: {
+              backgroundColor: "surface.core.active",
               outline: "none",
+              outlineColor: "transparent",
             },
           },
+
           _disabled: {
             backgroundColor: "surface.disabled",
             color: "surface.disabled",
@@ -95,7 +114,7 @@ export const tabsSlotRecipe = defineSlotRecipe({
       },
       accent: {
         list: {
-          backgroundColor: "bg.accent",
+          backgroundColor: "surface.accent",
           color: "text.accent",
         },
         trigger: {
@@ -108,18 +127,15 @@ export const tabsSlotRecipe = defineSlotRecipe({
           _hover: {
             backgroundColor: "surface.accent.hover",
             _active: {
-              backgroundColor: "surface.brand.active",
-              color: "text.brand",
+              backgroundColor: "surface.accent.active",
             },
           },
-          _selected: {
-            backgroundColor: "surface.brand",
-            color: "text.brand",
-            _hover: {
-              backgroundColor: "surface.brand.hover",
-              color: "text.brand",
-              outline: "none",
-            },
+        },
+        indicator: {
+          backgroundColor: "surface.brand",
+          _hover: {
+            backgroundColor: "surface.brand.hover",
+            outline: "none",
           },
         },
       },
@@ -133,6 +149,9 @@ export const tabsSlotRecipe = defineSlotRecipe({
         trigger: {
           paddingX: 2,
           paddingY: 0,
+        },
+        indicator: {
+          top: "2px",
         },
       },
       sm: {
@@ -163,10 +182,6 @@ export const tabsSlotRecipe = defineSlotRecipe({
           fontWeight: "bold",
           fontSize: "sm",
           paddingX: 3,
-          _focus: {
-            border: "md",
-            borderColor: "surface.accent",
-          },
         },
       },
     },


### PR DESCRIPTION
## Background

It has been requested that the navigation between tabs get an animation. 

---

## Solution

Added styling on the TabIndicator so it "glides" over the triggers when the user select a different TabTrigger. 

---

## How to test? 

Run it locally or use preview.
Visit the documentation for the tabs and choose the "With animation" code-example. Navigate between the different tabs. 
https://pr-2366.test.design.vy.no/spor/components/tabs