### PR TITLE
Update linjetag colours

### DIFF
--- a/.changeset/petite-rocks-create.md
+++ b/.changeset/petite-rocks-create.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/spor-design-tokens": patch
+---
+
+Update linjetag colours for fjerntog, ferge, trikk and tbane

--- a/packages/spor-design-tokens/tokens/color/linjetag.json
+++ b/packages/spor-design-tokens/tokens/color/linjetag.json
@@ -1,6 +1,12 @@
 {
   "color": {
     "linjetag": {
+      "tog": {
+        "value": "#123DA0"
+      },
+      "buss": {
+        "value": "#037D67"
+      },
       "lokaltog": {
         "value": "#65B152"
       },
@@ -20,7 +26,7 @@
         "value": "#D8F1F4"
       },
       "fjerntog": {
-        "value": "#325D93"
+        "value": "#123DA0"
       },
       "fjerntogLight": {
         "value": "#DCE4EF"
@@ -44,19 +50,19 @@
         "value": "#EBEBEC"
       },
       "ferge": {
-        "value": "#965F96"
+        "value": "#8835A5"
       },
       "fergeLight": {
         "value": "#F0DDF0"
       },
       "trikk": {
-        "value": "#3998DC"
+        "value": "#0392F1"
       },
       "trikkLight": {
         "value": "#D9EDFB"
       },
       "tbane": {
-        "value": "#FF8200"
+        "value": "#E77300"
       },
       "tbaneLight": {
         "value": "#FFE6CC"
@@ -72,6 +78,9 @@
       },
       "ruterAkershus": {
         "value": "#76A300"
+      },
+      "ukjent": {
+        "value": "#4F5054"
       }
     }
   }

--- a/packages/spor-design-tokens/tokens/color/linjetag.json
+++ b/packages/spor-design-tokens/tokens/color/linjetag.json
@@ -1,12 +1,6 @@
 {
   "color": {
     "linjetag": {
-      "tog": {
-        "value": "#123DA0"
-      },
-      "buss": {
-        "value": "#037D67"
-      },
       "lokaltog": {
         "value": "#65B152"
       },
@@ -78,9 +72,6 @@
       },
       "ruterAkershus": {
         "value": "#76A300"
-      },
-      "ukjent": {
-        "value": "#4F5054"
       }
     }
   }

--- a/packages/spor-design-tokens/tokens/color/vy-digital.json
+++ b/packages/spor-design-tokens/tokens/color/vy-digital.json
@@ -740,6 +740,12 @@
         },
         "transport": {
           "train": {
+            "DEFAULT": {
+              "value": {
+                "_light": "colors.linjetag.tog",
+                "_dark": "colors.linjetag.tog"
+              }
+            },
             "lokal": {
               "value": {
                 "_light": "colors.linjetag.lokaltog",
@@ -778,6 +784,12 @@
             }
           },
           "bus": {
+            "DEFAULT": {
+              "value": {
+                "_light": "colors.linjetag.buss",
+                "_dark": "colors.linjetag.buss"
+              }
+            },
             "bussfortog": {
               "value": {
                 "_light": "colors.linjetag.altTransport",
@@ -836,8 +848,8 @@
           "other": {
             "DEFAULT": {
               "value": {
-                "_light": "colors.darkGrey",
-                "_dark": "colors.darkGrey"
+                "_light": "colors.linjetag.ukjent",
+                "_dark": "colors.linjetag.ukjent"
               }
             }
           }

--- a/packages/spor-design-tokens/tokens/color/vy-digital.json
+++ b/packages/spor-design-tokens/tokens/color/vy-digital.json
@@ -740,12 +740,6 @@
         },
         "transport": {
           "train": {
-            "DEFAULT": {
-              "value": {
-                "_light": "colors.linjetag.tog",
-                "_dark": "colors.linjetag.tog"
-              }
-            },
             "lokal": {
               "value": {
                 "_light": "colors.linjetag.lokaltog",
@@ -784,12 +778,6 @@
             }
           },
           "bus": {
-            "DEFAULT": {
-              "value": {
-                "_light": "colors.linjetag.buss",
-                "_dark": "colors.linjetag.buss"
-              }
-            },
             "bussfortog": {
               "value": {
                 "_light": "colors.linjetag.altTransport",
@@ -848,8 +836,8 @@
           "other": {
             "DEFAULT": {
               "value": {
-                "_light": "colors.linjetag.ukjent",
-                "_dark": "colors.linjetag.ukjent"
+                "_light": "colors.darkGrey",
+                "_dark": "colors.darkGrey"
               }
             }
           }


### PR DESCRIPTION
 <!---
Thanks for creating a Pull Request! 🎉

✅ Keep your PR as small as possible.
📘 React component guide: https://design.vy.no/spor/guides/how-to-create-a-react-component
📦 How to make a changeset: https://design.vy.no/spor/guides/how-to-create-a-react-component#creating-a-pr-and-publish-package
💡 Preferably use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/

🚀 Deploy to environments:
- Comment `.preview` to deploy to preview environment
- Comment `.deploy test` to deploy to test environment

This template serves as a guideline; feel free to remove sections that do not apply to your pull request.
-->

## Background

We have new colours for "fjerntog", "ferge", "trikk" og "tbane" line tag colours.

See figma design: https://www.figma.com/design/Tmr2URVX2vNkyRLqKhNRQA/branch/pL6XnSQwXzfb5OKNMeXXNP/Spor-komponentbibliotek?node-id=21998-71943&m=dev

---

## Solution

Update the line tag colours for "fjerntog", "ferge", "trikk" og "tbane". 

---

## General Checklist

- [x] I have updated documentation if necessary
- [x] I have verified the design aligns with the latest Figma sketches.
- [x] I have created a changeset if publishing is required

---

## Screenshots

| Before | After |
| ------ | ----- |
|<img width="862" height="869" alt="Screenshot 2026-09-08 at 13 31 51" src="https://github.com/user-attachments/assets/12c2d4a5-4065-4598-96dc-b050df965e8f" />|<img width="862" height="865" alt="Screenshot 2026-09-08 at 13 50 35" src="https://github.com/user-attachments/assets/a82e6af3-d21d-40b7-a7ea-fe19319df4a0" />|

