### PR TITLE
make children of radiocard take 100% width

### DIFF
--- a/.changeset/smart-states-grow.md
+++ b/.changeset/smart-states-grow.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+RadioCard: Make children take 100% width

--- a/packages/spor-react/src/layout/RadioCard.tsx
+++ b/packages/spor-react/src/layout/RadioCard.tsx
@@ -65,7 +65,9 @@ export const RadioCard = ({
       />
       <ChakraRadioCard.ItemControl id={itemControlId} aria-hidden>
         {showIndicator && <ChakraRadioCard.ItemIndicator />}
-        <Flex direction="column">{children}</Flex>
+        <Flex direction="column" width="100%">
+          {children}
+        </Flex>
       </ChakraRadioCard.ItemControl>
     </ChakraRadioCard.Item>
   );


### PR DESCRIPTION
## Background

It was not possible for the children of a radiocard to take 100% width. 
