### PR TITLE
setup 2fa for npm release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
## Background

Npm  recommend setting up 2fa for package release. This requires some that some changes are done on the packages in npm (which have been done), and also that the GitHub Action that publishes/releases gets write access to create OIDC tokens. 

I have followed this guide: https://docs.npmjs.com/trusted-publishers
---