### PR TITLE
Size in TimePicker and DatePicker

### DIFF
--- a/.changeset/long-eagles-take.md
+++ b/.changeset/long-eagles-take.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-react": patch
+---
+
+Date and Timepicker: Adjust the styling so they follow the size standard where the height is 54px (md) and 42px (small).

--- a/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
+++ b/packages/spor-react/src/datepicker/CalendarTriggerButton.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { BoxProps, PopoverAnchor, useSlotRecipe } from "@chakra-ui/react";
-import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
+import {
+  CalendarOutline18Icon,
+  CalendarOutline30Icon,
+} from "@vygruppen/spor-icon-react";
 import { PropsWithChildren } from "react";
 import { AriaButtonProps } from "react-aria";
 
@@ -22,6 +25,7 @@ type CalendarTriggerButtonProps = AriaButtonProps<"button"> &
 export const CalendarTriggerButton = ({
   ref,
   variant,
+  size,
   disabled,
   // onPress is extracted because it is not supported by chakra.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -40,11 +44,14 @@ export const CalendarTriggerButton = ({
   return (
     <PopoverAnchor {...buttonProps} ref={ref} asChild>
       <IconButton
-        icon={<CalendarOutline24Icon />}
+        icon={
+          size == "sm" ? <CalendarOutline18Icon /> : <CalendarOutline30Icon />
+        }
         aria-label={t(texts.openCalendar)}
         css={styles.calendarTriggerButton}
         variant="ghost"
         disabled={disabled}
+        size={size}
       />
     </PopoverAnchor>
   );

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -59,7 +59,7 @@ export const DateField = ({
   );
 
   return (
-    <Box minWidth="6rem" width="100%">
+    <Box width="100%">
       {props.label && (
         <Box css={styles.inputLabel} position="absolute" paddingTop="2px">
           <Label
@@ -72,7 +72,7 @@ export const DateField = ({
           </Label>
         </Box>
       )}
-      <Flex {...fieldProps} ref={ref} paddingTop="3" paddingBottom="0.5">
+      <Flex {...fieldProps} ref={ref} paddingTop="3">
         {state.segments.map((segment, index) => (
           <DateTimeSegment
             key={index}

--- a/packages/spor-react/src/datepicker/DateField.tsx
+++ b/packages/spor-react/src/datepicker/DateField.tsx
@@ -61,7 +61,7 @@ export const DateField = ({
   return (
     <Box width="100%">
       {props.label && (
-        <Box css={styles.inputLabel} position="absolute" paddingTop="2px">
+        <Box css={styles.inputLabel} position="absolute">
           <Label
             padding="0"
             fontSize={["mobile.2xs", "desktop.2xs"]}

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -165,8 +165,8 @@ export const DatePicker = ({
                 ) : (
                   <ChakraPopover.Trigger asChild>
                     <CalendarTriggerButton
-                      marginLeft={1}
                       variant={variant}
+                      size={size}
                       ref={ref}
                       {...buttonProps}
                     />

--- a/packages/spor-react/src/datepicker/DatePicker.tsx
+++ b/packages/spor-react/src/datepicker/DatePicker.tsx
@@ -11,7 +11,10 @@ import {
   useFieldContext,
   useSlotRecipe,
 } from "@chakra-ui/react";
-import { CalendarOutline24Icon } from "@vygruppen/spor-icon-react";
+import {
+  CalendarOutline18Icon,
+  CalendarOutline30Icon,
+} from "@vygruppen/spor-icon-react";
 import React, { PropsWithChildren, useId, useRef } from "react";
 import {
   AriaDatePickerProps,
@@ -159,9 +162,11 @@ export const DatePicker = ({
                 overrideBorderColor={props.overrideBorderColor}
               >
                 {props.noCalendar ? (
-                  <Box pr={3} pl={0.5} mr={0.5}>
-                    <CalendarOutline24Icon />
-                  </Box>
+                  size === "sm" ? (
+                    <CalendarOutline18Icon flexShrink={0} marginX="1.5" />
+                  ) : (
+                    <CalendarOutline30Icon flexShrink={0} marginX="0.5" />
+                  )
                 ) : (
                   <ChakraPopover.Trigger asChild>
                     <CalendarTriggerButton

--- a/packages/spor-react/src/datepicker/TimeField.tsx
+++ b/packages/spor-react/src/datepicker/TimeField.tsx
@@ -46,7 +46,7 @@ export const TimeField = ({ state, ...props }: TimeFieldProps) => {
         {props.label}
         <ChakraField.RequiredIndicator />
       </spor.label>
-      <Flex {...fieldProps} ref={ref} paddingTop="3" paddingBottom="0.5">
+      <Flex {...fieldProps} ref={ref} paddingTop="3">
         {state.segments.map((segment: DateSegment, index) => (
           <DateTimeSegment
             key={index}

--- a/packages/spor-react/src/datepicker/TimePicker.tsx
+++ b/packages/spor-react/src/datepicker/TimePicker.tsx
@@ -4,7 +4,9 @@ import { CalendarDateTime } from "@internationalized/date";
 import { TimeValue } from "@react-types/datepicker";
 import {
   DropdownLeftFill18Icon,
+  DropdownLeftFill24Icon,
   DropdownRightFill18Icon,
+  DropdownRightFill24Icon,
 } from "@vygruppen/spor-icon-react";
 import { useTimeFieldState } from "react-stately";
 
@@ -82,6 +84,7 @@ export const TimePicker = ({
   minuteInterval = 30,
   disabled: isDisabledExternally = false,
   name,
+  size = "md",
   ...boxProps
 }: TimePickerProps) => {
   const { disabled: fieldDisabled, invalid: fieldInvalid } =
@@ -149,6 +152,7 @@ export const TimePicker = ({
         aria-disabled={isDisabled}
         aria-label={ariaLabel}
         position="relative"
+        size={size}
         {...boxProps}
       >
         <IconButton
@@ -157,7 +161,13 @@ export const TimePicker = ({
           borderRadius="xs"
           aria-label={backwardsLabel}
           title={backwardsLabel}
-          icon={<DropdownLeftFill18Icon />}
+          icon={
+            size == "sm" ? (
+              <DropdownLeftFill18Icon />
+            ) : (
+              <DropdownLeftFill24Icon />
+            )
+          }
           onClick={handleBackwardsClick}
           disabled={isDisabled}
           style={isDisabled ? { backgroundColor: "transparent" } : {}}
@@ -170,7 +180,13 @@ export const TimePicker = ({
           borderRadius="xs"
           aria-label={forwardsLabel}
           title={forwardsLabel}
-          icon={<DropdownRightFill18Icon />}
+          icon={
+            size == "sm" ? (
+              <DropdownRightFill18Icon />
+            ) : (
+              <DropdownRightFill24Icon />
+            )
+          }
           onClick={handleForwardClick}
           disabled={isDisabled}
           style={isDisabled ? { backgroundColor: "transparent" } : {}}

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -12,9 +12,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       borderRadius: "sm",
       display: "flex",
       flex: 1,
-      paddingY: 0.5,
       paddingX: 2,
-      gap: 1.5,
       alignItems: "center",
       _hover: {
         zIndex: "docked",
@@ -39,7 +37,6 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       },
     },
     inputLabel: {
-      fontSize: ["mobile.xs", "desktop.xs"],
       margin: 0,
       cursor: "text",
     },
@@ -60,7 +57,6 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       alignItems: "center",
       justifyContent: "center",
       transitionProperty: "box-shadow, background-color",
-      right: "0.5rem",
       _hover: {
         backgroundColor: "surface.ghost.hover",
       },
@@ -85,7 +81,6 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       maxWidth: "100vw",
     },
     rangeCalendarPopover: {
-      width: "43rem",
       maxWidth: "100vw",
     },
     weekdays: {
@@ -244,12 +239,16 @@ export const datePickerSlotRecipe = defineSlotRecipe({
         wrapper: {
           fontSize: ["mobile.xs", "desktop.xs"],
           paddingX: 1,
-          gap: 1,
+          paddingY: 0,
+          gap: 0.5,
         },
       },
       md: {
         wrapper: {
+          paddingTop: 0.5,
+          paddingBottom: 1,
           fontSize: ["mobile.sm", "desktop.sm"],
+          gap: 1,
         },
       },
     },

--- a/packages/spor-react/src/theme/slot-recipes/datepicker.ts
+++ b/packages/spor-react/src/theme/slot-recipes/datepicker.ts
@@ -248,7 +248,7 @@ export const datePickerSlotRecipe = defineSlotRecipe({
           paddingTop: 0.5,
           paddingBottom: 1,
           fontSize: ["mobile.sm", "desktop.sm"],
-          gap: 1,
+          gap: 1.5,
         },
       },
     },


### PR DESCRIPTION
## Background

The height of the time and datepicker did not follow the standard of 54px in medium size, and 42px in small size. 
Also, there were mismatches between the design in Figma and the implementation. 

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="877" height="306" alt="Skjermbilde 2026-09-08 kl  10 40 07" src="https://github.com/user-attachments/assets/ce4e4263-89e8-41f9-863c-5c5016880fb2" /> | <img width="799" height="266" alt="Skjermbilde 2026-09-08 kl  10 40 40" src="https://github.com/user-attachments/assets/ca415428-7c10-4731-8653-a520ac9c5abf" /> |
