### PR TITLE
Improve DatePicker accessibility

### DIFF
--- a/.changeset/four-feet-knock.md
+++ b/.changeset/four-feet-knock.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Datepicker: Improve accessibility by solving focus-order issue in calendar navigation

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -95,6 +95,17 @@ export const DatePicker = ({
   const { labelProps, fieldProps, buttonProps, dialogProps, calendarProps } =
     useDatePicker(props, state, ref as React.MutableRefObject<HTMLDivElement>);
 
+  const dateFieldRef = useRef<HTMLDivElement>(null);
+  const calendarPropsWithFocus = {
+    ...calendarProps,
+    onChange: (value: DateValue) => {
+      calendarProps.onChange?.(value);
+      dateFieldRef.current
+        ?.querySelector<HTMLElement>('[data-part="trigger"]')
+        ?.focus();
+    },
+  };
+
   const inputGroupId = `input-group-${useId()}`;
 
   const recipe = useSlotRecipe({
@@ -119,7 +130,7 @@ export const DatePicker = ({
       <ChakraPopover.Content css={styles.calendarPopover}>
         <ChakraPopover.Body minWidth="18rem">
           <Calendar
-            {...calendarProps}
+            {...calendarPropsWithFocus}
             variant={variant}
             showYearNavigation={showYearNavigation}
             css={css}
@@ -147,6 +158,7 @@ export const DatePicker = ({
             helperText={helperText}
             required={props.required}
             size={size}
+            ref={dateFieldRef}
           >
             <PopoverAnchor>
               <StyledField

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -95,14 +95,15 @@ export const DatePicker = ({
   const { labelProps, fieldProps, buttonProps, dialogProps, calendarProps } =
     useDatePicker(props, state, ref as React.MutableRefObject<HTMLDivElement>);
 
-  const dateFieldRef = useRef<HTMLDivElement>(null);
+  const focusCalendarTrigger = () => {
+    (ref as React.RefObject<HTMLElement>).current?.focus();
+  };
+
   const calendarPropsWithFocus = {
     ...calendarProps,
     onChange: (value: DateValue) => {
       calendarProps.onChange?.(value);
-      dateFieldRef.current
-        ?.querySelector<HTMLElement>('[data-part="trigger"]')
-        ?.focus();
+      focusCalendarTrigger();
     },
   };
 
@@ -149,7 +150,13 @@ export const DatePicker = ({
         width={width}
         css={css}
       >
-        <ChakraPopover.Root {...dialogProps} positioning={positioning}>
+        <ChakraPopover.Root
+          {...dialogProps}
+          positioning={positioning}
+          onOpenChange={({ open }) => {
+            if (!open) focusCalendarTrigger();
+          }}
+        >
           <Field
             display="inline-flex"
             id={inputGroupId}
@@ -158,7 +165,6 @@ export const DatePicker = ({
             helperText={helperText}
             required={props.required}
             size={size}
-            ref={dateFieldRef}
           >
             <PopoverAnchor>
               <StyledField

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -151,11 +151,11 @@ export const DatePicker = ({
         css={css}
       >
         <ChakraPopover.Root
-          {...dialogProps}
           positioning={positioning}
           onOpenChange={({ open }) => {
             if (!open) focusCalendarTrigger();
           }}
+          {...dialogProps}
         >
           <Field
             display="inline-flex"


### PR DESCRIPTION
## Background

There have been an accessibility issue in the Datepicker. After selecting a date through the Calendar-view (using keyboard naviation), the focus moved out to the top of the page instead of staying on the Datepicker's inputfield. 

---

## Solution

Add a custom handling that is called when the popover gets closed (pressing esc), and when the value changes

## How to test? 
Compare how navigation with keyboard and voiceover works with prod, and with this branch. 