### PR TITLE
Style adjustments on SelectItems

### DIFF
--- a/.changeset/sixty-waves-drum.md
+++ b/.changeset/sixty-waves-drum.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Select: adjust the styling of select-items to make them similar to the ones in Autocomplete

--- a/packages/spor-react/src/input/Select.tsx
+++ b/packages/spor-react/src/input/Select.tsx
@@ -138,7 +138,7 @@ export const SelectItem = ({
       {multiple && (
         <ChakraCheckbox.Root checked={isSelected} pointerEvents="none">
           <ChakraCheckbox.Control>
-            <ChakraCheckbox.Indicator />
+            <ChakraCheckbox.Indicator marginLeft="1px" />
           </ChakraCheckbox.Control>
         </ChakraCheckbox.Root>
       )}

--- a/packages/spor-react/src/theme/slot-recipes/select.ts
+++ b/packages/spor-react/src/theme/slot-recipes/select.ts
@@ -101,10 +101,9 @@ export const selectSlotRecipe = defineSlotRecipe({
       },
     },
     item: {
-      paddingX: 2,
-      paddingY: 2,
-      marginY: 1,
-      marginX: 1,
+      px: 2,
+      py: 1,
+      margin: 1,
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
@@ -113,30 +112,20 @@ export const selectSlotRecipe = defineSlotRecipe({
       color: "text.ghost",
       cursor: "pointer",
       outline: "none",
-      "&[data-highlighted]:hover": {
-        outlineOffset: "2px",
-        outline: "2px solid",
-        outlineColor: "outline.focus",
-        backgroundColor: "surface.accent.hover",
-      },
-      "&[data-highlighted]": {
-        outlineOffset: "2px",
-        outline: "2px solid",
-        outlineColor: "outline.focus",
-      },
-      _active: {
-        backgroundColor: "surface.accent.active",
-      },
-      _highlighted: {
-        _active: {
-          color: "text",
-        },
-      },
       _hover: {
         backgroundColor: "surface.accent.hover",
+        _active: {
+          backgroundColor: "surface.accent.active",
+        },
       },
       _selected: {
         backgroundColor: "surface.accent",
+      },
+      _highlighted: {
+        backgroundColor: "surface.ghost.active",
+        _selected: {
+          backgroundColor: "surface.accent",
+        },
       },
       _icon: {
         width: 3,
@@ -144,7 +133,7 @@ export const selectSlotRecipe = defineSlotRecipe({
       },
       "& [data-part='item-description']": {
         fontSize: ["mobile.xs", "desktop.xs"],
-        color: "text.ghost",
+        color: "text.subtle",
       },
     },
     control: {
@@ -269,9 +258,7 @@ export const selectSlotRecipe = defineSlotRecipe({
           },
         },
         item: {
-          paddingX: 2,
-          paddingY: 1,
-          fontSize: "xs",
+          fontSize: ["mobile.xs", "desktop.xs"],
           "& [data-part='item-description']": {
             fontSize: ["mobile.2xs", "desktop.2xs"],
           },


### PR DESCRIPTION
## Background

The SelectItems were styled in a different way than AutocompleteItems although they should be alike to create a more consistent stylingsystem. 

## Screenshots

| Before | After |
| ------ | ----- |
|  <img width="663" height="238" alt="Skjermbilde 2026-08-25 kl  13 06 46" src="https://github.com/user-attachments/assets/6758e64f-63a1-4add-bf6d-ede81c403b46" />  | <img width="738" height="231" alt="Skjermbilde 2026-08-25 kl  13 06 24" src="https://github.com/user-attachments/assets/65d5757e-e60e-4a73-aacf-561ac4c46ed3" />  |
